### PR TITLE
Make static files served by express render properly

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -5,6 +5,7 @@ var zlib = require('zlib');
 var parse = require('url').parse;
 
 app.use(express.static(__dirname + '/fixture'));
+app.use(express.static(__dirname + '/..'));
 app.use('/data/data/com.guardian/files/dev-templates/assets', express.static(__dirname + '/../ArticleTemplates/assets'));
 app.use('/performances', express.static(__dirname + '/../Performance'));
 app.use('/root', express.static(__dirname + '/..'));


### PR DESCRIPTION
The static html files in `test/fixture/` were changed from accessing
assets via /root to accessing them using relative paths.

    <link rel="stylesheet" type="text/css" media="all" href="/root/ArticleTemplates/assets/css/style-sync.css">
    <link rel="stylesheet" type="text/css" media="all" href="../../ArticleTemplates/assets/css/style-sync.css">

That change made the html files render properly if you manually open
them in a browser. That change also made the files not render if
accessed by localhost:3000/file.html.

This change exposes the whole source tree in the root of the express
server. This is a bit overkill, but it makes localhost:3000/file.html
render properly.

As a side effect, this also fixes wraith.