### PR TITLE
Fix issue with byline being hidden in paid for articles

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/common.js
+++ b/ArticleTemplates/assets/js/bootstraps/common.js
@@ -583,54 +583,29 @@ define([
     }
 
     function advertorialUpdates() {
-        var tones, tone, type, 
-            parentNodeClass, bylineElems, 
-            elemsToDelete, j;
-
-        tones = {
-            'tone--media': {
-                'video': 'meta__misc',
-                'gallery': 'meta__misc',
-                'audio': 'byline--mobile'
-            },
-            'tone--news': 'meta',
-            'tone--feature1': 'meta',
-            'tone--feature2': 'meta',
-            'tone--feature3': 'meta',
-            'tone--podcast': 'byline--media'
-        };
-
         if (GU.opts.isAdvertising) {
-            for (tone in tones) {
-                if (tones.hasOwnProperty(tone)) {
-                    if (document.body.classList.contains(tone)) {
-                        if (typeof tones[tone] === 'object') {
-                            for (type in tones[tone]) {
-                                if (tones[tone].hasOwnProperty(type)) {
-                                    if (document.body.dataset.contentType && document.body.dataset.contentType === type) {
-                                        parentNodeClass = tones[tone][type];
-                                        break;
-                                    }
-                                }
-                            }
-                        } else {
-                            parentNodeClass = tones[tone];
-                            break;
-                        }
-                    }
-                }
-            }
+            /**
+             * Remove element with class 'meta'
+             * if it's child element with class 'byline' is empty
+             * and it has no children with class 'sponsorship'
+             */
+            var i;
+            var metaContainers = document.getElementsByClassName('meta');
 
-            if (parentNodeClass) {
-                bylineElems = document.getElementsByClassName('byline');
-                if (bylineElems.length && !bylineElems[0].children.length) {
-                    elemsToDelete = document.body.getElementsByClassName(parentNodeClass);
-                    for (j = 0; j < elemsToDelete.length; j++) {
-                        if (elemsToDelete[j].parentNode && !elemsToDelete[j].getElementsByClassName('sponsorship').length) {
-                            elemsToDelete[j].parentNode.removeChild(elemsToDelete[j]);
-                        }
+            for (i = 0; i < metaContainers.length; i++) {
+                var metaContainer = metaContainers[i];
+                var bylineElem = metaContainer.getElementsByClassName('byline')[0];
+
+                if (bylineElem && 
+                    bylineElem.innerHTML === "" &&
+                    !metaContainer.getElementsByClassName('sponsorship').length) {
+                    var metaParent = metaContainer.parentNode;
+
+                    if (metaParent) {
+                        metaParent.removeChild(metaContainer);
                     }
                 }
+
             }
         }
     }


### PR DESCRIPTION
The Meta container was being removed on paid for content in the app even when there was a byline.

This was happening because the logic didn't take into account that  `bylineElems[0].children.length` could be 0 even if there was text content within `bylineElems[0]`. The original logic was written to accommodate bylines wrapped in anchor tags that linked to the author profile, however not all are wrapped in anchor tags.

I've updated the check to `bylineElem.innerHTML === ""` which fixes the issue.

I've also simplified this logic, as the only tone ever present on paid for content is `tone-news` so the a big chunk of the previous logic was totally redundant.

Before...

<img width="257" alt="picture 70" src="https://user-images.githubusercontent.com/1590704/30277862-f58851e6-9700-11e7-923e-02edc4a23d25.png">

After...

<img width="258" alt="picture 69" src="https://user-images.githubusercontent.com/1590704/30277590-34773df0-9700-11e7-9cc2-ed0554bb3bba.png">
