### PR TITLE
Only publish required assets to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,9 @@
 *
 
 # Apart from...
-!ArticleTemplates
+!ArticleTemplates/*.html
+!ArticleTemplates/assets/build/**/*.js
+!ArticleTemplates/assets/css/*.css
+!ArticleTemplates/assets/fonts/*
+!ArticleTemplates/assets/img/*
+


### PR DESCRIPTION
When installing mobile-apps-article-templates npm package I found no assets were included in the modules directory. This is because our .npmignore file wasn't working as expected. I've updated and tested (using this https://www.npmjs.com/package/irish-pub) and these changes should mean we only publish the files required by the native app. 