### PR TITLE
Move dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "d3": "^3.5.4",
+    "domready": "^1.0.7",
+    "fastclick": "^1.0.6",
+    "fence": "git://github.com/guardian/fence",
     "grunt": "^0.4.5",
     "grunt-contrib-cssmin": "^0.14.0",
     "grunt-contrib-jshint": "^1.0.0",
@@ -53,14 +57,8 @@
     "requirejs": "^2.3.3",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
+    "smooth-scroll": "git://github.com/cferdinandi/smooth-scroll",
     "squirejs": "^0.2.1"
-  },
-  "dependencies": {
-    "d3": "^3.5.4",
-    "domready": "^1.0.7",
-    "fastclick": "^1.0.6",
-    "fence": "git://github.com/guardian/fence",
-    "smooth-scroll": "git://github.com/cferdinandi/smooth-scroll"
   },
   "engines": {
     "node": "6.9.2"


### PR DESCRIPTION
When installing the mobile-apps-article-templates within the native app projects it also downloads and installs the dependencies listed in mobile-apps-article-templates. This is unnecessary, moving these modules from dependencies to devDependencies should mean when we install mobile-apps-article-templates it only installs the relevant files.