### PR TITLE
Use imported module 'util' instead of 'GU.util'

### DIFF
--- a/ArticleTemplates/assets/js/modules/youtube.js
+++ b/ArticleTemplates/assets/js/modules/youtube.js
@@ -122,7 +122,7 @@ define([
         var newSdkReport = buildSdkReport();
 
         if (newSdkReport !== sdkReport) {
-            GU.util.signalDevice('youtubeAtomPosition/' + newSdkReport);
+            util.signalDevice('youtubeAtomPosition/' + newSdkReport);
             sdkReport = newSdkReport;
         }
     }
@@ -132,7 +132,7 @@ define([
     }
 
     function getSdkReportPosProps(sdkPlaceholder) {
-        var posProps = GU.util.getElementOffset(sdkPlaceholder);
+        var posProps = util.getElementOffset(sdkPlaceholder);
         var atom = sdkPlaceholder.closest('[data-atom-id]');
 
         posProps.id = atom.dataset.atomId;


### PR DESCRIPTION
The youtube.js module imports a dependency `util.js`, all utility calls should call methods on this import, rather than using the previous `GU.util` object on the window.