### PR TITLE
Fix issue with ad position on Webviews using Chromium 61+

### DIFF
--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -104,8 +104,8 @@ function (
         var advertPosition,
             advertSlots = document.getElementsByClassName('advert-slot__wrapper'),
             i,
-            scrollLeft = document.scrollingElement.scrollLeft,
-            scrollTop = document.scrollingElement.scrollTop,
+            scrollLeft = document.scrollingElement? document.scrollingElement.scrollLeft : document.documentElement.scrollLeft,
+            scrollTop = document.scrollingElement ? document.scrollingElement.scrollTop : document.documentElement.scrollTop,
             params = {
                 x1: -1,
                 y1: -1,

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -104,8 +104,8 @@ function (
         var advertPosition,
             advertSlots = document.getElementsByClassName('advert-slot__wrapper'),
             i,
-            scrollLeft = document.body.scrollLeft,
-            scrollTop = document.body.scrollTop,
+            scrollLeft = document.scrollingElement.scrollLeft,
+            scrollTop = document.scrollingElement.scrollTop,
             params = {
                 x1: -1,
                 y1: -1,


### PR DESCRIPTION
An issues was reported with the Guardian App when it is used with a more recent version of Android WebView (based on Chrome 61).

In Chromium/Chrome (the web rendering engine) the scrolling element in HTML documents has been moved to be the `documentElement` instead of `document.body`. The ad was incorrectly placed in the page because it is using `document.body.scrollTop` to read the current scroll position.

Switching the references to `document.body.scrollTop` to use `document.scrollingElement.scrollTop` fixes the issue. 

The `document.scrollingElement.scrollTop` property acts as an alias for either `document.documentElement` or `document.body`, depending on which one will reflect the full page's scroll offset on its scrollTop property.