### PR TITLE
AND-3134 

### DIFF
--- a/ArticleTemplates/articleTemplate.html
+++ b/ArticleTemplates/articleTemplate.html
@@ -9,7 +9,7 @@
 </head>
 
 <body class="tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__" data-content-type="article" data-ads-enabled="__ADS_ENABLED__" data-ads-slot="/__AD_NETWORK_ID__/__AD_UNIT_IDENTIFIER__" data-ads-config="__ADS_CONFIG__" data-ads-keyword="__AD_KEYWORD_TARGETING__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__">
-    <div class="advert-slot advert-slot--banner advert-slot--__ADS_ENABLED__">
+    <div class="advert-slot advert-slot--banner advert-slot--__ADS_ENABLED__" id="banner_container">
         <div class="advert-slot__label">Advertisement</div>
         <div class="advert-slot__wrapper"></div>
     </div>

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -61,7 +61,7 @@ define([
 
             getBannerPos : function(formatter) {
                 var r;
-                var el = document.getElementById("advert-banner-content");
+                var el = document.getElementById("banner_container");
                 if (el) {
                     r = el.getBoundingClientRect();
                     return formatter(r.left + document.body.scrollLeft, r.top+document.body.scrollTop, r.width, r.height);
@@ -96,8 +96,9 @@ define([
                 });
             },
             getBannerPosCallback : function(callbackNamespace, callbackFunction) {
-                console.info("Called getBannerPosCallback");
+                // console.info("Called getBannerPosCallback");
                 modules.getBannerPos(function(x, y, w, h){
+                    // console.info("left "+ x +" top " + y + " width "+ w +" height "+ h);
                     window.GuardianJSInterface.bannerAdsPosition(x, y, w, h);
                 });
             },
@@ -111,11 +112,11 @@ define([
                         modules.getMpuPos(function(x, y, w, h){
                             window.GuardianJSInterface.mpuAdsPosition(x, y, w, h);
                         });
-                    };   
+                    }   
 
-                    iframe ? setTimeout(onloadHandler, 3000) : onloadHandler();
+                    var loadAds = iframe ? setTimeout(onloadHandler, 3000) : onloadHandler();
 
-                }
+                };
                 window.applyNativeFunctionCall("getMpuPosCallback");
 
             }

--- a/ArticleTemplates/audioTemplate.html
+++ b/ArticleTemplates/audioTemplate.html
@@ -9,7 +9,7 @@
 </head>
 
 <body class="tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__" data-content-type="audio" data-ads-enabled="__ADS_ENABLED__" data-ads-slot="/__AD_NETWORK_ID__/__AD_UNIT_IDENTIFIER__" data-ads-config="__ADS_CONFIG__" data-ads-keyword="__AD_KEYWORD_TARGETING__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__">
-    <div class="advert-slot advert-slot--banner advert-slot--__ADS_ENABLED__">
+    <div class="advert-slot advert-slot--banner advert-slot--__ADS_ENABLED__"  id="banner_container">
         <div class="advert-slot__label">Advertisement</div>
         <div class="advert-slot__wrapper"></div>
     </div>

--- a/ArticleTemplates/footballTemplate.html
+++ b/ArticleTemplates/footballTemplate.html
@@ -9,7 +9,7 @@
 </head>
 
 <body class="tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__" data-content-type="football" data-ads-enabled="__ADS_ENABLED__" data-ads-slot="/__AD_NETWORK_ID__/__AD_UNIT_IDENTIFIER__" style="margin-top: __ACTIONBARHEIGHT__px;" data-ads-config="__ADS_CONFIG__" data-ads-keyword="__AD_KEYWORD_TARGETING__" data-font-size="__FONT_SIZE_INT__">
-    <div class="advert-slot advert-slot--banner advert-slot--__ADS_ENABLED__">
+    <div class="advert-slot advert-slot--banner advert-slot--__ADS_ENABLED__"  id="banner_container">
         <div class="advert-slot__label">Advertisement</div>
         <div class="advert-slot__wrapper"></div>
     </div>

--- a/ArticleTemplates/galleryTemplate.html
+++ b/ArticleTemplates/galleryTemplate.html
@@ -9,7 +9,7 @@
 </head>
 
 <body class="tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__" data-content-type="gallery" data-ads-enabled="__ADS_ENABLED__" data-ads-slot="/__AD_NETWORK_ID__/__AD_UNIT_IDENTIFIER__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-ads-keyword="__AD_KEYWORD_TARGETING__" data-font-size="__FONT_SIZE_INT__">
-    <div class="advert-slot advert-slot--banner advert-slot--__ADS_ENABLED__">
+    <div class="advert-slot advert-slot--banner advert-slot--__ADS_ENABLED__" id="banner_container">
         <div class="advert-slot__label">Advertisement</div>
         <div class="advert-slot__wrapper"></div>
     </div>

--- a/ArticleTemplates/liveblogTemplate.html
+++ b/ArticleTemplates/liveblogTemplate.html
@@ -9,7 +9,7 @@
 </head>
 
 <body class="tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_LIVE__" data-content-type="liveblog" data-ads-enabled="__ADS_ENABLED__" data-ads-slot="/__AD_NETWORK_ID__/__AD_UNIT_IDENTIFIER__" data-ads-config="__ADS_CONFIG__" data-ads-keyword="__AD_KEYWORD_TARGETING__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__">
-    <div class="advert-slot advert-slot--banner advert-slot--__ADS_ENABLED__">
+    <div class="advert-slot advert-slot--banner advert-slot--__ADS_ENABLED__" id="banner_container">
         <div class="advert-slot__label">Advertisement</div>
         <div class="advert-slot__wrapper"></div>
     </div>

--- a/ArticleTemplates/videoTemplate.html
+++ b/ArticleTemplates/videoTemplate.html
@@ -9,7 +9,7 @@
 </head>
 
 <body class="tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ " data-content-type="video" data-ads-enabled="__ADS_ENABLED__" data-ads-slot="/__AD_NETWORK_ID__/__AD_UNIT_IDENTIFIER__" data-ads-config="__ADS_CONFIG__" data-ads-keyword="__AD_KEYWORD_TARGETING__"  style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__">
-    <div class="advert-slot advert-slot--banner advert-slot--__ADS_ENABLED__">
+    <div class="advert-slot advert-slot--banner advert-slot--__ADS_ENABLED__" id="banner_container">
         <div class="advert-slot__label">Advertisement</div>
         <div class="advert-slot__wrapper"></div>
     </div>


### PR DESCRIPTION
Banner positions change: also relates to AND-3149 an Android native code change so that Banners get positions sent from ads.js in the same way Mpus are sent positions. To achieve this I've added getBannerPosCallback a duplicate of the original getMpuPosCallback function. Also created getBannerPos a duplicate method of getMpuPos. getBannerPosCallback now passes x, y coords, width and height values to native function window.GuardianJSInterface.bannerAdsPosition(x, y, w, h) and now banners are positioned in the same way as MPUs and the original bug 'AND-3134 banner ads alignment incorrect' is now in the correct position.
