### PR TITLE
Send the path of the article in the handshake response

### DIFF
--- a/ArticleTemplates/assets/js/modules/messenger.js
+++ b/ArticleTemplates/assets/js/modules/messenger.js
@@ -22,7 +22,10 @@ define([
 
     function start(modules) {
         register('syn', function() {
-            return 'ack';
+            return {
+              msg: 'ack',
+              src: location.pathname
+            };
         });
 
         modules.forEach(function (module) {


### PR DESCRIPTION
That is necessary for reporting data back to Ophan, as the iframe origin is on a different domain.