### PR TITLE
replace ‘list’ in template with placeholder __TAG_TYPE__

### DIFF
--- a/ArticleTemplates/articleTemplateTag.html
+++ b/ArticleTemplates/articleTemplateTag.html
@@ -1,1 +1,1 @@
-<li class="inline-list__item"><a href="x-gu://list/__TAG_URI__">__TAG_TITLE__</a></li>
+<li class="inline-list__item"><a href="x-gu://__TAG_TYPE__/__TAG_URI__">__TAG_TITLE__</a></li>


### PR DESCRIPTION
Tags can link to lists or fronts in the native apps. However the href in articleTemplateTag.html has 'link' hardcoded in the path, meaning tags which should link to fronts don't  go anywhere right now.

This updates articleTemplateTag.html to replace the hardcoded 'link' with a placeholder __TAG_TYPE__. The native layers will replace this with 'link' or 'front' depending on the tag, and the tag should then work correctly!