### PR TITLE
Circle CI: cd into correct dir for Android App

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -21,7 +21,7 @@ git commit -m "$(printf "Update to mobile-apps-article-templates version $PACKAG
 git push origin master
 cd ..
 git clone git@github.com:guardian/android-news-app.git
-cd android-news-app
+cd android-news-app/android-news-app
 jq ".dependencies[\"@guardian/mobile-apps-article-templates\"] = \"${PACKAGE_VERSION}\"" package.json > tmp
 mv tmp package.json
 git add package.json


### PR DESCRIPTION
Currently publishing the update to the android-news-app is failing because the `package.json` is in the `android-news-app` subdirectory, not the root directory of the repo.

This change checks for the `package.json` in the correct directory of the android-news-app repo.