### PR TITLE
Ads and epics shouldn't be inserted after the same block

### DIFF
--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -39,17 +39,19 @@ function (
     }
 
     function updateLiveblogAdPlaceholders(reset) {
-        var i,
-            advertSlots,
-            mpu,
-            block,
-            blocks = document.querySelectorAll('.article__body > .block');
+        var i;
+        var advertSlots;
+        var mpu;
+        var block;
+        // The selector here is taking all .block elements within article body
+        // which are not siblings of contributions-epic__container
+        var blocks = document.querySelectorAll('.article__body > .block:first-child, .article__body > div:not(.contributions-epic__container) + .block');
 
         if (reset) {
             advertSlots = document.getElementsByClassName('advert-slot--mpu');
 
-            for (i = advertSlots.length; i > 0; i--) {
-                advertSlots[i-1].parentNode.removeChild(advertSlots[i-1]);
+            while(advertSlots.length > 0){
+                advertSlots[0].parentNode.removeChild(advertSlots[0]);
             }
 
             numberOfMpus = 0;
@@ -58,12 +60,12 @@ function (
         for (i = 0; i < blocks.length; i++) {
             block = blocks[i];
 
-            if (i === 1 || i === 6) {
+            if (i === 2 || i === 7) {
                 numberOfMpus++;
                 mpu = createMpu(numberOfMpus);
 
                 if (block.nextSibling) {
-                    block.parentNode.insertBefore(mpu, block.nextSibling);
+                    block.parentNode.insertBefore(mpu, block);
                 } else {
                     block.parentNode.appendChild(mpu);
                 }

--- a/ArticleTemplates/assets/js/modules/creativeInjector.js
+++ b/ArticleTemplates/assets/js/modules/creativeInjector.js
@@ -32,7 +32,7 @@ function (
             liveBlogEpicContainer.setAttribute('data-tracked', 'true');
 
             addEventListenerScroll(liveBlogEpicContainer, liveBlogEpicContainerId);
-        };
+        }
     }
 
     function injectCreative(html, css, id, type) {

--- a/ArticleTemplates/assets/js/modules/creativeInjector.js
+++ b/ArticleTemplates/assets/js/modules/creativeInjector.js
@@ -20,7 +20,7 @@ function (
 
     function trackLiveBlogEpic() {
         // if there is already a data-tracked attribute than we don't need to set up tracking again
-        var liveBlogEpicContainers = document.querySelectorAll('.contributions-epic:not([data-tracked])');
+        var liveBlogEpicContainers = document.querySelectorAll('.contributions-epic__container:not([data-tracked])');
         var liveBlogEpicContainerId;
         var i;
         var liveBlogEpicContainer;

--- a/ArticleTemplates/liveblogTemplateContributionsEpic.html
+++ b/ArticleTemplates/liveblogTemplateContributionsEpic.html
@@ -1,4 +1,4 @@
-<div class="contributions-epic" id="__CONTRIBUTIONS_EPIC_ID__">
+<div class="contributions-epic__container" id="__CONTRIBUTIONS_EPIC_ID__">
     <style class="contributions-epic__styling">
         // Contributions Epic styling will go here
         __CONTRIBUTIONS_EPIC_STYLE__

--- a/test/spec/unit/modules/adsTest.js
+++ b/test/spec/unit/modules/adsTest.js
@@ -104,7 +104,7 @@ define([
 
                     expect(articleBody.children.length).to.eql(10);
                     expect(articleBody.children[2].classList.contains('advert-slot')).to.eql(true);
-                    expect(articleBody.children[8].classList.contains('advert-slot')).to.eql(true);
+                    expect(articleBody.children[9].classList.contains('advert-slot')).to.eql(true);
 
                     expect(window.initMpuPoller).to.not.be.undefined;
                     expect(window.killMpuPoller).to.not.be.undefined;
@@ -263,7 +263,7 @@ define([
                 };
             });
 
-            it('inserts liveblog ads after 1st and 7th blocks', function (done) {
+            it('inserts liveblog ads after 2nd and 7th blocks', function (done) {
                 ads.init(config);
 
                 expect(articleBody.children[2].classList.contains('advert-slot--mpu')).to.eql(true);
@@ -302,6 +302,45 @@ define([
             });
         });
 
+        describe('if there is a contribution epic after the 2nd block', function () {
+            var articleBody,
+                config;
+
+            beforeEach(function () {
+                var i,
+                    block;
+
+                articleBody = document.createElement('div');
+                articleBody.classList.add('article__body');
+
+                container.appendChild(articleBody);
+
+                var epic = document.createElement('div');
+                epic.classList.add('contributions-epic__container');
+
+                for (i = 0; i < 5; i++) {
+                    block = document.createElement('div');
+                    block.classList.add('block', i);
+                    articleBody.appendChild(block);
+                }
+
+                articleBody.insertBefore(epic, articleBody.children[2]);
+
+                config = {
+                    adsType: 'liveblog'
+                };
+            });
+
+
+
+            it('inserts liveblog ad after the 3rd block instead', function (done) {
+                ads.init(config);
+
+                expect(articleBody.children[4].classList.contains('advert-slot--mpu')).to.eql(true);
+
+                done();
+            });
+        });
 
         describe('window.initMpuPoller()', function () {
             var advertSlotWrapper,


### PR DESCRIPTION
This PR: 
* Changes the name of the class to not conflict with a same already in the markup submitted by the contributions team
* If there is a contributions epic after a liveblog block which an ad should go, the ad should instead go after the next liveblog block.