### PR TITLE
use double quotes to wrap data-content-section

### DIFF
--- a/ArticleTemplates/articleTemplate.html
+++ b/ArticleTemplates/articleTemplate.html
@@ -11,7 +11,7 @@
     </script>
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/shim.js"></script>
 </head>
-<body class="tone--__SECTION_TONE__ __IS_IMMERSIVE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__" data-content-type="article" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__" data-content-section='__SECTION__'>
+<body class="tone--__SECTION_TONE__ __IS_IMMERSIVE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__" data-content-type="article" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__" data-content-section="__SECTION__">
 
     __ARTICLE_CONTAINER__
 


### PR DESCRIPTION
data-content-section on the body tag was using single quotes, section names can contain unescaped apostrophes, if they do this breaks the template. Wrapping the section name in double quotes guards against this.