### PR TITLE
define style for inverting already inverted images

### DIFF
--- a/ArticleTemplates/assets/scss/style-sync.scss
+++ b/ArticleTemplates/assets/scss/style-sync.scss
@@ -68,3 +68,4 @@
 
 // Special Immersive styles (import last to override tones)
 @import 'layout/article--immersive';
+@import 'inverted-colors.scss';

--- a/inverted-colors.scss
+++ b/inverted-colors.scss
@@ -1,0 +1,5 @@
+@media (inverted-colors) {  
+  img {  
+  filter: #{"invert()"} 
+  }  
+}


### PR DESCRIPTION
Uses Media Query to detect if colours are inverted on iOS. Then inverts the colour of the already inverted image. This is used to make images not inverted when the 'invert' accessibility setting is switched on in iOS.

@GHaberis 

Before:
![2](https://user-images.githubusercontent.com/1769276/33376904-6b6085b6-d507-11e7-9ad1-2328ada9fc45.jpg)

After:
![1](https://user-images.githubusercontent.com/1769276/33376911-6fd33012-d507-11e7-80d2-e602babd1c94.jpg)

