### PR TITLE
Rendering atoms using the library

### DIFF
--- a/ArticleTemplates/articleTemplate.html
+++ b/ArticleTemplates/articleTemplate.html
@@ -21,6 +21,11 @@
     __ARTICLE_CONTAINER__
 
     <script type="text/javascript">
+        var atoms = {};
+        function readAtoms() {
+            __ATOMS_JS__
+        }
+        readAtoms.call(atoms);
         GU.bootstrap.init({
             sectionTone: "__SECTION_TONE__",
             isImmersive: "__IS_IMMERSIVE__" ? true : false,
@@ -41,7 +46,7 @@
             section: "__SECTION__",
             tests: '__TEST_SPEC__',
             nativeYoutubeEnabled: "__NATIVE_YOUTUBE_ENABLED__" === "true" ? true : false,
-            atoms: __ATOMS_JS__
+            atoms: atoms
         });
     </script>
 </body>

--- a/ArticleTemplates/articleTemplate.html
+++ b/ArticleTemplates/articleTemplate.html
@@ -6,6 +6,9 @@
     <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
     <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="__TEMPLATES_DIRECTORY__assets/css/fonts-__PLATFORM__.css" />
     <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/style-sync.css" />
+    <style>/* <-- */
+        __ATOMS_CSS__
+    /* --> */</style>
     <script type="text/javascript">
         window.GU = window.GU || {};
     </script>
@@ -37,7 +40,8 @@
             useAdsReady: "__ADS_FAST_CALLBACK__" === "true" ? true : false,
             section: "__SECTION__",
             tests: '__TEST_SPEC__',
-            nativeYoutubeEnabled: "__NATIVE_YOUTUBE_ENABLED__" === "true" ? true : false
+            nativeYoutubeEnabled: "__NATIVE_YOUTUBE_ENABLED__" === "true" ? true : false,
+            atoms: __ATOMS_JS__
         });
     </script>
 </body>

--- a/ArticleTemplates/articleTemplate.html
+++ b/ArticleTemplates/articleTemplate.html
@@ -21,6 +21,7 @@
     __ARTICLE_CONTAINER__
 
     <script type="text/javascript">
+    (function () {
         var atoms = {};
         function readAtoms() {
             __ATOMS_JS__
@@ -48,6 +49,7 @@
             nativeYoutubeEnabled: "__NATIVE_YOUTUBE_ENABLED__" === "true" ? true : false,
             atoms: atoms
         });
+    }());
     </script>
 </body>
 </html>

--- a/ArticleTemplates/assets/js/article.js
+++ b/ArticleTemplates/assets/js/article.js
@@ -1,15 +1,18 @@
 define([
 	'bootstraps/common',
-    'bootstraps/article'
+    'bootstraps/article',
+    'bootstraps/atoms'
 ], function (
 	common,
-    article
+    article,
+    atoms
 ) {
     'use strict';
     
     function init() {
         common.init();
         article.init();
+        atoms.init();
     }
 
     return {

--- a/ArticleTemplates/assets/js/bootstraps/atoms.js
+++ b/ArticleTemplates/assets/js/bootstraps/atoms.js
@@ -24,6 +24,10 @@ define([
             console.log("ophan called with:");
             console.dir(arguments);
           }
+        },
+        dom: {
+          write: function(f) { f(); },
+          read: function(f)  { f(); }
         }
       });
       var atoms = document.querySelectorAll('.element-atom[data-atom-type="' + atomType + '"]');

--- a/ArticleTemplates/assets/js/bootstraps/atoms.js
+++ b/ArticleTemplates/assets/js/bootstraps/atoms.js
@@ -20,7 +20,7 @@ define([
       for( var i = 0; i < atoms.length; i++ ) {
         var atom = atomBuilder(atoms[i]).runTry();
         if (typeof atom === 'string') {
-          console.log('Failed to initialise atom [' + atomType + '/' + atom.getAttribute('data-atom-id') + ']: ' + atom);
+          console.log('Failed to initialise atom [' + atomType + '/' + atoms[i].getAttribute('data-atom-id') + ']: ' + atom);
         } else {
           atom.start();
         }

--- a/ArticleTemplates/assets/js/bootstraps/atoms.js
+++ b/ArticleTemplates/assets/js/bootstraps/atoms.js
@@ -26,7 +26,7 @@ define([
           }
         }
       });
-      var atoms = document.querySelectorAll('[data-atom-type="' + atomType + '"]');
+      var atoms = document.querySelectorAll('.element-atom[data-atom-type="' + atomType + '"]');
       for( var i = 0; i < atoms.length; i++ ) {
         var atom = atomBuilder(atoms[i]).runTry();
         atom.start();

--- a/ArticleTemplates/assets/js/bootstraps/atoms.js
+++ b/ArticleTemplates/assets/js/bootstraps/atoms.js
@@ -19,7 +19,11 @@ define([
       var atoms = document.querySelectorAll('.element-atom[data-atom-type="' + atomType + '"]');
       for( var i = 0; i < atoms.length; i++ ) {
         var atom = atomBuilder(atoms[i]).runTry();
-        atom.start();
+        if (typeof atom === 'string') {
+          console.log('Failed to initialise atom [' + atomType + '/' + atom.getAttribute('data-atom-id') + ']: ' + atom);
+        } else {
+          atom.start();
+        }
       }
     }
 

--- a/ArticleTemplates/assets/js/bootstraps/atoms.js
+++ b/ArticleTemplates/assets/js/bootstraps/atoms.js
@@ -1,0 +1,39 @@
+define([
+], function (
+) {
+    'use strict';
+
+    function init() {
+      var atomTypes = GU.opts.atoms;
+      Object.keys(atomTypes).forEach(function (t) {
+        bootAtomType(t, atomTypes[t]);
+      });
+    }
+
+    function bootAtomType(atomType, atomFactory) {
+      // Need to pass in the API to native services, something that looks
+      // like this: 
+      // {
+      //    ophan:    { record: function(obj) { ... } },
+      //    identity: { ... },
+      //    ...
+      // }
+      var atomBuilder = atomFactory.default({
+        ophan: {
+          record: function() {
+            console.log("ophan called with:");
+            console.dir(arguments);
+          }
+        }
+      });
+      var atoms = document.querySelectorAll('[data-atom-type="' + atomType + '"]');
+      for( var i = 0; i < atoms.length; i++ ) {
+        var atom = atomBuilder(atoms[i]).runTry();
+        atom.start();
+      }
+    }
+
+    return {
+      init: init
+    };
+});

--- a/ArticleTemplates/assets/js/bootstraps/atoms.js
+++ b/ArticleTemplates/assets/js/bootstraps/atoms.js
@@ -1,35 +1,21 @@
 define([
+  'modules/atoms/services'
 ], function (
+  services
 ) {
     'use strict';
 
     function init() {
       var atomTypes = GU.opts.atoms;
       Object.keys(atomTypes).forEach(function (t) {
+        var f = atomTypes[t];
+        if( typeof f.default !== 'function' || f.default.length !== 1 ) return;
         bootAtomType(t, atomTypes[t]);
       });
     }
 
     function bootAtomType(atomType, atomFactory) {
-      // Need to pass in the API to native services, something that looks
-      // like this: 
-      // {
-      //    ophan:    { record: function(obj) { ... } },
-      //    identity: { ... },
-      //    ...
-      // }
-      var atomBuilder = atomFactory.default({
-        ophan: {
-          record: function() {
-            console.log("ophan called with:");
-            console.dir(arguments);
-          }
-        },
-        dom: {
-          write: function(f) { f(); },
-          read: function(f)  { f(); }
-        }
-      });
+      var atomBuilder = atomFactory.default(services);
       var atoms = document.querySelectorAll('.element-atom[data-atom-type="' + atomType + '"]');
       for( var i = 0; i < atoms.length; i++ ) {
         var atom = atomBuilder(atoms[i]).runTry();

--- a/ArticleTemplates/assets/js/bootstraps/common.js
+++ b/ArticleTemplates/assets/js/bootstraps/common.js
@@ -33,7 +33,6 @@ define([
         comments.init(); // load comments
         cards.init(); // load cards
         loadEmbeds();
-        // smoothScroll.init(); // scroll to anchor
         loadInteractives(); 
         setupOfflineSwitch();
         setupAlertSwitch();
@@ -47,6 +46,10 @@ define([
         setupTracking(); // track common events
         ab.init(); // init ab tests
 
+        if (smoothScroll !== undefined && typeof smoothScroll.init === 'function') {
+            smoothScroll.init(); // scroll to anchor
+        }
+        
         if (!document.body.classList.contains('no-ready')) {
             util.signalDevice('ready');
         }

--- a/ArticleTemplates/assets/js/bootstraps/common.js
+++ b/ArticleTemplates/assets/js/bootstraps/common.js
@@ -33,7 +33,7 @@ define([
         comments.init(); // load comments
         cards.init(); // load cards
         loadEmbeds();
-        smoothScroll.init(); // scroll to anchor
+        // smoothScroll.init(); // scroll to anchor
         loadInteractives(); 
         setupOfflineSwitch();
         setupAlertSwitch();

--- a/ArticleTemplates/assets/js/modules/atoms/services.js
+++ b/ArticleTemplates/assets/js/modules/atoms/services.js
@@ -16,6 +16,19 @@ define(function () {
     dom: {
       write: function(f) { f(); },
       read: function(f)  { f(); }
+    },
+    viewport: {
+      observe: function(element, threshold, callback) {
+        var observer = new IntersectionObserver(function(entries) {
+          entries.forEach(function(entry) {
+            callback(entry.intersectionRatio);
+          });
+        }, { threshold: threshold });
+        observer.observe(element);
+      },
+      unobserve: function() { 
+        console.log("Unobserving element...");
+      }
     }
   };
 })

--- a/ArticleTemplates/assets/js/modules/atoms/services.js
+++ b/ArticleTemplates/assets/js/modules/atoms/services.js
@@ -1,4 +1,8 @@
-define(function () {
+define([
+  'modules/services/viewport'
+], function (
+  viewport
+) {
   // Need to pass in the API to native services, something that looks
   // like this: 
   // {
@@ -17,18 +21,6 @@ define(function () {
       write: function(f) { f(); },
       read: function(f)  { f(); }
     },
-    viewport: {
-      observe: function(element, threshold, callback) {
-        var observer = new IntersectionObserver(function(entries) {
-          entries.forEach(function(entry) {
-            callback(entry.intersectionRatio);
-          });
-        }, { threshold: threshold });
-        observer.observe(element);
-      },
-      unobserve: function() { 
-        console.log("Unobserving element...");
-      }
-    }
+    viewport: viewport
   };
 })

--- a/ArticleTemplates/assets/js/modules/atoms/services.js
+++ b/ArticleTemplates/assets/js/modules/atoms/services.js
@@ -1,0 +1,21 @@
+define(function () {
+  // Need to pass in the API to native services, something that looks
+  // like this: 
+  // {
+  //    ophan:    { record: function(obj) { ... } },
+  //    identity: { ... },
+  //    ...
+  // }
+  return {
+    ophan: {
+      record: function() {
+        console.log("ophan called with:");
+        console.dir(arguments);
+      }
+    },
+    dom: {
+      write: function(f) { f(); },
+      read: function(f)  { f(); }
+    }
+  };
+})

--- a/ArticleTemplates/assets/js/modules/services/impl/viewport-io.js
+++ b/ArticleTemplates/assets/js/modules/services/impl/viewport-io.js
@@ -1,0 +1,42 @@
+define(function() {
+  var observers = Object.create(null);
+  var callbacks = Object.create(null);
+
+  function observe(element, threshold, callback) {
+    if (!observers[threshold]) {
+      callbacks[threshold] = [callback];
+      observers[threshold] = new IntersectionObserver(function(entries) {
+        entries.forEach(function(entry) {
+          if (entry.isIntersecting) {
+            callbacks[threshold].forEach(function (c) {
+              c(entry.intersectionRatio);
+            });
+          }
+        });
+      }, { threshold: threshold });
+    } else {
+      callbacks[threshold].push(callback);
+    }
+    observers[threshold].observe(element);
+  }
+
+  function unobserve(element, threshold, callback) {
+    if (!observers[threshold]) return;
+
+    observers[threshold].unobserve(element);
+    
+    var idx = callbacks[threshold].indexOf(callback);
+    if (idx !== -1) {
+      callbacks[threshold].splice(idx, 1);
+    }
+
+    if (callbacks[threshold].length === 0) {
+      observers[threshold] = null;
+    }
+  }
+  
+  return {
+    observe: observe,
+    unobserve: unobserve
+  };
+});

--- a/ArticleTemplates/assets/js/modules/services/impl/viewport-scroll.js
+++ b/ArticleTemplates/assets/js/modules/services/impl/viewport-scroll.js
@@ -6,6 +6,7 @@ define(function() {
   function observe(element, threshold, callback) {
     if (!listening) {
       window.addEventListener('scroll', onScroll);
+      listening = true;
     }
 
     elements[threshold] || (elements[threshold] = []);
@@ -25,6 +26,7 @@ define(function() {
 
     if (elementCount === 0) {
       window.removeEventListener('scroll', onScroll);
+      listening = false;
     }
   }
 
@@ -41,8 +43,9 @@ define(function() {
           ? 0
           : rect.top >= viewportHeight
           ? 0
-          : (Math.max(viewportHeight, rect.bottom) - Math.min(0, rect.top)) * (rect.right - rect.left);
-        if (isNotHidden && visibleArea >= threshold) {
+          : (Math.min(viewportHeight, rect.bottom) - Math.max(0, rect.top)) * (rect.right - rect.left);
+        var intersectionRatio = visibleArea / area;
+        if (isNotHidden && intersectionRatio >= threshold) {
           setTimeout(record.callback, 0, visibleArea);
         }
       });

--- a/ArticleTemplates/assets/js/modules/services/impl/viewport-scroll.js
+++ b/ArticleTemplates/assets/js/modules/services/impl/viewport-scroll.js
@@ -1,0 +1,56 @@
+define(function() {
+  var listening = false;
+  var elements = Object.create(null);
+  var elementCount = 0;
+
+  function observe(element, threshold, callback) {
+    if (!listening) {
+      window.addEventListener('scroll', onScroll);
+    }
+
+    elements[threshold] || (elements[threshold] = []);
+    elements[threshold].push({ element: element, callback: callback });
+    elementCount += 1;
+  }
+
+  function unobserve(element, threshold, callback) {
+    if (!elements[threshold]) return;
+
+    var lengthBefore = elements[threshold].length;
+    elements[threshold] = elements[threshold].filter(function (record) {
+      return record.element !== element && record.callback !== callback;
+    });
+    
+    elementCount -= lengthBefore - elements.length;
+
+    if (elementCount === 0) {
+      window.removeEventListener('scroll', onScroll);
+    }
+  }
+
+  function onScroll() {
+    var viewportHeight = window.innerHeight;
+
+    Object.keys(elements).forEach(function (threshold) {
+      var visibleElements = elements[threshold].forEach(function (record) {
+        var rect = record.element.getBoundingClientRect();
+        var isNotHidden =
+            rect.top + rect.left + rect.right + rect.bottom !== 0;
+        var area = (rect.bottom - rect.top) * (rect.right - rect.left);
+        var visibleArea = rect.bottom <= 0
+          ? 0
+          : rect.top >= viewportHeight
+          ? 0
+          : (Math.max(viewportHeight, rect.bottom) - Math.min(0, rect.top)) * (rect.right - rect.left);
+        if (isNotHidden && visibleArea >= threshold) {
+          setTimeout(record.callback, 0, visibleArea);
+        }
+      });
+    });
+  }
+  
+  return {
+    observe: observe,
+    unobserve: unobserve
+  };
+});

--- a/ArticleTemplates/assets/js/modules/services/viewport.js
+++ b/ArticleTemplates/assets/js/modules/services/viewport.js
@@ -1,0 +1,8 @@
+define([
+  'modules/services/impl/viewport-io',
+  'modules/services/impl/viewport-scroll'
+], function (viewportIO, viewportScroll) {
+  return 'IntersectionObserver' in window 
+    ? viewportIO
+    : viewportScroll;
+});


### PR DESCRIPTION
This is to insert the CSS and JS necessary for atoms to run properly. CSS is straightforward. For JS, it is trickier. We need a reference to the generated JS, as each atom will expose a factory module. To avoid polluting the global scope, atoms will be assigned to the `this` object (each JS bundle will be of the form `this.<atom type> = <expression returning a module>`), which we can define by wrapping the generated code inside a function and call that function using `Function.prototype.call`, passing an object to serve as a repository.

TODO:
- [x] kick-off atoms in `GU.bootstrap.init`
- [x] safety-check the shape of the atom factory and its result
- [x] provide interface to native implementation of services (ophan, identity, etc.)