### PR TITLE
Fix MPU position on iOS11

### DIFF
--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -118,25 +118,22 @@ function (
             },
             mpuOffsetTop = getMpuTop(scrollTop);
 
-            if (advertSlots.length) {
-                for (i = 0; i < advertSlots.length; i++) {
-                    advertPosition = advertSlots[i].getBoundingClientRect();
+        if (advertSlots.length) {
+            for (i = 0; i < advertSlots.length; i++) {
+                advertPosition = advertSlots[i].getBoundingClientRect();
 
-                    if (advertPosition.width !== 0 && advertPosition.height !== 0) {
-                        params['x' + (i + 1)] = advertPosition.left + scrollLeft;
-                        
-                        params['y' + (i + 1)] = (advertPosition.top - mpuOffsetTop) + scrollTop;
-                        // params['y' + (i + 1)] = advertPosition.top + scrollTop;
-                        
-                        params['w' + (i + 1)] = advertPosition.width;
-                        params['h' + (i + 1)] = advertPosition.height;
-                    }
+                if (advertPosition.width !== 0 && advertPosition.height !== 0) {
+                    params['x' + (i + 1)] = advertPosition.left + scrollLeft;
+                    params['y' + (i + 1)] = (advertPosition.top - mpuOffsetTop) + scrollTop;
+                    params['w' + (i + 1)] = advertPosition.width;
+                    params['h' + (i + 1)] = advertPosition.height;
                 }
-
-                return formatter(params);
-            } else {
-                return null;
             }
+
+            return formatter(params);
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -115,24 +115,26 @@ function (
                 y2: -1, 
                 w2: -1,
                 h2: -1
-            };
+            },
+            bodyTop = document.body.getBoundingClientRect().top,
+            offsetTop = scrollTop + bodyTop;
 
-        if (advertSlots.length) {
-            for (i = 0; i < advertSlots.length; i++) {
-                advertPosition = advertSlots[i].getBoundingClientRect();
+            if (advertSlots.length) {
+                for (i = 0; i < advertSlots.length; i++) {
+                    advertPosition = advertSlots[i].getBoundingClientRect();
 
-                if (advertPosition.width !== 0 && advertPosition.height !== 0) {
-                    params['x' + (i + 1)] = advertPosition.left + scrollLeft;
-                    params['y' + (i + 1)] = advertPosition.top + scrollTop;
-                    params['w' + (i + 1)] = advertPosition.width;
-                    params['h' + (i + 1)] = advertPosition.height;
+                    if (advertPosition.width !== 0 && advertPosition.height !== 0) {
+                        params['x' + (i + 1)] = advertPosition.left + scrollLeft;
+                        params['y' + (i + 1)] = (advertPosition.top - offsetTop) + scrollTop;
+                        params['w' + (i + 1)] = advertPosition.width;
+                        params['h' + (i + 1)] = advertPosition.height;
+                    }
                 }
-            }
 
-            return formatter(params);
-        } else {
-            return null;
-        }
+                return formatter(params);
+            } else {
+                return null;
+            }
     }
 
     function getMpuPosCommaSeparated() {

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -116,8 +116,7 @@ function (
                 w2: -1,
                 h2: -1
             },
-            bodyTop = document.body.getBoundingClientRect().top,
-            offsetTop = scrollTop + bodyTop;
+            mpuOffsetTop = getMpuTop(scrollTop);
 
             if (advertSlots.length) {
                 for (i = 0; i < advertSlots.length; i++) {
@@ -125,7 +124,10 @@ function (
 
                     if (advertPosition.width !== 0 && advertPosition.height !== 0) {
                         params['x' + (i + 1)] = advertPosition.left + scrollLeft;
-                        params['y' + (i + 1)] = (advertPosition.top - offsetTop) + scrollTop;
+                        
+                        params['y' + (i + 1)] = (advertPosition.top - mpuOffsetTop) + scrollTop;
+                        // params['y' + (i + 1)] = advertPosition.top + scrollTop;
+                        
                         params['w' + (i + 1)] = advertPosition.width;
                         params['h' + (i + 1)] = advertPosition.height;
                     }
@@ -135,6 +137,19 @@ function (
             } else {
                 return null;
             }
+    }
+
+    /**
+        bodyTop and offsetTop added to fix issue on iOS11
+        where ad position was misreported.
+    **/
+    function getMpuTop(scrollTop) {
+        if (GU.opts.platform === 'android') {
+            return 0;
+        }
+
+        var bodyTop = document.body.getBoundingClientRect().top,
+            offsetTop = scrollTop + bodyTop;
     }
 
     function getMpuPosCommaSeparated() {


### PR DESCRIPTION
Ads are positioned within the app by the template adding a placeholder to the DOM and reporting it's position to the native layer. @aodhol reported an issue on iOS11 where ads were being positioned incorrectly, this was because the position reported by the template was incorrect.

This fix addresses the issue and has been tested on iOS11, iOS10 and Android.

