### PR TITLE
Go back to merging, not reseting

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -12,7 +12,7 @@ if [[ `git status --porcelain` ]]; then
     git status
     git commit -m "Generate files for release [skip ci]"
     git checkout release
-    git reset --hard master
+    git merge master
     git log -1
-    git push origin release -f
+    git push origin release
 fi


### PR DESCRIPTION
Unfortunately I didn't realise that the apps release was depending on a particular git commit hash, so this stops the commits from being overwritten.

Sanity check @GHaberis ?