### PR TITLE
Move byline in front of cutout

### DIFF
--- a/ArticleTemplates/articleTemplateContainerComment.html
+++ b/ArticleTemplates/articleTemplateContainerComment.html
@@ -10,10 +10,10 @@
                 </div>
             </div>
             <div class="cutout__container" id="cutout-container">
-                <h1 class="headline selectable" id="headline">__TITLE__ 
+                __CUTOUT__
+                <h1 class="headline selectable" id="headline">__TITLE__
                     <div class="headline__byline">__COMMENT_AUTHOR__</div>
                 </h1>
-                __CUTOUT__
             </div>
 
             <div class="meta" id="meta">
@@ -44,7 +44,7 @@
         <div class="tags" id="tags">
             <ul class="inline-list" id="tag-list">
                 <li class="inline-list__item screen-readable">Tags:</li>
-                
+
             </ul>
         </div>
     </div>

--- a/test/fixture/article-tone-comment.html
+++ b/test/fixture/article-tone-comment.html
@@ -30,10 +30,10 @@
                 </div>
             </div>
             <div class="cutout__container" id="cutout-container">
-                <h1 class="headline selectable" id="headline">Ai Weiwei is making a feature film: I'm worried 
+                <div class="cutout__image" style="background-image: url(https://mobile.guardianapis.com/img/static/sys-images/Guardian/Pix/pictures/2014/3/13/1394733741000/JonathanJones.png/0826f5f3e581f3b62868887019497d65?width=600&amp;height=360&amp;quality=60);"></div>
+                <h1 class="headline selectable" id="headline">Ai Weiwei is making a feature film: I'm worried
                     <div class="headline__byline"><span class="byline__author"><a href="x-gu://list/mobile-apps.guardianapis.com/lists/tag/profile/jonathanjones">Jonathan Jones</a></span></div>
                 </h1>
-                <div class="cutout__image" style="background-image: url(https://mobile.guardianapis.com/img/static/sys-images/Guardian/Pix/pictures/2014/3/13/1394733741000/JonathanJones.png/0826f5f3e581f3b62868887019497d65?width=600&amp;height=360&amp;quality=60);"></div>
             </div>
 
             <div class="meta" id="meta">


### PR DESCRIPTION
Currently the cutout sits in front of the byline on opinion articles. This makes it impossible to tap the author's byline and navigate to their author page.

This change moves the cutout behind the byline, allowing the user to tap the byline.

![picture 207](https://cloud.githubusercontent.com/assets/5931528/24807282/8bd9cb66-1baf-11e7-93ad-ef7abb55e482.png)
