### PR TITLE
Layout fixes

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
+++ b/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
@@ -109,7 +109,7 @@ $meta-lead: 2.2rem;
 
 
 // Link Underline Style
-@mixin text-underline($color, $background, $color-accent) {
+@mixin text-underline($color, $color-accent) {
     a {
         color: $color;
         text-decoration: none;
@@ -126,25 +126,10 @@ $meta-lead: 2.2rem;
             background-position: 0 93%;
         }
 
-        // Clear descendors from underline
-        text-shadow: 3px 0 $background, 2px 0 $background, 1px 0 $background, -1px 0 $background, -2px 0 $background, -3px 0 $background;
-
         a:active,
         &:hover {
             color: $color-accent;
             background-image: linear-gradient(to bottom, darken($color-accent, 6%) 0%, darken($color-accent, 6%) 100%);
-        }
-
-        // Style selected links (or else text-shadow makes it look crazy ugly)
-        // Pseudo selectors must go separately, or they break each other
-        &,
-        > * {
-            &::selection {
-                text-shadow: none;
-            }
-            &::-moz-selection {
-                text-shadow: none;
-            }
         }
     }
 }

--- a/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
+++ b/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
@@ -114,13 +114,22 @@ $meta-lead: 2.2rem;
         color: $color;
         text-decoration: none;
 
-        padding-bottom: 1px;
-        border-bottom: 1px solid rgba($color, .3);
+        // Underline via gradient background
+        background-image: linear-gradient(rgba($color, .25) 0%, $color 100%);
+        background-repeat: repeat-x;
+        background-size: 1px 1px;
+        background-position: 0 bottom;
+
+        // Tweak position + thickness for high res (1.75x and up) displays
+        @media (-webkit-min-device-pixel-ratio: 1.75), (min-resolution: 168dpi) {
+            background-image: linear-gradient(rgba($color, .25) 0%, $color 100%);
+            background-position: 0 93%;
+        }
 
         a:active,
         &:hover {
             color: $color-accent;
-            border-bottom: 1px solid rgba($color-accent, .4);
+            background-image: linear-gradient(to bottom, darken($color-accent, 6%) 0%, darken($color-accent, 6%) 100%);
         }
     }
 }

--- a/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
+++ b/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
@@ -141,7 +141,7 @@ $meta-lead: 2.2rem;
     &:before {
         content: '';
         background-color: $color;
-        margin-right: $right-space;
+        margin-right: $right-space*2;
         width: 1.2rem; // 12px
         height: 1.2rem; // 12px
         border-radius: .6rem; // 6px

--- a/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
+++ b/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
@@ -114,22 +114,13 @@ $meta-lead: 2.2rem;
         color: $color;
         text-decoration: none;
 
-        // Underline via gradient background
-        background-image: linear-gradient(rgba($color, .25) 0%, $color 100%);
-        background-repeat: repeat-x;
-        background-size: 1px 1px;
-        background-position: 0 bottom;
-
-        // Tweak position + thickness for high res (1.75x and up) displays
-        @media (-webkit-min-device-pixel-ratio: 1.75), (min-resolution: 168dpi) {
-            background-image: linear-gradient(rgba($color, .25) 0%, $color 100%);
-            background-position: 0 93%;
-        }
+        padding-bottom: 1px;
+        border-bottom: 1px solid rgba($color, .3);
 
         a:active,
         &:hover {
             color: $color-accent;
-            background-image: linear-gradient(to bottom, darken($color-accent, 6%) 0%, darken($color-accent, 6%) 100%);
+            border-bottom: 1px solid rgba($color-accent, .4);
         }
     }
 }

--- a/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
+++ b/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
@@ -113,7 +113,7 @@ $meta-lead: 2.2rem;
     a {
         color: $color;
         text-decoration: none;
-        padding-bottom: 0.2em;
+        padding-bottom: .2em;
 
         // Underline via gradient background
         background-image: linear-gradient(rgba($color-accent, .25) 0%, $color-accent 100%);
@@ -179,7 +179,7 @@ $meta-lead: 2.2rem;
         font-style: normal;
         font-size: 7em;
         line-height: 1;
-        margin-top: 0px;
+        margin-top: -11px;
         margin-bottom: base-px(-1.6);
         padding-right: base-px(.5);
         float: left;
@@ -190,7 +190,7 @@ $meta-lead: 2.2rem;
 
         @include mq($from: col4) {
             font-size: 7.3em;
-            margin-top: -4px;
+            margin-top: -16px;
         }
     }
 }

--- a/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
+++ b/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
@@ -113,16 +113,17 @@ $meta-lead: 2.2rem;
     a {
         color: $color;
         text-decoration: none;
+        padding-bottom: 0.2em;
 
         // Underline via gradient background
-        background-image: linear-gradient(rgba($color, .25) 0%, $color 100%);
+        background-image: linear-gradient(rgba($color-accent, .25) 0%, $color-accent 100%);
         background-repeat: repeat-x;
         background-size: 1px 1px;
         background-position: 0 bottom;
 
         // Tweak position + thickness for high res (1.75x and up) displays
         @media (-webkit-min-device-pixel-ratio: 1.75), (min-resolution: 168dpi) {
-            background-image: linear-gradient(rgba($color, .25) 0%, $color 100%);
+            background-image: linear-gradient(rgba($color-accent, .25) 0%, $color-accent 100%);
             background-position: 0 93%;
         }
 

--- a/ArticleTemplates/assets/scss/garnett-layout/_article--audio.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_article--audio.scss
@@ -14,10 +14,6 @@
             position: relative;
             z-index: 1; // this is so it sits over the canvas background element;
             padding-right: 0;
-            padding-bottom: base-px(7); // To avoid clashing with meta bar
-            @include mq($from:col2) {
-                padding-bottom: 0;
-            }
         }
 
         .headline {
@@ -29,13 +25,6 @@
         .meta {
             margin-bottom: 1px; // Prevents header showing 1px scroll weirdness
             border-bottom: 0;
-            position: absolute;
-            right: 0;
-            bottom: 0;
-            left: 0;
-            @include mq($from:col2) {
-                position: static;
-            }
         }
     }
 

--- a/ArticleTemplates/assets/scss/garnett-layout/_article--audio.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_article--audio.scss
@@ -1,0 +1,70 @@
+.article--audio {
+    .article__header {
+        position: relative;
+
+        .cutout__background {
+            position: absolute;
+            top: 0;
+            left: 50%;
+            -webkit-transform: translateX(-50%);
+            transform: translateX(-50%);
+        }
+
+        .cutout__container {
+            position: relative;
+            z-index: 1; // this is so it sits over the canvas background element;
+            padding-right: 0;
+            padding-bottom: base-px(7); // To avoid clashing with meta bar
+            @include mq($from:col2) {
+                padding-bottom: 0;
+            }
+        }
+
+        .headline {
+            @include mq($from: col2) {
+                padding-right: cols($base-3, 3, 1);
+            }
+        }
+
+        .meta {
+            margin-bottom: 1px; // Prevents header showing 1px scroll weirdness
+            border-bottom: 0;
+            position: absolute;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            @include mq($from:col2) {
+                position: static;
+            }
+        }
+    }
+
+    .content__labels:first-child::before {
+        content: '\e047';
+        font-family: $icon;
+        padding-right: base-px(.5);
+    }
+
+    .byline {
+        &--tablet {
+            @include mq($to: col2) {
+                display: none;
+            }
+        }
+        &--mobile {
+            border-bottom: 1px rgba(color(shade-3), .4) dotted;
+            padding: base-px(1);
+            display: block;
+
+            @include mq($from: col2) {
+                display: none;
+            }
+        }
+    }
+
+    .article__body {
+        .standfirst {
+            padding: base-px(0, 0, 1.5, 0);
+        }
+    }
+}

--- a/ArticleTemplates/assets/scss/garnett-layout/_article--comment.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_article--comment.scss
@@ -9,8 +9,12 @@
         }
 
         .headline__byline {
+            display: block;
             font-style: italic;
             font-weight: 100;
+            .byline__author {
+                display: inline;
+            }
         }
         .byline__author {
             display: inline-block;

--- a/ArticleTemplates/assets/scss/garnett-layout/_article--immersive.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_article--immersive.scss
@@ -324,7 +324,7 @@
     .prose {
         p,
         li {
-            @include text-underline(color(tone-feature1), color(shade-7), color(tone-feature1-accent));
+            @include text-underline(color(tone-feature1), color(tone-feature1-accent));
         }
 
         h2:not(.section__rule):not(.title--image) {

--- a/ArticleTemplates/assets/scss/garnett-layout/_article--sponsorship.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_article--sponsorship.scss
@@ -1,0 +1,488 @@
+/* Supported: tone--news, tone--feature1, tone--feature2, tone--feature3, tone--media, tone--podcast */
+
+@mixin sponsorship {
+    padding: 0;
+    display: block;
+    position: relative;
+    border-bottom: 1px rgba(color(global-adv-bands), .4) dotted;
+    font-size: 1.6rem;
+
+    .sponsorship__inner {
+        padding: 12px 0;
+        position: relative;
+
+        @include mq($from: col4) {
+            margin-left: 240px;
+            margin-right: 320px
+        }
+    }
+
+    .sponsorship__formatted-sponsor-name {
+        padding: 0 0 0 12px;
+        display: inline-block;
+        vertical-align: middle;
+    }
+
+    .sponsorship__logo {
+        display: inline-block;
+        vertical-align: middle;
+    }
+
+    @include mq($from: col4) {
+        padding: {
+            left: 0;
+        }
+    }
+}
+
+.is_advertising {
+    background-color: color(global-adv-bg);
+
+    @include mq($from: col4) {
+        background-color: color(shade-11);
+    }
+
+    /* Common */
+    &.tone--news,
+    &.tone--feature1,
+    &.tone--feature2,
+    &.tone--feature3,
+    &.tone--media,
+    &.tone--podcast {
+        .section,
+        .section__container .content__series-label,
+        .headline,
+        .standfirst,
+        .byline,
+        .article__body,
+        .article__body > .prose > p:first-of-type::first-letter,
+        .element-rich-link a::before,
+        .element-rich-link a,
+        .prose h2,
+        .article--liveblog .article__header .section {
+            font-family: $guardian-sans;
+        }
+
+        .article {
+            .sponsorship.sponsored {
+                display: none !important;
+            }
+
+            .sponsorship.paid {
+                @include sponsorship;
+            }
+
+            .article {
+                &__header {
+                    .alerts,
+                    .meta__pubdate,
+                    .section__container {
+                        display: none;
+                    }
+
+                    .headline,
+                    .standfirst,
+                    .standfirst__inner,
+                    .sponsorship,
+                    .meta,
+                    .content__labels {
+                        color: color(global-adv-text);
+                    }
+
+                    .main-media,
+                    .headline,
+                    .standfirst,
+                    .standfirst__inner,
+                    .sponsorship,
+                    .meta,
+                    .content__labels,
+                    .main-media figcaption {
+                        background-color: color(global-adv-bg);
+                    }
+
+                    .headline {
+                        padding-bottom: 18px;
+                    }
+
+                    .meta__misc,
+                    .standfirst__inner {
+                        padding-bottom: 12px;
+                    }
+
+                    a,
+                    .byline {
+                        color: color(global-adv-shade-1) !important;
+                    }
+
+                    .standfirst a {
+                        text-decoration: none;
+                    }
+
+                    ul > li::before,
+                    .bullet::before {
+                        background-color: color(global-adv-bands);
+                    }
+
+                    ul > li,
+                    ul > li strong {
+                        color: color(shade-1);
+                    }
+
+                    ul > li strong {
+                        font-weight: bold;
+                    }
+                }
+
+                &__body {
+                    color: color(global-adv-text);
+                    background-color: color(global-adv-bg);
+
+                    .prose p,
+                    .prose li {
+                        @include text-underline(color(global-adv-shade-1), lighten(color(global-adv-shade-1), 10%));
+                    }
+
+                    .prose .advert-slot--mpu {
+                        border-top: 0;
+                    }
+
+                    .prose .element-pullquote blockquote cite,
+                    .prose .element-pullquote blockquote::before,
+                    .prose .element-pullquote blockquote::after {
+                        color: color(global-adv-shade-1);
+                    }
+
+                    .prose figure figcaption,
+                    .prose .element-rich-link {
+                        border-color: rgba(color(global-adv-bands), .4);
+                    }
+
+                    .prose figure.portrait-thumbnail figcaption {
+                        background: none;
+                        border-top: 1px color(shade-3) dotted;
+                        border-bottom: 1px color(shade-3) dotted;
+                        color: color(shade-6);
+                    }
+
+                    .prose figure.figure--thumbnail-with-caption {
+                        background: none;
+                    }
+                }
+            }
+
+            .element-placeholder .element-placeholder__button {
+                .touchpoint__button {
+                    background-color: color(global-adv-shade-2);
+
+                    &:active {
+                        color: color(global-adv-bands);
+                        background-color: color(global-adv-text);
+                    }
+                }
+
+                .touchpoint__label {
+                    color: color(global-adv-shade-2);
+                    text-shadow: 0 0 4px  rgba(0, 0, 0, .5);
+                }
+            }
+
+            .element-placeholder:active .touchpoint__button {
+                color: color(global-adv-bands);
+            }
+
+            .tags {
+                background-color: color(global-adv-bg);
+                border-color: rgba(color(global-adv-bands), .4);
+
+                .inline-list .inline-list__item a {
+                    color: color(shade-7);
+                    background-color: color(global-adv-bands);
+                }
+
+                .inline-list .inline-list__item.more-button a {
+                    border: 1px solid rgba(color(global-adv-bands), 1);
+                    color: color(global-adv-text);
+                    background-color: color(global-adv-bg);
+                }
+            }
+
+            @include mq($from: col4) {
+                background-color: color(shade-11);
+
+                .article {
+                    &__header,
+                    &__header .standfirst {
+                        background-color: color(shade-11);
+                    }
+                }
+
+                .container__outbrain {
+                    background-color: color(global-adv-bg);
+                }
+            }
+        }
+
+        .comments {
+            display: none;
+        }
+
+        .container__outbrain {
+            margin-bottom: 0;
+        }
+    }
+
+    /* News overrides */
+    &.tone--news {
+        .article {
+            .article {
+                &__header {
+                    .sponsorship {
+                        border-top: 1px rgba(color(global-adv-bands), .4) dotted;
+                    }
+
+                    .meta {
+                        border-bottom: 0;
+                        border-top: 1px rgba(color(global-adv-bands), .4) dotted;
+                    }
+
+                    .main-media {
+                        figcaption {
+                            border-bottom: 0;
+                        }
+                        @include mq($from: col4) {
+                            border-bottom: 0;
+                        }
+                    }
+                }
+
+                &__body {
+                    border-bottom: 1px rgba(color(global-adv-bands), .4) dotted;
+                }
+            }
+
+            .tags {
+                border-top: 0;
+            }
+        }
+
+        @include mq($from: col4) {
+            .audio-player__container {
+                background: color(shade-5);
+            }
+        }
+    }
+
+    /* Feature overrides */
+    &.tone--feature1,
+    &.tone--feature2,
+    &.tone--feature3 {
+        .article {
+            a:active {
+                color: lighten(color(global-adv-text), 10%);
+            }
+
+            .article__body > .prose:not(.prose--has-thumbnails-without-caps) > p {
+                @include dropcap(color(global-adv-shade-1));
+            }
+
+            .article {
+                &__header {
+                    .headline {
+                        background-color: color(shade-12);
+                    }
+
+                    .standfirst__inner,
+                    .meta {
+                        border-bottom: 1px rgba(color(global-adv-bands), .4) dotted;
+                    }
+                }
+            }
+        }
+    }
+
+    /* Video overrides */
+    &.tone--news[data-content-type='video'],
+    &.tone--media[data-content-type='video'] {
+        .article {
+            .article {
+                &__header {
+                    .meta {
+                        border-bottom: 1px rgba(color(global-adv-bands), .4) dotted;
+                    }
+
+                    .meta .meta__misc {
+                        border-top: 1px rgba(color(global-adv-bands), .4) dotted;
+
+                        .sponsorship {
+                            padding-top: 0;
+                        }
+
+                        .sponsorship__inner {
+                            padding: 0;
+                        }
+
+                        .sponsorship__formatted-sponsor-name {
+                            padding-left: 0;
+                        }
+
+                        @include mq($from: col2) {
+                            border-top: 0;
+                            border-left: 1px rgba(color(global-adv-bands), .4) dotted;
+
+                            .sponsorship__formatted-sponsor-name {
+                                display: block;
+                                padding-top: 0;
+                                padding-bottom: 0;
+                            }
+
+                            .sponsorship__logo {
+                                margin-left: 0;
+                            }
+                        }
+                    }
+
+                    .meta .standfirst {
+                        background-color: color(global-adv-bg);
+
+                        @include mq($from: col4) {
+                            padding-left: 0;
+                            padding-right: 0;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /* Audio overrides */
+    &.tone--podcast,
+    &.tone--news[data-content-type='audio'],
+    &.tone--media[data-content-type='audio'] {
+        .article {
+            &__header {
+                .headline {
+                    margin-top: 0;
+                }
+
+                .meta {
+                    display: none;
+                }
+
+                .cutout__background {
+                    z-index: 1;
+                }
+
+                .cutout__container {
+                    min-height: 155px;
+                    background-color: color(global-adv-bg);
+                }
+
+                @include mq($from: col4) {
+                    .audio-player__container {
+                        background-color: color(shade-11);
+                    }
+                }
+
+                .audio-player__wrapper,
+                .audio-player {
+                    background-color: color(tone-podcast-adv-ply-background);
+                }
+
+                .audio-player__button.touchpoint--primary .touchpoint__button,
+                .audio-player__slider__knob {
+                    background-color: color(global-adv-shade-2);
+
+                    &:active {
+                        background-color: darken(color(global-adv-shade-2), 10%);
+                    }
+                }
+
+                .audio-player__slider__track {
+                    background-color: color(tone-podcast-adv-ply-range);
+                }
+            }
+
+            .sponsorship.sponsored {
+                display: none !important;
+            }
+
+            .sponsorship.paid {
+                @include sponsorship;
+            }
+
+            .sponsorship,
+            .byline--mobile {
+                background-color: color(global-adv-bg);
+                border-bottom: 1px rgba(color(global-adv-bands), .4) dotted;
+            }
+
+            .byline,
+            .byline a {
+                color: color(global-adv-shade-1) !important;
+            }
+
+            &__body {
+                .standfirst,
+                .prose p {
+                    color: color(global-adv-text);
+                    @include text-underline(color(global-adv-shade-1), lighten(color(global-adv-shade-1), 10%));
+                }
+            }
+        }
+    }
+
+    /* Gallery overrides */
+    &.tone--news[data-content-type='gallery'],
+    &.tone--media[data-content-type='gallery'] {
+        .article {
+            .article {
+                &__header {
+                    background-color: color(global-adv-bg);
+
+                    .gallery {
+                        background-color: color(global-adv-bg);
+                    }
+
+                    .meta {
+                        border-bottom: 0;
+
+                        .meta__misc {
+                            border-top: 0;
+                            border-bottom: 1px rgba(color(global-adv-bands), .4) dotted;
+                        }
+                    }
+
+                    .standfirst {
+                        border-bottom: 1px rgba(color(global-adv-bands), .4) dotted;
+                    }
+
+                    .sponsorship {
+                        border-top: 0;
+                    }
+
+                    @include mq($from: col2) {
+                        .sponsorship {
+                            border-bottom: 0;
+                            border-top: 1px rgba(color(global-adv-bands), .4) dotted;
+                        }
+
+                        .meta {
+                            border-top: 1px rgba(color(global-adv-bands), .4) dotted;
+
+                            .meta__misc {
+                                border-top: 0;
+                                border-bottom: 0;
+                                border-left: 1px rgba(color(global-adv-bands), .4) dotted;
+                            }
+                        }
+
+                        .standfirst {
+                            border-bottom: 0;
+                            background-color: color(global-adv-bg);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ArticleTemplates/assets/scss/garnett-layout/_base-tone.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_base-tone.scss
@@ -45,7 +45,7 @@ body {
             &__image {
                 z-index: 21;
                 background-size: auto 160px;
-                @include mq($from:col2) {
+                @include mq($from: col2) {
                     background-size: auto 220px;
                 }
             }

--- a/ArticleTemplates/assets/scss/garnett-layout/_base-tone.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_base-tone.scss
@@ -44,7 +44,10 @@ body {
             }
             &__image {
                 z-index: 21;
-                background-size: auto 220px;
+                background-size: auto 160px;
+                @include mq($from:col2) {
+                    background-size: auto 220px;
+                }
             }
         }
 

--- a/ArticleTemplates/assets/scss/garnett-modules/_cutout.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/_cutout.scss
@@ -1,0 +1,84 @@
+// /*doc
+// ---
+// title: Cutout
+// name: cutout
+// category: Modules
+// ---
+// Display a large image of contributor in background of container.
+//
+// ```html_example
+// <div class="cutout">
+//     <div class="cutout__container" style="background-image: url(http://png-resizer.mobile-apps.guardianapis.com/static/sys-images/Guardian/Pix/pictures/2014/3/13/1394733748508/SeumasMilne.png?width=600);" id="cutout">
+//         <!--Content-->
+//     </div>
+// </div>
+// ```
+// */
+
+.cutout {
+    .cutout__container {
+        @include mq($to: col1) {
+            min-height: 245px;
+            padding-right: cols($base-1, 1);
+        }
+
+        @include mq(col1, col2) {
+            min-height: 280px;
+            padding-right: cols($base-2, 2);
+        }
+
+        @include mq(col2, col3) {
+            min-height: 320px;
+        }
+
+        @include mq($from: col3) {
+            min-height: 320px;
+        }
+
+        @include mq($from: col4) {
+            margin: 0 auto;
+            min-height: 220px;
+            max-width: 1200px;
+        }
+
+        .headline {
+            position: relative;
+            z-index: 1;
+
+            @include mq($from: col4) {
+                margin: 0;
+            }
+        }
+    }
+
+    .cutout__image {
+        background-repeat: no-repeat;
+        background-position: bottom right;
+        background-size: 50%;
+        bottom: 0;
+        left: 0;
+        position: absolute;
+        right: -10%;
+        top: 0;
+        z-index: 1;
+
+        @include mq($from: col1) {
+            background-size: 45%;
+            right: -7%
+        }
+
+        @include mq($from: col2) {
+            background-size: 40%;
+        }
+
+        @include mq($from: col3) {
+            background-size: 30%;
+            right: -5%;
+        }
+
+        @include mq($from: col4) {
+            background-size: contain;
+            right: 10%;
+        }
+    }
+}

--- a/ArticleTemplates/assets/scss/garnett-modules/blocks/_block--live.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/blocks/_block--live.scss
@@ -1,0 +1,272 @@
+// /*doc
+// ---
+// title: Liveblog
+// name: block--live
+// category: Blocks
+// ---
+// Display a liveblog update:
+//
+// ```html_example
+// <div class="block block--live-blog" id="block-539ac02ce4b0bc906f6b6039">
+//     <p class="block__time" title="2014-06-13T09:18:19Z">50 minutes ago</p>
+//     <div class="block__body">
+//         <div class="from-content-api prose resizable selectable">
+//             <p><b>Adrian Giles and ITV's expert analysts found themselves under attack from anti-World Cup protesters during the Brazil v Croatia game. </b>Lee Dixon, Fabio Cannavaro and Patrick Vieira were uninjured during the attack on their studio in Rio, but it was a prescient reminder that not everyone is in carnival mood. <a href="#">For full details of the assault with rocks, read here.</a></p>
+//         </div>
+//         <p class="block__updated">Last Updated: 10:21 GMT+1 Friday, 13 June 2014</p>
+//     </div>
+// </div>
+// ```
+//
+// Highlight a key event:
+//
+// ```html_example
+// <div class="block block--live-key-event" id="block-5399f964e4b076bb7c59cad9">
+//     <p class="block__time" title="20:04">20:04</p>
+//     <div class="block__body">
+//         <div class="from-content-api prose resizable selectable">
+//             <h2 class="block__title">Brazil v Croatia - line-ups</h2>
+//             <p><b>Brazil:</b> Cesar; Alves, Silva, Luiz, Marcelo; Paulinho, Gustavo; Hulk, Oscar, Neymar; Fred.</p>
+//             <p><b>Croatia:</b> Pletikosa; Srna, Corluka, Lovren, Vrsaijko; Kovacic, Modric; Rakitic, Perisic, Olic; Jelavic.</p>
+//         </div>
+//         <p class="block__updated">Last Updated: 20:14 GMT+1 Thursday, 12 June 2014</p>
+//     </div>
+// </div>
+// ```
+//
+// Provide a summary of events:
+//
+// ```html_example
+// <div class="block block--live-summary" id="block-539a8ba0e4b06fa6efefb577">
+//     <p class="block__time" title="2014-06-13T05:28:14Z">5 hours ago</p>
+//     <div class="block__body">
+//         <div class="from-content-api prose resizable selectable">
+//             <h2 class="block__title">Day two starts here</h2>
+//             <p>Hello world, whatever time of day it may be for you. Finally the World Cup is up and running, and we'll be bringing you all the reaction to the opening game (Brazil won, you may have heard) and looking forward to the next three, which take place this evening, late at night or early tomorrow morning, depending on where you are.</p>
+//         </div>
+//     </div>
+// </div>
+// ```
+// */
+
+[class*='block--live-'] {
+    padding-top: 0;
+
+    @include mq($from: col2) {
+        padding-top: 12px;
+    }
+
+    @include mq($from: col4) {
+        padding: {
+            left: 20px;
+            right: 20px;
+        }
+    }
+
+    .block__time {
+        color: color(shade-2);
+        display: inline-block;
+        font-family: $agate-sans;
+        padding: base-px(1, 0);
+        vertical-align: top;
+
+        @include mq($from: col2) {
+            float: left;
+            height: 100px; // Forces both block__byline and block__body to float next to time
+            padding: base-px(0, 1, 0, 0);
+            margin-top: -5px; // Offset for space above in our fonts to align text to top of block rule
+        }
+
+        @include mq(col2, col3) {
+            width: cols($base-3, 4, 1);
+        }
+
+        @include mq($from: col3) {
+            width: cols($base-4, 5, 1);
+        }
+
+        @include mq($from: col4) {
+            width: 220px;
+        }
+    }
+
+    .block__body {
+        @include mq($to: col4) {
+            .element-rich-link:last-child {
+                width: 100%;
+            }
+        }
+
+        @include mq($from: col2) {
+            float: left;
+
+            .twitter-tweet,
+            .js-tweet {
+                position: relative;
+
+                &::before {
+                    position: absolute;
+                    left: -4rem;
+                }
+            }
+
+            .twitter-tweet,
+            .js-tweet {
+                &::before {
+                    left: -5rem;
+                }
+            }
+        }
+
+        @include mq(col2, col3) {
+            width: cols($base-3, 8);
+        }
+
+        @include mq($from: col3) {
+            width: cols($base-4, 11);
+        }
+
+        @include mq($from: col4) {
+            width: 620px;
+        }
+    }
+
+    .block__updated {
+        clear: both;
+        color: color(shade-3);
+        font-family: $agate-sans;
+        @include meta();
+    }
+
+    .block__byline {
+        border-left: 1px solid color(shade-5);
+        display: inline-block;
+        padding: base-px(.5, 1);
+        margin: base-px(0, 0, 1, 1);
+        vertical-align: top;
+
+        @include mq($from: col2) {
+            border: 0;
+            float: left;
+            margin: base-px(0, 0, 1, 0);
+            padding: 0;
+        }
+
+        @include mq($from: col4) {
+            width: 620px;
+        }
+    }
+
+    .block__avatar {
+        background: color(shade-5);
+        border-radius: 50%;
+        display: inline-block;
+        height: 40px;
+        margin-right: base-px(.5);
+        overflow: hidden;
+        position: relative;
+        vertical-align: middle;
+        width: 40px;
+
+        img {
+            left: 50%;
+            max-height: 100%;
+            position: absolute;
+            top: 0;
+            -webkit-transform: translateX(-50%);
+            transform: translateX(-50%);
+            width: auto;
+        }
+    }
+
+    .block__author {
+        display: inline;
+        line-height: 40px;
+    }
+
+    .prose {
+        blockquote {
+            margin-right: 0;
+            margin-left: 0;
+        }
+
+        figure {
+            &.figure-inline {
+                float: none;
+                clear: both;
+            }
+
+            // When thumbnail images are the first element of a block
+            &.element--thumbnail:first-child {
+                margin-top: 2px; // line up to floated text
+
+                @include mq($from: col4) {
+                    margin-top: 20px; // add space beneath time stamp
+                }
+            }
+
+            &:last-child {
+                figcaption:not(.figure--thumbnail, .figure-wide, .figure--thumbnail-with-caption) {
+                    border-bottom: 0;
+                }
+            }
+        }
+
+        figcaption {
+            padding: base-px(.5, 0, 1, .33);
+        }
+
+        @include mq($to: col1) {
+            figure {
+                &.portrait-thumbnail {
+                    figcaption {
+                        padding: 0 0 0 6px;
+                    }
+
+                    .element-image__caption {
+                        @include text-ellipses(9);
+                    }
+                }
+           }
+        }
+
+        @include mq($from: col1, $to: col4) {
+            figure {
+                &.portrait-thumbnail, &.landscape-thumbnail {
+                    margin-bottom: 2px;
+                }
+            }
+        }
+
+        // Offsets for space above in our fonts to align text to top of block rule
+        p:first-child {
+            margin-top: -2px;
+        }
+
+        h2:first-child {
+            margin-top: -3px;
+        }
+    }
+}
+
+.block--live-key-event {
+    border-top: 2px solid color(tone-live-accent);
+
+    .block__title {
+        color: color(tone-live);
+    }
+}
+
+.block--live-summary {
+    background-color: darken(color(shade-5), 4%);
+    border: 1px dotted color(shade-4);
+
+    .prose p,
+    .prose li {
+        @include text-underline(color(tone-news), color(tone-news-accent));
+    }
+
+    .block__time {
+        font-weight: bold;
+    }
+}

--- a/ArticleTemplates/assets/scss/garnett-modules/content/_prose.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/content/_prose.scss
@@ -289,7 +289,6 @@
             &::after {
                 @extend %quoteIconSharedStyles;
                 font-size: 3rem;
-                color: color(tone-news);
                 content: '\E092';
                 position: absolute;
                 top: 2px;
@@ -301,10 +300,6 @@
                 content: '\E096';
                 top: auto;
                 bottom: 19px;
-            }
-
-            footer {
-                color: color(tone-news);
             }
         }
 

--- a/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
@@ -55,6 +55,14 @@
         }
     }
 
+    // Pull quotes
+    .prose .element-pullquote blockquote {
+        &:before,
+        &:after,
+        footer {
+            color: $p-kicker;
+        }
+    }
 
     // Maybe make this bit less smart and more manual later?
     @include pillar-reversible(

--- a/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
@@ -91,7 +91,7 @@
     .standfirst {
         // text links
         p, li {
-            @include text-underline($kicker, $background, $feature);
+            @include text-underline($kicker, $feature);
         }
     }
 

--- a/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
@@ -25,6 +25,8 @@
         .article__header,
         .article__body {
             background-color: $p-media-background;
+        }
+        .article__header {
             @include mq($from: col4) {
                 background-color: darken($p-media-background, 5%);
             }
@@ -46,7 +48,19 @@
             @include mq($from: col4) {
                 background-color: darken($p-media-background, 5%);
             }
+        }
 
+        .audio-player__container {
+            .audio-player {
+                background-color: transparent;
+            }
+            .audio-player__wrapper {
+                background-color: $p-media-background;
+                border-bottom: 1px color(shade-2) dotted;
+            }
+            @include mq($from: col4) {
+                background-color: darken($p-media-background, 5%);
+            }
         }
 
         // hide horizontal white line above video cover image

--- a/ArticleTemplates/assets/scss/garnett-pillar/_news.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_news.scss
@@ -5,6 +5,13 @@ $p-inverted: #ff4e36; // MAPI: light kicker — need to update MAPI for news
 $p-background: #ffffff; // MAPI: card background
 $p-media-background: #161616;
 
+// $p-kicker: #005689; // MAPI: kicker text
+// $p-feature-headline: #02345e; // MAPI: feature headline
+// $p-soft: #f6f6f6; // MAPI: ?
+// $p-inverted: #00D4FF; // MAPI: light kicker — need to update MAPI for news
+// $p-background: #ffffff; // MAPI: card background
+// $p-media-background: #161616;
+
 .garnett--pillar-news {
     @include pillar-colour(
         $p-kicker,

--- a/ArticleTemplates/assets/scss/garnett-pillar/_news.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_news.scss
@@ -1,16 +1,16 @@
-$p-kicker: #cc0a11; // MAPI: kicker text
-$p-feature-headline: #ff1921; // MAPI: feature headline
-$p-soft: #f6f6f6; // MAPI: ?
-$p-inverted: #ff4e36; // MAPI: light kicker — need to update MAPI for news
-$p-background: #ffffff; // MAPI: card background
-$p-media-background: #161616;
-
-// $p-kicker: #005689; // MAPI: kicker text
-// $p-feature-headline: #02345e; // MAPI: feature headline
+// $p-kicker: #cc0a11; // MAPI: kicker text
+// $p-feature-headline: #ff1921; // MAPI: feature headline
 // $p-soft: #f6f6f6; // MAPI: ?
-// $p-inverted: #00D4FF; // MAPI: light kicker — need to update MAPI for news
+// $p-inverted: #ff4e36; // MAPI: light kicker — need to update MAPI for news
 // $p-background: #ffffff; // MAPI: card background
 // $p-media-background: #161616;
+
+$p-kicker: #005689; // MAPI: kicker text
+$p-feature-headline: #02345e; // MAPI: feature headline
+$p-soft: #f6f6f6; // MAPI: ?
+$p-inverted: #00D4FF; // MAPI: light kicker — need to update MAPI for news
+$p-background: #ffffff; // MAPI: card background
+$p-media-background: #161616;
 
 .garnett--pillar-news {
     @include pillar-colour(

--- a/ArticleTemplates/assets/scss/garnett-style-async.scss
+++ b/ArticleTemplates/assets/scss/garnett-style-async.scss
@@ -23,7 +23,7 @@
 @import 'modules/atoms';
 @import 'modules/error';
 @import 'modules/blocks/block--discussion';
-@import 'modules/blocks/block--live';
+@import 'garnett-modules/blocks/block--live';
 @import 'modules/blocks/comment';
 @import 'modules/content/flyers';
 @import 'garnett-modules/content/prose';

--- a/ArticleTemplates/assets/scss/garnett-style-sync.scss
+++ b/ArticleTemplates/assets/scss/garnett-style-sync.scss
@@ -16,7 +16,7 @@
 @import 'garnett-modules/alerts';
 @import 'modules/avatar';
 @import 'modules/bullet';
-@import 'modules/cutout';
+@import 'garnett-modules/cutout';
 @import 'garnett-modules/figure';
 @import 'modules/key-events';
 @import 'modules/loading';

--- a/ArticleTemplates/assets/scss/garnett-style-sync.scss
+++ b/ArticleTemplates/assets/scss/garnett-style-sync.scss
@@ -41,7 +41,7 @@
 
 // Layout
 @import 'layout/article';
-@import 'layout/article--audio';
+@import 'garnett-layout/article--audio';
 @import 'garnett-layout/article--comment';
 @import 'layout/article--liveblog';
 @import 'layout/article--minute';

--- a/ArticleTemplates/assets/scss/garnett-style-sync.scss
+++ b/ArticleTemplates/assets/scss/garnett-style-sync.scss
@@ -47,7 +47,7 @@
 @import 'layout/article--minute';
 @import 'layout/article--us-minute';
 @import 'layout/article--shared';
-@import 'layout/article--sponsorship';
+@import 'garnett-layout/article--sponsorship';
 @import 'layout/article--visual';
 @import 'layout/article--photo-essay';
 @import 'layout/cricket';
@@ -80,7 +80,7 @@
 // Tones
 // @import 'tones/tone--analysis';
 // @import 'tones/tone--comment';
-@import 'tones/tone--deadblog';
+@import 'garnett-tones/tone--deadblog';
 @import 'tones/tone--editorial';
 // @import 'tones/tone--feature';
 @import 'tones/tone--live';

--- a/ArticleTemplates/assets/scss/garnett-tones/_tone--deadblog.scss
+++ b/ArticleTemplates/assets/scss/garnett-tones/_tone--deadblog.scss
@@ -1,0 +1,234 @@
+/*.tone--deadBlog {
+    .section {
+        color: color(tone-liveBlogSection); // Default
+        font-family: $egyptian-display;
+        font-weight: 600;
+        @include headline(.5);
+        float: left;
+        padding-bottom: 0;
+
+        &::before {
+            margin-right: base-px(.66666);
+            line-height: 92%; // Offset for different font
+            vertical-align: bottom;
+        }
+    }
+
+    .content__series-label {
+        color: color(tone-liveBlogSeriesLabel);
+        font-weight: normal;
+        font-family: $egyptian-display;
+        @include headline(.5);
+        padding: 6px 12px 0 0;
+        padding-bottom: 0;
+        float: left;
+    }
+
+} */
+
+.tone--deadBlog {
+    .witness {
+        margin-top: base-px(1);
+
+        @include mq($from: col4) {
+            margin-left: 240px;
+        }
+    }
+
+    a.touchpoint:active {
+        color: color(tone-deadblog);
+    }
+
+    #comments .touchpoint--primary {
+        .touchpoint__button {
+            background-color: color(tone-deadblog);
+        }
+
+        &:active .touchpoint__button {
+            background-color: color(tone-deadblog);
+        }
+    }
+
+    // Template specific styles
+    .article--liveblog {
+        border-top-color: color(tone-deadblog);
+
+        .prose table,
+        .table {
+            border-top-color: color(tone-deadblog);
+        }
+
+        .meta {
+            background-color: color(shade-8);
+            border: 0;
+            border-left: 1px dotted rgba(color(shade-7), .2);
+            margin: 0;
+
+            @include mq($from: col4) {
+                background-color: darken(color(shade-8), 10%);
+                border: 0;
+                max-width: 100%;
+                width: 100%;
+            }
+
+            .meta__pubdate {
+                color: rgba(color(shade-3), .8);
+            }
+        }
+
+        .meta__misc {
+            @include mq($from: col4) {
+                background-color: color(shade-8);
+                margin: 0 auto;
+                padding: {
+                    left: 240px;
+                    right: 340px;
+                }
+                width: 1200px;
+            }
+        }
+    }
+
+    .article__header {
+        background-color: color(shade-7);
+
+        @include mq($from: col4) {
+            background-color: color(shade-5);
+
+            .section,
+            .headline,
+            .standfirst__inner,
+            .main-media {
+                background-color: color(shade-7);
+            }
+        }
+
+        .byline__author,
+        .byline__author a {
+            color: color(shade-1);
+        }
+
+        a {
+            color: color(tone-deadblog);
+
+            &:active {
+                opacity: rgba(color(tone-deadblog), .8);
+            }
+        }
+
+        .bullet,
+        ul > li {
+            &::before {
+                background-color: color(shade-2);
+            }
+        }
+
+        .headline {
+            color: color(shade-1);
+        }
+
+        .content__series-label,
+        .content__series-label a {
+            color: color(shade-2);
+        }
+
+        .section {
+            @include headline(.5);
+            color: color(tone-deadblog); // Default
+            font-family: $egyptian-display;
+            font-weight: 600;
+
+            &::before {
+                margin-right: base-px(.66666);
+                line-height: 92%; // Offset for different font
+                vertical-align: bottom;
+            }
+        }
+
+        .section__live {
+            display: block;
+        }
+
+        .standfirst {
+            color: color(shade-2);
+
+            a {
+                color: color(tone-deadblog);
+            }
+        }
+
+        .sponsorship {
+            background-color: color(shade-7);
+            border-bottom: 0;
+
+            &__about-uri {
+                color: color(global-sponsored-about);
+            }
+        }
+    }
+
+    .tags {
+        background-color: color(shade-5);
+        border-bottom: 0;
+        padding-left: 0;
+
+        .inline-list__item {
+            a {
+                @include tag-button(color(shade-1), color(blogs-tags));
+            }
+
+            &.more-button a {
+                @include tag-more-button(color(shade-1), darken(color(blogs-tags), 10%));
+            }
+        }
+    }
+
+    .block--live-summary {
+        background-color: color(shade-7);
+        border-top: 1px solid color(shade-3);
+
+        .prose p,
+        .prose li {
+            @include text-underline(color(tone-news), color(tone-news-accent));
+        }
+
+        .block__time {
+            font-weight: bold;
+        }
+    }
+
+    .alerts:active,
+    .alerts.following {
+        background-color: color(tone-live);
+        color: color(shade-7);
+    }
+
+    .alerts,
+    .alerts.following:active {
+        border-color: rgba(color(tone-live), .5);
+        color: color(tone-live);
+    }
+
+    .cricket {
+        .article--liveblog {
+            border-top: 0;
+        }
+
+        a.alerts {
+            margin: 0;
+        }
+
+        a.alerts:active,
+        a.alerts.following {
+            background-color: color(shade-3);
+            color: color(shade-7);
+        }
+
+        a.alerts,
+        a.alerts.following:active {
+            border-color: rgba(color(shade-4), .5);
+            background-color: transparent;
+            color: color(shade-3);
+        }
+    }
+}

--- a/ArticleTemplates/assets/scss/garnett-type/_media-all.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_media-all.scss
@@ -55,8 +55,7 @@
             }
         }
 
-        .audio-player__wrapper,
-        .audio-player {
+        .audio-player__wrapper {
             background-color: darken(color(shade-1), 10%);
         }
 

--- a/ArticleTemplates/assets/scss/garnett-type/_media-audio.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_media-audio.scss
@@ -3,9 +3,6 @@
         border-bottom: 1px rgba(234, 234, 234, .3) dotted;
         color: color(shade-5);
 
-        > div {
-            color: color(tone-podcast); // Content Label Section
-        }
 
         .content__series-label,
         .content__series-label a {
@@ -20,51 +17,9 @@
         z-index: 1;
     }
 
-    .audio-player__button {
-        &.touchpoint--primary .touchpoint__button {
-            background-color: color(tone-podcast);
-            color: color(tone-podcast-ply-background);
-
-            &:active {
-                background-color: color(tone-news-accent); /* NB Need new colour???!!! */
-            }
-        }
-    }
-
-    .audio-player__slider__knob {
-        background-color: color(tone-podcast);
-    }
-
-    .section__container {
-        background-color: color(shade-6);
-    }
-
-    .article {
-        border-top-color: color(tone-podcast);
-    }
-
-    .article__body {
-        background-color: color(shade-7);
-    }
-
     .article__header {
-        background-color: color(shade-6);
-
-        .section {
-            display: block;
-        }
-
         .cutout__container {
             background-color: inherit;
-        }
-
-        .headline {
-            color: color(shade-7);
-
-            .headline__accent {
-                color: color(shade-1);
-                display: block;
-            }
         }
 
         .card__titletext {
@@ -81,56 +36,20 @@
             .byline {
                 color: color(shade-7);
             }
-
-            .byline__author a {
-                color: color(tone-podcast);
-            }
         }
-
-        .comment-count a {
-            color: color(tone-podcast);
-        }
-    }
-
-    @include mq($from: col4) {
-        .cutout {
-            background-color: darken(color(shade-6), 5%);
-
-            .cutout__container {
-                background-color: transparent;
-            }
-        }
-    }
-
-    .standfirst {
-        color: color(shade-1);
     }
 
     .meta,
     .meta__pubdate {
-        color: rgba(color(shade-7), .8);
+        color: rgba(color(shade-7), .75);
     }
 
     .meta {
-        border-top: 1px rgba(color(shade-7), .4) dotted;
-    }
-
-    .meta__misc {
-        @include mq($from: col4) {
-            padding: {
-                left: 0;
-                right: 0;
-            }
-        }
+        border-top: 1px rgba(color(shade-7), .2) dotted;
     }
 
     .comment-count {
-        color: color(tone-podcast);
         border-left-color: rgba(color(shade-7), .4);
-
-        a {
-            color: color(tone-podcast);
-        }
     }
 
     &.ios .article__header .card__title--audio::before {

--- a/ArticleTemplates/assets/scss/garnett-type/_media-audio.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_media-audio.scss
@@ -54,8 +54,11 @@
             display: block;
         }
 
+        .cutout__container {
+            background-color: inherit;
+        }
+
         .headline {
-            margin-top: base-px(.5);
             color: color(shade-7);
 
             .headline__accent {

--- a/ArticleTemplates/assets/scss/garnett-type/_media-video.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_media-video.scss
@@ -23,6 +23,9 @@
                             padding-top: 8px;
                             padding-left: 12px;
                         }
+                        .meta__pubdate {
+                            padding-bottom: 16px;
+                        }
 
                         .sponsorship__inner {
                             margin: 0;

--- a/ArticleTemplates/assets/scss/garnett-type/_media-video.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_media-video.scss
@@ -22,6 +22,7 @@
                         .meta__pubdate {
                             padding-top: 8px;
                             padding-left: 12px;
+                            padding-right: 12px;
                         }
                         .meta__pubdate {
                             padding-bottom: 16px;


### PR DESCRIPTION
This tries to fix an assortment of visual issues with the templates — mostly caused by my previous PRs…

Among the issues fixed:
- Stops headline and author cutouts from overlapping
- Removes old blue from quotemarks
- Shows the full standfirst in audio articles
- Removes a white stripe next to standfirst in audio articles
- Changes the way the link underline is implemented so liveblog links are readable
- Adds padding around metadata in video articles
- Separates bullet points and text a little more
- Aligns immersive dropcap (need to bring dropcap back to feature articles)

