### PR TITLE
CI merge conflict fix

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -13,7 +13,7 @@ if [[ `git status --porcelain` ]]; then
     git commit -m "Generate files for release"
     git checkout release
     git reset --hard origin/release
-    git merge master -m "Merge master into release"
+    git merge -X theirs master -m "Merge master into release"
     git log -1
     npm --no-git-tag-version version patch 
     git add package.json


### PR DESCRIPTION
On the CI env we merge master into release, we should always take the changes from master over release if/when we have conflicts. 