### PR TITLE
Better workflow

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -197,7 +197,7 @@ module.exports = function(grunt) {
             },
             scss: {
                 files: ['ArticleTemplates/assets/scss/**/*.scss'],
-                tasks: ['scsslint','sass','hologram','rsync']
+                tasks: ['scsslint','sass','hologram','cssmin','rsync']
             },
             copy: {
                 files: ['ArticleTemplates/*.html', 'ArticleTemplates/assets/img/**'],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -263,6 +263,12 @@ module.exports = function(grunt) {
             },
             wraith: {
                 command: 'cd ' + config.base.html + 'test/visual && wraith latest ' + config.base.html + 'test/visual/visual.yaml'
+            },
+            ziptemplates: {
+                command: 'cd ArticleTemplates && zip -q -r ArticleTemplates.zip ./* -x "./assets/scss/*" "./assets/js/*" "*.DS_Store" "*.map" && mv ArticleTemplates.zip ../'
+            },
+            deployandroid: {
+                command: 'adb push ArticleTemplates.zip /sdcard/ArticleTemplates.zip && adb shell am startservice -n "com.guardian/.templates.UpdateTemplatesService"'
             }
         }
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -279,6 +279,7 @@ module.exports = function(grunt) {
     grunt.registerTask('build', ['initRequireJS', 'jshint', 'requirejs', 'scsslint','sass:dev','cssmin']);
     grunt.registerTask('buildJS', ['initRequireJS', 'jshint', 'requirejs']);
     grunt.registerTask('buildCSS', ['scsslint','sass:dev','cssmin']);
+    grunt.registerTask('deploy', ['build','shell:ziptemplates', 'shell:deployandroid']);
     grunt.registerTask('apk', ['build', 'rsync', 'shell:android']);
     grunt.registerTask('ipa', ['build', 'rsync', 'shell:ios']);
     grunt.registerTask('installer', ['build', 'rsync', 'shell:ios', 'shell:android']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -264,6 +264,9 @@ module.exports = function(grunt) {
             wraith: {
                 command: 'cd ' + config.base.html + 'test/visual && wraith latest ' + config.base.html + 'test/visual/visual.yaml'
             },
+            clean: {
+                command: 'git checkout ArticleTemplates/assets/build ArticleTemplates/assets/css ArticleTemplates/assets/scss/*.css DocumentationTemplates test'
+            },
             ziptemplates: {
                 command: 'cd ArticleTemplates && zip -q -r ArticleTemplates.zip ./* -x "./assets/scss/*" "./assets/js/*" "*.DS_Store" "*.map" && mv ArticleTemplates.zip ../'
             },


### PR DESCRIPTION
This is templates-side bit of work from what David started on the android side.

David's pull request is https://github.com/guardian/android-news-app/pull/2441 . The new "Templates (development mode)" debug option needs to be on for this to work!

`grunt deploy` will build and deploy the templates to the device, and force an article reload

Here's an extra trick I added
`grunt shell:clean` clears all the generated files : -)