### PR TITLE
Update app FAQs

### DIFF
--- a/ArticleTemplates/simpleBodyTemplatePrepopHelp.html
+++ b/ArticleTemplates/simpleBodyTemplatePrepopHelp.html
@@ -38,11 +38,9 @@
             <h2>Subscriptions</h2>
             <ul>
                 <li><a href="#subs-01" data-scroll>What do I get with a premium tier subscription?</a></li>
-                <li><a href="#subs-02" data-scroll>How much does a subscription cost?</a></li>
-                <li><a href="#subs-03" data-scroll>I had an old subscription, will this still work?</a></li>
-                <li><a href="#subs-04" data-scroll>How do I cancel my subscription?</a></li>
-                <li><a href="#subs-05" data-scroll>Can I use my subscription on more than one device?</a></li>
-                <li><a href="#subs-06" data-scroll>I have a print+ Digital, or Guardian subscription. Can I use it to get access to the premium tier?</a></li>
+                <li><a href="#subs-02" data-scroll>How do I cancel my subscription?</a></li>
+                <li><a href="#subs-03" data-scroll>Can I use my subscription on more than one device?</a></li>
+                <li><a href="#subs-04" data-scroll>I have a print+ Digital, or Guardian subscription. Can I use it to get access to the premium tier?</a></li>
             </ul>
 
             <h2>Offline reading and data</h2>
@@ -88,7 +86,7 @@
             </ul>
 
             <h3 id="personal-05">How can I manage or stop the notifications I receive?</h3>
-            <p>You can manage your alerts&nbsp;from the settings area. Here, you can choose the alerts you no longer wish to receive or unsubscribe from all of them.</p>
+            <p>You can manage your notifications&nbsp;from the settings area. Here, you can choose the notifications you no longer wish to receive or unsubscribe from all of them.</p>
 
             <h3 id="personal-06">How can I change the font-size of articles?</h3>
             <p>In any article, tap on the font-size icon and then the larger or smaller buttons. This will change the size of the text in the main portion or the article. Your choice will be remembered for every article you then visit.</p>
@@ -106,20 +104,14 @@
             </ul>
             <p>Subscriptions are fulfilled by Apple. You do not pay the Guardian directly. We cannot directly offer refunds. They need to be requested via Apple.</p>
 
-            <h3 id="subs-02">How much does a subscription cost?</h3>
-            <p>A premium tier subscription costs &pound;2.49&nbsp;($3.99) a month for new subscribers. Because of exchange rates, the exact amount a subscription costs varies from country to country.</p>
-
-            <h3 id="subs-03">I had an old subscription, will this still work?</h3>
-            <p>If you bought an auto-renewing subscription in the app before June 2014 this will continue to work, and at your original price too.</p>
-
-            <h3 id="subs-04">How do I cancel my subscription?</h3>
+            <h3 id="subs-02">How do I cancel my subscription?</h3>
             <p>You can cancel your subscription via the settings menu on your iPhone or iPad. </p>
             <p>Open settings, then select iTunes &amp; App Store. Tap on your Apple ID, then &lsquo;View Apple ID&rsquo;. Sign in, then select &lsquo;Manage&rsquo; under &lsquo;Subscriptions&rsquo;.</p>
 
-            <h3 id="subs-05">Can I use my subscription on more than one device?</h3>
+            <h3 id="subs-03">Can I use my subscription on more than one device?</h3>
             <p>Yes. Your subscription should work on each iPhone, iPod Touch, or iPad&nbsp;you&rsquo;ve signed-in on using &nbsp;your Apple ID. </p>
 
-            <h3 id="subs-06">I have a print+ Digital, or Guardian subscription. Can I use it to get access to the premium tier?</h3>
+            <h3 id="subs-04">I have a print+ Digital, or Guardian subscription. Can I use it to get access to the premium tier?</h3>
             <p>Yes. Simply open the settings menu, select &lsquo;Subscription&rsquo;, then tap on &lsquo;I am a Guardian subscriber&rsquo;.</p>
 
             <hr />

--- a/ArticleTemplates/simpleBodyTemplatePrepopHelp.html
+++ b/ArticleTemplates/simpleBodyTemplatePrepopHelp.html
@@ -40,7 +40,7 @@
                 <li><a href="#subs-01" data-scroll>What do I get with a premium tier subscription?</a></li>
                 <li><a href="#subs-02" data-scroll>How do I cancel my subscription?</a></li>
                 <li><a href="#subs-03" data-scroll>Can I use my subscription on more than one device?</a></li>
-                <li><a href="#subs-04" data-scroll>I have a print+ Digital, or Guardian subscription. Can I use it to get access to the premium tier?</a></li>
+                <li><a href="#subs-04" data-scroll>I have a digital or paper+digital subscription. Can I use it to get access to the premium tier?</a></li>
             </ul>
 
             <h2>Offline reading and data</h2>
@@ -111,8 +111,8 @@
             <h3 id="subs-03">Can I use my subscription on more than one device?</h3>
             <p>Yes. Your subscription should work on each iPhone, iPod Touch, or iPad&nbsp;you&rsquo;ve signed-in on using &nbsp;your Apple ID. </p>
 
-            <h3 id="subs-04">I have a print+ Digital, or Guardian subscription. Can I use it to get access to the premium tier?</h3>
-            <p>Yes. Simply open the settings menu, select &lsquo;Subscription&rsquo;, then tap on &lsquo;I am a Guardian subscriber&rsquo;.</p>
+            <h3 id="subs-04">I have a digital or paper+digital subscription. Can I use it to get access to the premium tier?</h3>
+            <p>Yes. Simply open the settings menu, then select &lsquo;I'm a Guardian Subscriber&rsquo;.</p>
 
             <hr />
 


### PR DESCRIPTION
As per https://theguardian.atlassian.net/browse/GLA-275, I've removed all references to the price from the FAQs. I've also taken the opportunity to rename 'alerts' to 'notifications' (which we changed a while ago in the app).