### PR TITLE
need to force the `merge`

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -12,6 +12,7 @@ if [[ `git status --porcelain` ]]; then
     git status
     git commit -m "Generate files for release [skip ci]"
     git checkout release
-    git merge master
-    git push origin release
+    git reset --hard master
+    git log -1
+    git push origin release -f
 fi


### PR DESCRIPTION
Annoyingly, there is a merge conflict in the CI that I can't replicate locally.  

![image](https://cloud.githubusercontent.com/assets/8774970/25995160/dfe32d6e-3708-11e7-92e2-9ddf14d1168c.png)


This should just force the release branch to be the same state as master.

Are you okay with this @GHaberis ?