### PR TITLE
Cancel a subscription page (AND-11756)

### DIFF
--- a/ArticleTemplates/simpleBodyTemplatePrepopCancelSubscriptionAndroid.html
+++ b/ArticleTemplates/simpleBodyTemplatePrepopCancelSubscriptionAndroid.html
@@ -24,5 +24,10 @@
             <p>If you need any more help, would like to provide feedback or contact us for any other reason, please email: <a href="mailto:android.app.feedback@theguardian.com?subject=Android - Apps feedback">android.app.feedback@theguardian.com</a></p>
         </div>
     </div>
+
+    <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/smoothScroll.js"></script>
+    <script type="text/javascript">
+        smoothScroll.init();
+    </script>
 </body>
 </html>

--- a/ArticleTemplates/simpleBodyTemplatePrepopCancelSubscriptionAndroid.html
+++ b/ArticleTemplates/simpleBodyTemplatePrepopCancelSubscriptionAndroid.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+    <title>cancel a subscription</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
+    <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="__TEMPLATES_DIRECTORY__assets/css/fonts-__PLATFORM__.css" />
+    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/style-sync.css" />
+    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/style-async.css" />
+</head>
+
+<body class="__FONT_SIZE__" data-template-directory="__TEMPLATES_DIRECTORY__">
+    <div class="support">
+        <div class="from-content-api prose">
+            <p>If you choose to cancel your Premium Tier subscription, you will be downgraded to the free and ad-supported option. This means that you will no longer get the advantages of the Premium Tier, like an advert-free experience, exclusive content, or crosswords.</p>
+            <p>Subscriptions are handled directly by Google, so you can't cancel them from within the Guardian app. Instead follow these instructions:</p>
+            <ul>
+                <li>Open the Google Play Store app</li>
+                <li>Select 'My Apps' from the options menu</li>
+                <li>Choose the 'Subscriptions' tag on the top left and tap on 'The Guardian'. Here you can see more subscriptions information and choose to cancel your subscription.</li>
+            </ul>
+            <hr />
+            <h2 id="contact">Getting in touch</h2>
+            <p>If you need any more help, would like to provide feedback or contact us for any other reason, please email: <a href="mailto:android.app.feedback@theguardian.com?subject=Android - Apps feedback">android.app.feedback@theguardian.com</a></p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Goes with this PR: https://github.com/guardian/android-news-app/pull/3873

Adds a simple new "cancel a subscription" page. I copied the "simple...Help.html" template and changed the words.