### PR TITLE
Make iframes in immersive articles 100% width

### DIFF
--- a/ArticleTemplates/assets/scss/layout/_article--immersive.scss
+++ b/ArticleTemplates/assets/scss/layout/_article--immersive.scss
@@ -69,6 +69,7 @@ body.immersive .article--immersive {
 
                 iframe {
                     height: 100% !important;
+                    width: 100%;
 
                     video {
                         -webkit-transform: (-50%, -50%);


### PR DESCRIPTION
If an immersive article header contains an iframe, the iframe does not stretch to fit the full width of the viewport, leaving a black space to the right. 

A temporary fix has been implemented in this specific article, whereby the width is added by asynchronously loaded JavaScript, resulting in a FOUC. 

This change implements a more permanent fix to this display issue.

![aug-04-2017 11-42-50](https://user-images.githubusercontent.com/5931528/28965698-4870ce0c-790a-11e7-805f-be8a5f5cef5d.gif)
