### PR TITLE
Commenting out hiding the breaks

### DIFF
--- a/ArticleTemplates/css/scss/partials/_prose.scss
+++ b/ArticleTemplates/css/scss/partials/_prose.scss
@@ -19,9 +19,9 @@
 	ul,
 	ol {
 		@include margin(1, 0);
-		br:first-child {
-			display: none;
-		}
+		// br:first-child {
+		//	display: none;
+		// }
 	}
 
 	ol {

--- a/ArticleTemplates/css/style.css
+++ b/ArticleTemplates/css/style.css
@@ -1506,10 +1506,6 @@ figure.figure-inline {
 .prose ul,
 .prose ol {
   margin: 12px 0px 12px 0px; }
-  .prose p br:first-child,
-  .prose ul br:first-child,
-  .prose ol br:first-child {
-    display: none; }
 .prose ol {
   counter-reset: li; }
   .prose ol > li:before {


### PR DESCRIPTION
These are being commented out for now, as breaks were initially disabled to sidetrack naughty editors. However, sometimes this means we remove line breaks when they're legitimate.

For now we're re-instating them, living with it for a week and seeing if they still cause issues.
