### PR TITLE
Add is live flag to cricket template

### DIFF
--- a/ArticleTemplates/cricketTemplate.html
+++ b/ArticleTemplates/cricketTemplate.html
@@ -74,6 +74,7 @@
         GU.Bootstrap.init({
             sectionTone: '__SECTION_TONE__',
             fontSize: '__FONT_SIZE__',
+            isLive: '__IS_LIVE__' ? true : false,
             platform: '__PLATFORM__',
             isOffline: '__IS_OFFLINE__' ? true : false,
             contentType: 'cricket',


### PR DESCRIPTION
If __IS_LIVE__ replaced by native layer then the timestamps on a cricket live blog will be reformatted using relativeDates module.