### PR TITLE
Remove the unused __SUMMARY__ tag from the football liveblog template

### DIFF
--- a/ArticleTemplates/footballTemplateLiveblog.html
+++ b/ArticleTemplates/footballTemplateLiveblog.html
@@ -14,7 +14,6 @@
 
                 <div class="article__body article__body--liveblog">
                     <div class="article__body--liveblog__pinned">
-                        __SUMMARY__
                         __ASIDE_WITNESS__
                     </div>
                     __BLOCKS__


### PR DESCRIPTION
It is never set in the app and is showing up as is on football liveblogs.