### PR TITLE
AND-2973 - Match info tab populated by default.

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/football.js
+++ b/ArticleTemplates/assets/js/bootstraps/football.js
@@ -138,7 +138,7 @@ define([
                 html = bonzo.create(html);
                 $(html).appendTo('#football__tabpanel--stats');
                 modules.footballChart(homeTeam, awayTeam);
-                if (!$('.tabs [href="#football__tabpanel--stats"]').hasClass('selected')) {
+                if (!$('[aria-selected="true"]')) {
                     $('#football__tabpanel--stats').hide();
                 }
             };


### PR DESCRIPTION
Data was present however content was hidden due to the setupGlobals function applying a condition that hides content if the 'selected' class is not present. However the current selected state is determined by the 'aria-selected' attribute which is true (selected) or false (not selected) not by a selected class.
