### PR TITLE
update docs to reflect changes to iOS releases

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
     });
 
     grunt.initConfig({
-        // sync templates to local ios/android projects
+        // sync templates to local android projects
         rsync: {
             options: {
                 recursive: true,
@@ -62,12 +62,6 @@ module.exports = function(grunt) {
                 options: {
                     src: 'ArticleTemplates/',
                     dest: config.base.android
-                }
-            },
-            ios: {
-                options: {
-                    src: 'ArticleTemplates/',
-                    dest: config.base.ios
                 }
             }
         },

--- a/README.md
+++ b/README.md
@@ -15,16 +15,23 @@ Article templates used within the Guardian’s next-generation iOS, Android and 
 * checkout the project in a separate directory, outside the iOS and the Android app.
 * copy config.sample.js to config.js and fill in the details
     * `base.android` is the 'ArticleTemplate' path within the Android app, eg: `/Users/sandropaganotti/Projects/android-news-app/android-news-app/src/main/assets/templates/`
-    * `base.ios` is the 'ArticleTemplate' path within the iOS app, eg: `/Users/sandropaganotti/Projects/ios-live/mobile-apps-article-templates/ArticleTemplates/`
     * `base.html` is the path where this repository has been checked out, eg: `/Users/sandropaganotti/Projects/mobile-apps-article-templates/`
 * run `yarn` to install dependencies.
 * run `yarn setup` to locally ignore build files so they are not checked into master
 
 ## IOS and Android devs
 If you are developing against a branch which is not `release`, please follow the steps below:
+
 * Pull down the branch which you are developing against
-* Please follow the requirements and developing steps
-* run `yarn sync` which will build the project, and move the build into the individual Android and IOS projects
+* Follow the 'requirements' and 'developing' steps outlined above
+
+## IOS devs
+* run `yarn build` 
+* Within the root of ios-live open the package.json and update the dependency "@guardian/mobile-apps-article-templates" to point towards "file:../mobile-apps-article-templates"
+* next time you build using xcode it will use your local version of mobile-apps-article-templates
+
+## Android devs
+* run `yarn sync` which will build the project, and move the build into the Android
 
 ## Yarn scripts
 Yarn will provide the following services:
@@ -32,7 +39,7 @@ Yarn will provide the following services:
 * `yarn test` runs the JS unit tests from the test/spec/unit/ directory
 * `yarn validate` runs sasslint checks on SCSS and jshint checks on JS
 * `yarn build` builds JS/CSS assets, used on CI environment for building assets
-* `yarn develop` builds JS and CSS (with source maps) assets and watches for changes to JS/CSS. If changes then rebuilds and copies assets to iOS/Android to the iOS and Android projects as specified in config.js
+* `yarn develop` builds JS and CSS (with source maps) assets and watches for changes to JS/CSS. If changes then rebuilds and copies assets to the Android project as specified in config.js
 
 ## deploying
 

--- a/config.sample.js
+++ b/config.sample.js
@@ -1,7 +1,6 @@
 module.exports = {
 	base: {
 		android: , // android 'ArticleTemplate' path
-		ios: ,// ios 'ArticleTemplate' path
 		html: // html base path (where sits Gruntfile.js)
 	}
 }

--- a/docs/how-to-deploy.md
+++ b/docs/how-to-deploy.md
@@ -3,8 +3,8 @@
 1. When you merge your changes into master, Circle CI should pick them up and run the tests and validations
 2. Once that is successful it will build the project committing those changes
 3. The updated branch will then be pushed back to the origin `release` branch.
-4a: Release to Android: visit https://iosuiauto.gutools.co.uk and run the tasks 'Deploy latest template release to Android'. This task will update the templates submodule in the Android repo to the latest commit in the mobile-apps-article-templates release branch.
-4b: Release to iOS: CircleCI will publish the latest templates as an NPM package and update the ios-live repo to use the updated NPM package so you shouldn't have to do anything.
+4a. Release to Android: visit https://iosuiauto.gutools.co.uk and run the tasks 'Deploy latest template release to Android'. This task will update the templates submodule in the Android repo to the latest commit in the mobile-apps-article-templates release branch.
+4b. Release to iOS: CircleCI will publish the latest templates as an NPM package and update the ios-live repo to use the updated NPM package so you shouldn't have to do anything.
 5. If you need to release to the Windows repo pull the pending release branch from the windows-10-app repo and manually copy the directory 'ArticleTemplates' to windows-10-app/Code/TheGuardian.UI.Win/ArticleTemplates and push these changes.
 
 _TODO:_ Revisit step 4a and see if there's any reason why we couldn't automatically update Android.

--- a/docs/how-to-deploy.md
+++ b/docs/how-to-deploy.md
@@ -3,7 +3,8 @@
 1. When you merge your changes into master, Circle CI should pick them up and run the tests and validations
 2. Once that is successful it will build the project committing those changes
 3. The updated branch will then be pushed back to the origin `release` branch.
-4. To release to the iOS and Android repos visit https://iosuiauto.gutools.co.uk and run the tasks 'Deploy latest template release to Android' and 'Deploy latest template release to iOS'. These tasks will update the templates submodule in each respective repo to the latest commit in the mobile-apps-article-templates release branch.
+4a: Release to Android: visit https://iosuiauto.gutools.co.uk and run the tasks 'Deploy latest template release to Android'. This task will update the templates submodule in the Android repo to the latest commit in the mobile-apps-article-templates release branch.
+4b: Release to iOS: CircleCI will publish the latest templates as an NPM package and update the ios-live repo to use the updated NPM package so you shouldn't have to do anything.
 5. If you need to release to the Windows repo pull the pending release branch from the windows-10-app repo and manually copy the directory 'ArticleTemplates' to windows-10-app/Code/TheGuardian.UI.Win/ArticleTemplates and push these changes.
 
-_TODO:_ Revisit step 4/5 and see if there's any reason why we couldn't automatically update iOS/Android.
+_TODO:_ Revisit step 4a and see if there's any reason why we couldn't automatically update Android.


### PR DESCRIPTION
The mobile-apps-article-templates NPM package is now used by the ios-live repo. These changes update the docs to reflect this change.