### PR TITLE
Fix unduly harsh quiz result messages

### DIFF
--- a/ArticleTemplates/assets/js/modules/quiz.js
+++ b/ArticleTemplates/assets/js/modules/quiz.js
@@ -458,7 +458,7 @@ define([
         var i,
             scoreDisplayMessage = '';
 
-        for (i = 0; i < score; i++) {
+        for (i = 0; i <= score; i++) {
             if (scoreMessages[i]) {
                 scoreDisplayMessage = scoreMessages[i];
             }


### PR DESCRIPTION
The mobile apps have been showing users the quiz result message that corresponds to `score`**`- 1`**. For instance, on this quiz:

* https://www.theguardian.com/uk/quiz/2013/jan/27/british-citizenship-test-quiz-new

...if you complete the quiz with a score of 8 out of 10 correct answers, you get the right score displayed (_"You scored: 8/10"_), but the message shown is the message for 7/10, which includes the phrase _"...on this 10-question test you've come in at **70%**..."_ and exposes the problem:

![screenshot](https://user-images.githubusercontent.com/52038/33402242-dd50fdb2-d553-11e7-8631-37e2dd08a3ba.png)

We've had this off-by-one error since the functionality to show the result text was initially added with 102c32bfc, and [a few other users spotted it](https://twitter.com/Open_Book/status/775340704637788160), but obviously it only affects quizzes displaying on the mobile apps (iOS and Android), not the website, tho' that did have https://github.com/guardian/frontend/pull/15276 last year :)

Thanks to avid Guardian reader Michael Goldrei for reporting this issue with a good screenshot and url!