### PR TITLE
Fix: Account for multiple elements on the same threshold

### DIFF
--- a/ArticleTemplates/assets/js/modules/services/impl/viewport-io.js
+++ b/ArticleTemplates/assets/js/modules/services/impl/viewport-io.js
@@ -1,21 +1,26 @@
 define(function() {
   var observers = Object.create(null);
   var callbacks = Object.create(null);
+  var elements = Object.create(null);
 
   function observe(element, threshold, callback) {
     if (!observers[threshold]) {
       callbacks[threshold] = [callback];
+      elements[threshold] = [element];
       observers[threshold] = new IntersectionObserver(function(entries) {
         entries.forEach(function(entry) {
           if (entry.isIntersecting) {
-            callbacks[threshold].forEach(function (c) {
-              c(entry.intersectionRatio);
+            callbacks[threshold].forEach(function (c, index) {
+              if (elements[threshold][index] === entry.target) {
+                c(entry.intersectionRatio);
+              }
             });
           }
         });
       }, { threshold: threshold });
     } else {
       callbacks[threshold].push(callback);
+      elements[threshold].push(element);
     }
     observers[threshold].observe(element);
   }
@@ -28,6 +33,7 @@ define(function() {
     var idx = callbacks[threshold].indexOf(callback);
     if (idx !== -1) {
       callbacks[threshold].splice(idx, 1);
+      elements[threshold].splice(idx, 1);
     }
 
     if (callbacks[threshold].length === 0) {


### PR DESCRIPTION
Whenever multiple snippets are in the page and each registers a viewport observer at the same threshold, they may all fire when the first element crosses its threshold. This fix makes sure only the callbacks corresponding to the element targeted by the intersection are called.