### PR TITLE
Show and hide elements for new templates

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-modules/_hide-garnett.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/_hide-garnett.scss
@@ -1,0 +1,3 @@
+.hide-garnett {
+    display: none;
+}

--- a/ArticleTemplates/assets/scss/garnett-style-sync.scss
+++ b/ArticleTemplates/assets/scss/garnett-style-sync.scss
@@ -38,6 +38,7 @@
 @import 'modules/media/audio-player';
 @import 'modules/media/gallery';
 @import 'modules/witness/contribute';
+@import 'garnett-modules/hide-garnett';
 
 // Layout
 @import 'layout/article';

--- a/ArticleTemplates/assets/scss/modules/_show-garnett.scss
+++ b/ArticleTemplates/assets/scss/modules/_show-garnett.scss
@@ -1,0 +1,3 @@
+.show-garnett {
+    display: none;
+}

--- a/ArticleTemplates/assets/scss/style-sync.scss
+++ b/ArticleTemplates/assets/scss/style-sync.scss
@@ -38,6 +38,7 @@
 @import 'modules/media/audio-player';
 @import 'modules/media/gallery';
 @import 'modules/witness/contribute';
+@import 'modules/show-garnett';
 
 // Layout
 @import 'layout/article';


### PR DESCRIPTION
Garnett set-up CSS to show/hide HTML blocks without affecting the current templates.

Anything with the class `show-garnett` will show up on garnett, but be hidden with `display: none` on the current templates. Conversely, anything with the class `show-garnett` will show only on garnett, and not on the currently active templates.