### PR TITLE
Extract validation and test tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -244,5 +244,5 @@ module.exports = function(grunt) {
 
     grunt.registerTask('buildCSS', ['sass', 'cssmin']);
 
-    grunt.registerTask('default', ['buildJS', 'buildCSS', 'watch']);
+    grunt.registerTask('default', ['buildJS', 'buildCSS', 'rsync', 'watch']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,7 @@
 module.exports = function(grunt) {
 
     require('load-grunt-tasks')(grunt);
-    
+
     config = {};
 
     try {
@@ -111,7 +111,7 @@ module.exports = function(grunt) {
                 force: true
             },
             uses_defaults: [
-                'Gruntfile.js', 
+                'Gruntfile.js',
                 'ArticleTemplates/assets/js/{bootstraps, modules}/*.js'
             ],
             with_overrides: {
@@ -210,18 +210,18 @@ module.exports = function(grunt) {
         watch: {
             js: {
                 files: ['ArticleTemplates/assets/js/**/*.js'],
-                tasks: ['buildJS','rsync']
+                tasks: ['validateJS', 'testJS', 'buildJS','rsync']
             },
             scss: {
                 files: ['ArticleTemplates/assets/scss/**/*.scss'],
-                tasks: ['buildCSS','rsync']
+                tasks: ['validateCSS', 'buildCSS','rsync']
             },
             copy: {
                 files: ['ArticleTemplates/*.html', 'ArticleTemplates/assets/img/**'],
                 tasks: ['rsync']
             }
         },
-        // desktop notifications for Grunt errors 
+        // desktop notifications for Grunt errors
         notify_hooks: {
             options: {
                 enabled: true,
@@ -234,9 +234,15 @@ module.exports = function(grunt) {
 
     grunt.task.run('notify_hooks');
 
-    grunt.registerTask('buildJS', ['jshint', 'karma', 'initRequireJS', 'requirejs']);
+    grunt.registerTask('testJS', ['karma']);
 
-    grunt.registerTask('buildCSS', ['sasslint', 'sass', 'cssmin']);
+    grunt.registerTask('validateJS', ['jshint']);
+
+    grunt.registerTask('validateCSS', ['sasslint']);
+
+    grunt.registerTask('buildJS', ['initRequireJS', 'requirejs']);
+
+    grunt.registerTask('buildCSS', ['sass', 'cssmin']);
 
     grunt.registerTask('default', ['buildJS', 'buildCSS', 'watch']);
 };

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ dependencies:
 
 test:
   override:
-    - yarn build
+    - yarn build && yarn validate && yarn test
 
 deployment:
   release:

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "ArticleTemplates/",
   "scripts": {
     "setup": "if [ ! -d .git/info ]; then  mkdir -p .git/info; fi; echo ArticleTemplates/assets/css/ >> .git/info/exclude && echo ArticleTemplates/assets/build/ >> .git/info/exclude",
-    "test": "grunt karma",
-    "validate": "grunt sasslint && grunt jshint",
+    "test": "grunt testJS",
+    "validate": "grunt validateJS && grunt validateCSS",
     "buildJS": "grunt buildJS",
     "buildCSS": "grunt buildCSS",
     "build": "yarn buildJS && yarn buildCSS",


### PR DESCRIPTION
I have experienced some frustration with the way the build, testing and validation tasks are tightly coupled within the Gruntfile. It means the developer has to wait for tests and validation to pass when they run `yarn develop`.

I have extracted validation and testing into their own Grunt tasks. These are still executed as part of the watch task when code is changed, but are not executed when the task is first started. The `rsync` task will also be called when `yarn develop` is first started.

The fact that I didn't need to change the README as part of this change indicates that perhaps this is the way it ought to be working anyway.

This level of task granularity gives us a greater flexibility over when tasks are run, allowing us to develop more efficiently.