### PR TITLE
Gia 3133

### DIFF
--- a/ArticleTemplates/assets/js/app.js
+++ b/ArticleTemplates/assets/js/app.js
@@ -52,25 +52,6 @@ require([
             adsKeywordTargeting: document.body.getAttribute('data-ads-keyword')
         };
 
-        // Debug JS
-        window.logOnScreen = function(log) 
-        {
-            if (!window.loggingPanel)
-            {
-                window.loggingPanel = document.createElement("div");
-                window.loggingPanel.setAttribute("id", "logging-panel");
-                window.loggingPanel.setAttribute("style", "font-size:1.5rem;position:fixed;bottom:0;background-color:rgba(0,0,0,0.7);;height:30%;width:100%;z-index:30;color:orange;overflow-y:scroll;padding:3px;");
-                document.documentElement.appendChild(loggingPanel);
-                window.loggingPanel.innerHTML +='|||||HEADER|||||'+$(".headline.selectable")[0].innerHTML+'|||||';
-                window.loggingPanel.innerHTML +='<br>--------------------------------------------------------------<br>';
-                window.onerror = function myErrorHandler(errorMsg, url, lineNumber)
-                {
-                    window.logOnScreen(errorMsg+' '+url+' '+lineNumber);
-                }
-            }
-            window.loggingPanel.innerHTML += log+' | <br>';
-        };
-
         // Common bootstrap
         Common.init(config);
 

--- a/ArticleTemplates/assets/js/bootstraps/gallery.js
+++ b/ArticleTemplates/assets/js/bootstraps/gallery.js
@@ -16,9 +16,6 @@ define([
             window.onorientationchange = function(){
                 $(".gallery")[0].removeAttribute("style");
                 collagePlus.init(".gallery", ".gallery__image");
-
-                window.logOnScreen("onorientationchange " + document.body.clientWidth);
-                window.logOnScreen("orientation is " +window.orientation);
             },
             window.redrawGallery = function() {
                 $(".gallery")[0].removeAttribute("style");
@@ -29,10 +26,7 @@ define([
                 } else {
                     mode = "portrait";
                 }
-
                 collagePlus.init(".gallery", ".gallery__image", mode);
-                window.logOnScreen("redrawGallery " + mode);
-
             };
         }
     },
@@ -41,7 +35,6 @@ define([
         if (!this.initialised) {
             this.initialised = true;
             modules.galleryLayout();
-            //console.info("Gallery ready");
         }
     };
 

--- a/ArticleTemplates/assets/js/modules/collagePlus.js
+++ b/ArticleTemplates/assets/js/modules/collagePlus.js
@@ -93,19 +93,13 @@ define([
         switch (orientation) {
           case "portrait":
             albumWidth = 675;
-            window.logOnScreen("collagePlus plugin is " + orientation + " available screen space is "+screenSpace);
-            window.logOnScreen("collagePlus plugin padding is " + padding);
             $(".gallery").css('padding', gp);
             break;
           case "landscape":
             albumWidth = 930;
-            window.logOnScreen("collagePlus plugin is " + orientation + " available screen space is "+screenSpace);
-            window.logOnScreen("collagePlus plugin padding is " + padding);
             break;
           default:
             albumWidth = $(selector)[0].clientWidth - (padding * 2);
-            window.logOnScreen("collagePlus plugin default is " + albumWidth + " available screen space is "+screenSpace);
-            window.logOnScreen("collagePlus plugin padding is " + padding);
         }
 
         if (window.innerWidth < 450) {
@@ -126,9 +120,6 @@ define([
             "allowPartialLastRow"   : false
         };
 
-        window.logOnScreen("albumWidth "+settings.albumWidth);
-        window.logOnScreen("bodywidth "+ document.body.clientWidth);
-
         var row = 0,
             elements = [],
             rownum = 1;
@@ -136,7 +127,7 @@ define([
         settings.images.each(function(scope, index) {
             var w = this.width,
                 h = this.height;
-            // window.logOnScreen("Image width "+w+" Image height "+h);
+
             var nw = Math.ceil(w/h*settings.targetHeight),
                 nh = Math.ceil(settings.targetHeight);
 


### PR DESCRIPTION
Fixed gallery layout after rotation in slideshow/enlarged picture (native) view.  --

collagePlus is the plugin that lays out the gallery according to available space in either portrait or landscape views and is initialised when first viewing the page and on orientation change. With iOS there is a native overlay above the gallery and although the onorientationchange function is still triggered behind the scenes when in the slideshow/gallery view, it calculates the layout for the image gallery based on the previous orientation that was in view.

This fix includes a new native trigger when the slideshow is closed called redrawGallery that tells collagePlus the orientation change type (var called mode). In the collagePlus plugin if the orientation var is passed into the init function then the initial width called albumWidth gets a new calculated value depending on whether orientation is landscape or portrait. This overrides the calculated clientWidth (which is default behaviour when there is no overlay) and therefore forces the last known view and dimensions, fixing the problem.
