### PR TITLE
GIA-3854: Specify git address for smooth-scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "phantomjs": "^1.9.15",
     "qwery": "^4.0.0",
     "raven-js": "^1.1.18",
-    "smooth-scroll": "7.0.2"
+    "smooth-scroll": "git://github.com/cferdinandi/smooth-scroll"
   }
 }


### PR DESCRIPTION
The smooth-scroll package defined in package.json was changed in commit 10e4672e8e061937cda3945b335dc232f7888882 from using a github url to a version number.

Version numbers can only be used for packages that exist in NPM. Smooth-scroll doesn't, so npm install fails to find the package.

This needs to be changed back to a git url.