### PR TITLE
Sunset release branch

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -6,7 +6,6 @@ git config --global user.name "GuardianAndroid"
 git config --global user.email "guardian.android@gmail.com"
 git config --global push.default simple
 git status
-git reset --hard origin/master
 npm --no-git-tag-version version patch
 git add package.json
 PACKAGE_VERSION=$(node -p "require('./package.json').version")

--- a/circle.sh
+++ b/circle.sh
@@ -1,7 +1,17 @@
 #!/bin/bash -xe
 
+git status
+git log -1
+git config --global user.name "GuardianAndroid"
+git config --global user.email "guardian.android@gmail.com"
+git config --global push.default simple
+git status
+git reset --hard origin/master
 npm --no-git-tag-version version patch
+git add package.json
 PACKAGE_VERSION=$(node -p "require('./package.json').version")
+git commit -m "$(printf "Update to version $PACKAGE_VERSION")"
+git push origin master
 npm publish --access public
 git clone git@github.com:guardian/ios-live.git
 cd ios-live

--- a/circle.sh
+++ b/circle.sh
@@ -1,26 +1,10 @@
 #!/bin/bash -xe
 
-git status
-git log -1
-git config --global user.name "GuardianAndroid"
-git config --global user.email "guardian.android@gmail.com"
-git config --global push.default simple
-git status
-git add .
-git status
-git commit -m "Generate files for release"
-git checkout release
-git reset --hard origin/release
-git merge -X theirs master -m "Merge master into release"
-git log -1
-npm --no-git-tag-version version patch 
-git add package.json
+npm --no-git-tag-version version patch
 PACKAGE_VERSION=$(node -p "require('./package.json').version")
-git commit -m "$(printf "Update to version $PACKAGE_VERSION")"
-git push origin release
 npm publish --access public
 git clone git@github.com:guardian/ios-live.git
-cd ios-live    
+cd ios-live
 jq ".dependencies[\"@guardian/mobile-apps-article-templates\"] = \"${PACKAGE_VERSION}\"" package.json > tmp
 mv tmp package.json
 git add package.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/mobile-apps-article-templates",
-  "version": "1.0.0",
+  "version": "1.0.29",
   "description": "Templates for articles on both iOS and Android next-gen apps",
   "main": "ArticleTemplates/",
   "scripts": {


### PR DESCRIPTION
Now that the templates are being published to NPM, there is no need for a release branch.

This change removes commits to the release branch from the CI process.

Automated version bumps to `package.json` will be committed directly to master.