### PR TITLE
Fix comment breakage.

### DIFF
--- a/ArticleTemplates/liveblogTemplateContributionsEpic.html
+++ b/ArticleTemplates/liveblogTemplateContributionsEpic.html
@@ -1,6 +1,6 @@
 <div class="contributions-epic__container" id="__CONTRIBUTIONS_EPIC_ID__">
     <style class="contributions-epic__styling">
-        // Contributions Epic styling will go here
+        /* Contributions Epic styling will go here */
         __CONTRIBUTIONS_EPIC_STYLE__
     </style>
     <!-- Contributions Epic will be inserted here -->


### PR DESCRIPTION
This comment is causing problems in the liveblog template as it isn't a valid CSS comment.
It had the consequence of ignoring the first CSS class of the CSS blob.

A workaround is in place by pre-pending a dummy CSSS class in the CSS blob, but this should fix it long term wise.

cc @Leyths 