### PR TITLE
Change message for require('./config') failure

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,7 +7,7 @@ module.exports = function(grunt) {
         config = require('./config');
     }
     catch (e) {
-        console.log('Config module not found, trying an empty config');
+        console.log('Empty config will be used as config file failed to load with error:\n' + e);
         config = {
             base: {
                 android: '',


### PR DESCRIPTION
If there's a syntax error in `config.js`, an empty configuration will
be assumed and "Config module not found" will be printed to the
console.

This patch changes the message to a more generic "failed to load"
explanation and prints out the exception for full detail. This
hopefully makes syntax errors more obvious and easier to find.