### PR TITLE
Updates to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@ Article templates used within the Guardian’s next-generation iOS and Android a
 ## Requirements
 * A Mac or Linux PC.
 * [brew](http://brew.sh/) as a package manager.
-* [rbenv](https://github.com/sstephenson/rbenv). Install it using brew `brew install rbenv ruby-build`. Remember to add `eval "$(rbenv init -)"` to `~/.profile`.
-* [NVM](https://github.com/creationix/nvm). 
-* [NodeJS](http://nodejs.org/). Install using nvm: `nvm install v0.12.5`. Remember to add `nvm use v0.12.5` to `~/.profile`.
+* [rbenv](https://github.com/sstephenson/rbenv). Install it using brew `brew install rbenv ruby-build`. Remember to add `eval "$(rbenv init -)"` to your preferred shell startup file (e.g. `~/.profile`, `~/.zshrc`, etc).
+* [NVM](https://github.com/creationix/nvm).
+* [NodeJS](http://nodejs.org/). Install using nvm: `nvm install v0.12.5`. Remember to add `nvm use v0.12.5` to your preferred shell startup file.
 * [Grunt](http://gruntjs.com/). Install using `npm install -g grunt grunt-cli`.
 * ImageMagick and PhantomJS. Install using brew: `brew install phantomjs imagemagick`.
+* It is recommended you restart your shell to ensure changes added the startup file are applied.
 
 ## Usage
-* checkout the project in a separate directory, outside the iOs and the Android app.
-* run `rbenv install && gem install bundler && source ~/.profile`.
-* run `npm install`. 
+* checkout the project in a separate directory, outside the iOS and the Android app.
+* run `rbenv install && gem install bundler`.
+* run `npm install`.
 * run `bundle install`.
 * copy config.sample.js to config.js and fill in the details
     * `base.android` is the 'ArticleTemplate' path within the Android app, eg: `'/Users/sandropaganotti/Projects/guardian-app/android-news-app/android-news-app/src/debug/assets/templatesSubmodule/ArticleTemplates/'`
@@ -26,7 +27,7 @@ Article templates used within the Guardian’s next-generation iOS and Android a
         * read the (very long) output log, at the end there are two rows `Signing Identity:` and `Provisioning Profile:`
         * use the value of `Signing Identity:` for `ios.sign`
         * look on your hard drive for a file named after the `Provisioning Profile:` - the part between the brakets, eg: if your `Provisioning Profile:` value is (`123456-3136-4783-95e8-ac71ca306f46`) you need to look for a file named `123456-3136-4783-95e8-ac71ca306f46.mobileprovision` eg: `/Users/sandropaganotti/Library/MobileDevice/Provisioning Profiles/123456-3136-4783-95e8-ac71ca306f46.mobileprovision` and use that path for the `ios.provisioning`
-* run `grunt` 
+* run `grunt`
 
 ## Grunt tasks
 Grunt will provide the following services:
@@ -46,7 +47,7 @@ Grunt will provide the following services:
 These services are also available packed into recipes
 * `grunt buildJS` concatenate and minify javascript files, check javascript syntax, and start karma unit test runner.
 * `grunt buildCSS` run scsslint, compile SCSS into CSS and minify CSS.
-* `grunt apk --card=1234` it launches `build` then `rsync` and then `shell:android` to make sure that the resulting build contains the current files from the project and not some stale files.  
+* `grunt apk --card=1234` it launches `build` then `rsync` and then `shell:android` to make sure that the resulting build contains the current files from the project and not some stale files.
 * `grunt ipa` it launches `build` then `rsync` and then `shell:ios`.
 * `grunt installer --card=1234` it launches `apk` and `ipa` in sequence.
 
@@ -54,8 +55,8 @@ _By simply running `grunt` (without any argument) the system keeps watching for 
 
 ## Experimental performance measurement
 ![](https://raw.githubusercontent.com/guardian/mobile-apps-article-templates/master/Performance/_cover.png)
-This feature allows us to record several timelines from a page loaded into the device and then it extracts some 
-particular features (such as frame rate, page load time and more) and it creates a chart for it. 
+This feature allows us to record several timelines from a page loaded into the device and then it extracts some
+particular features (such as frame rate, page load time and more) and it creates a chart for it.
 To use this feature there are a few steps involved:
 * make sure to use an Android device.
 * make sure to have the Android SDK installer and `adb` in `PATH`.

--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ Article templates used within the Guardian’s next-generation iOS and Android a
 * run `npm install`.
 * run `bundle install`.
 * copy config.sample.js to config.js and fill in the details
-    * `base.android` is the 'ArticleTemplate' path within the Android app, eg: `'/Users/sandropaganotti/Projects/guardian-app/android-news-app/android-news-app/src/debug/assets/templatesSubmodule/ArticleTemplates/'`
-    * `base.ios` is the 'ArticleTemplate' path within the iOs app, eg: `/Users/sandropaganotti/Projects/guardian-app/ios-live/mobile-apps-article-templates/ArticleTemplates/`
-    * `base.html` is the path where this repository has been checked out, eg: `/Users/sandropaganotti/Projects/guardian-app/html-webview/`
+    * `base.android` is the 'ArticleTemplate' path within the Android app, eg: `/Users/sandropaganotti/Projects/android-news-app/android-news-app/src/main/assets/templates/`
+    * `base.ios` is the 'ArticleTemplate' path within the iOs app, eg: `/Users/sandropaganotti/Projects/ios-live/mobile-apps-article-templates/ArticleTemplates/`
+    * `base.html` is the path where this repository has been checked out, eg: `/Users/sandropaganotti/Projects/mobile-apps-article-templates/`
     * `performance.server` is the URL that points to your local machine, you can use `http://127.0.0.1` temporarily but you'll need to switch it to the LAN IP if you want to use the performance testing on an external device.
-    * `ios.sign` and `ios.provisioning`. This is more tricky, these two values can be extracted following this procedure:
+    * `ios.sign` and `ios.provisioning`. These fields can be set to empty strings for testing on an iOS device simulator. If you need to test on a physical provisioned device, the correct values can be extracted following this procedure:
         * from a terminal go to the folder `GLA` within the `ios-live` repository
         * run `xcodebuild build -sdk iphoneos8.3 -configuration Debug -workspace GLA.xcworkspace -scheme GLADebug`
         * read the (very long) output log, at the end there are two rows `Signing Identity:` and `Provisioning Profile:`
         * use the value of `Signing Identity:` for `ios.sign`
-        * look on your hard drive for a file named after the `Provisioning Profile:` - the part between the brakets, eg: if your `Provisioning Profile:` value is (`123456-3136-4783-95e8-ac71ca306f46`) you need to look for a file named `123456-3136-4783-95e8-ac71ca306f46.mobileprovision` eg: `/Users/sandropaganotti/Library/MobileDevice/Provisioning Profiles/123456-3136-4783-95e8-ac71ca306f46.mobileprovision` and use that path for the `ios.provisioning`
+        * look on your hard drive for a file named after the `Provisioning Profile:` - the part between the brackets, eg: if your `Provisioning Profile:` value is (`123456-3136-4783-95e8-ac71ca306f46`) you need to look for a file named `123456-3136-4783-95e8-ac71ca306f46.mobileprovision` eg: `/Users/sandropaganotti/Library/MobileDevice/Provisioning Profiles/123456-3136-4783-95e8-ac71ca306f46.mobileprovision` and use that path for the `ios.provisioning`
 * run `grunt`
 
 ## Grunt tasks


### PR DESCRIPTION
I had a few trip-ups while getting this running locally, so I thought I'd make a couple of updates to the docs:

- make no assumptions about a developer's shell
- set correct paths to native apps' templates directory
- clarify that `ios.sign` and `ios.provisioning` are only needed for testing on a physical iOS device