### PR TITLE
Fix jshint warning

### DIFF
--- a/ArticleTemplates/assets/js/modules/messenger.js
+++ b/ArticleTemplates/assets/js/modules/messenger.js
@@ -1,4 +1,3 @@
-/* global Promise */
 define([
     'modules/post-message'
 ], function (postMessage) {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -139,7 +139,6 @@ module.exports = function(grunt) {
                     'undef': true,
                     'unused': true,
                     'white': true,
-                    'predef': [ '-Promise' ],
                     'globals': {
                         'console': true,
                         'GU': true,
@@ -148,7 +147,8 @@ module.exports = function(grunt) {
                         'sinon': true,
                         'expect': true,
                         'twttr': true,
-                        'YT': true
+                        'YT': true,
+                        'Promise': true
                     }
                 },
                 files: {


### PR DESCRIPTION
jshint was throwing a warning saying the global 'Promise' wasn't defined, even though the global comment at the top of messenger.js was present. 

This is because '-Promise' was listed in the predef (pre-defined) option list, the '-' prefix removed Promise from the list of predefined variables and caused this issue. 

Promise no longer belongs is in this predef list so I've removed it which fixes the issue.

