### PR TITLE
Encode JSON as a URI component

### DIFF
--- a/ArticleTemplates/assets/js/modules/atoms/services.js
+++ b/ArticleTemplates/assets/js/modules/atoms/services.js
@@ -71,7 +71,7 @@ define([
         if (window.GuardianJSInterface && window.GuardianJSInterface.trackComponentEvent) {
             window.GuardianJSInterface.trackComponentEvent(newObj);
         } else {
-            util.signalDevice('trackComponentEvent/' + JSON.stringify(newObj));
+            util.signalDevice('trackComponentEvent/' + encodeURIComponent(JSON.stringify(newObj)));
         }
       }
     },


### PR DESCRIPTION
Makes sure special characters such as `?` are properly encoded before inserting into the DOM.