### PR TITLE
AND 3194

### DIFF
--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -142,7 +142,7 @@ define([
 
                 window.getMpuPosCallback = function (callbackNamespace, callbackFunction) {
 
-                    var iframe = document.getElementsByTagName("iframe")[0];
+                    var interactive  =  (document.getElementsByTagName("iframe")[0] || document.getElementsByClassName("interactive")[0]) ? true : false;
 
                     function onloadHandler () { 
                         modules.getMpuPos(function(x, y, w, h){
@@ -159,7 +159,7 @@ define([
                         });
                     }
 
-                    var loadAds = iframe ? iframeHandler() : onloadHandler();
+                    var loadAds = (interactive == true) ? iframeHandler() : onloadHandler();
 
                 };
 


### PR DESCRIPTION
Fix for MPU ad positioning on pages that contain interactive (iframe) content. This solution introduces a 'Polling' function that essential queries the position of the MPU placeholder for 20 seconds (as a background process). If that position value changes then the MPU is repositioned, the timer continues until the 20 seconds is up to account for interactive content loading times. This value can easily be amended.

New functions for the above:

getMpuOffsetTop: Gets the Y axis position used for the comparison
timer: Uses setTimeout to count for 1 second and then triggers runPoller (this creates a loop) 
runPoller: 
This is a looping function that evaluates time passed from timer to check Y position for 20 seconds and if it changes trigger the native MPU function to reposition the MPU. (The setTimeOut loop is preferred over setInterval for accuracy and early triggering etc.)
posPoller: Sets initial start value, Y Position value and initialises runPoller.

There is also a new iframeHandler private function in getAds method's getMpuPosCallback function that handles the iFrame and calls posPoller otherwise only calls onloadHandler - for non iFrame pages that loads MPUs without this checking functionality. This iframeHandler now replaces the former setTimeOut intermediate solution.
