### PR TITLE
Stop letters from touching in immersive template

### DIFF
--- a/ArticleTemplates/assets/scss/layout/_article--immersive.scss
+++ b/ArticleTemplates/assets/scss/layout/_article--immersive.scss
@@ -120,7 +120,7 @@ body.immersive .article--immersive {
 
         &__series {
             display: block;
-            padding-bottom: 12px;
+            padding-bottom: 6px;
 
             > a, & {
                 color: color(shade-7);
@@ -144,14 +144,13 @@ body.immersive .article--immersive {
         &__headline {
             color: color(shade-7);
             font-size: 3.5rem !important;
-            line-height: 3.3rem;
-            padding: 0 0 24px;
+            line-height: 1.04;
+            padding: 0;
             z-index: 1;
 
             @include mq($from: col2) {
                 font-size: 2.8em !important;
                 font-weight: 100;
-                line-height: .9375;
                 margin-bottom: 24px;
             }
 


### PR DESCRIPTION
This increases line-height in immersive headlines, and tightens spacing around the headline so the header doesn't take as much space.

## Before & After

![animated](https://user-images.githubusercontent.com/4561/27649204-fdd24fea-5c28-11e7-96b4-fc5defcd8da2.gif)
