### PR TITLE
Fix view more append for liveblogs

### DIFF
--- a/ArticleTemplates/js/amd/bootstraps/liveblog.js
+++ b/ArticleTemplates/js/amd/bootstraps/liveblog.js
@@ -14,10 +14,10 @@ define([
             blockUpdates: function () {
                 var newBlockHtml = '',
                     updateCounter = 0,
-                    liveblogStartPos = $('.body-container').offset(),
+                    liveblogStartPos = $('.live-container').offset(),
 
                     liveblogNewBlockDump = function () {
-                        $(newBlockHtml).hide().prependTo('.liveblog-body').show().addClass('animated bounceIn');
+                        $(newBlockHtml).hide().prependTo('.article__body').show().addClass('animated bounceIn');
                         window.articleImageSizer();
                         window.liveblogTime();
                         newBlockHtml = '';
@@ -67,7 +67,7 @@ define([
                 window.liveblogLoadMore = function (html) {
                     html = bonzo.create(html);
                     $('.live-more-loading').hide();
-                    $(html).hide().appendTo('.liveblog-body').show().addClass('animated bounceIn');
+                    $(html).hide().appendTo('.article__body').show().addClass('animated bounceIn');
 
                     // See Common bootstrap
                     window.articleImageSizer();


### PR DESCRIPTION
Updates class names, container `liveblog-body` [was removed](https://github.com/guardian/ios-live/commit/eba03b53dbf081cfa3f418a3c8e35962845c57f0#diff-708f55dda88b32ac533b2c729ff5c41dL36), selector wasn't updated.
