### PR TITLE
Move author icon to the right

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-modules/_alerts.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/_alerts.scss
@@ -32,7 +32,7 @@
 // */
 
 .alerts {
-    @include meta();
+    @include meta(0.875);
     font-family: $agate-sans;
     white-space: nowrap;
     padding: base-px(.3, 1, .7, 1);
@@ -58,8 +58,9 @@
         vertical-align: bottom;
         font-size: $body-size-2;
         position: relative;
-        right: 3px;
+        right: 5px;
         top: 1px;
+        transform: scale(0.85);
     }
 
     &__label {

--- a/ArticleTemplates/assets/scss/garnett-modules/_avatar.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/_avatar.scss
@@ -1,0 +1,53 @@
+// /*doc
+// ---
+// title: Avatar
+// name: avatar
+// category: Modules
+// ---
+// Display the image of author or user.
+//
+// ```html_example
+// <a class="avatar avatar--author" href="#">
+//     <img class="avatar__img" src="http://png-resizer.mobile-apps.guardianapis.com/static/sys-images/Guardian/Pix/pictures/2014/3/13/1394733739319/IanSample.png?width=300"/>
+// </a>
+//
+// <span class="avatar avatar--user">
+//     <img class="avatar__img" src="http://static.guim.co.uk/sys-images/Guardian/Pix/site_furniture/2010/09/01/no-user-image.gif"/>
+// </span>
+// ```
+// */
+
+.avatar {
+    border-radius: 100%;
+    border-radius: 100%;
+    overflow: hidden;
+    display: block;
+
+    .avatar__img {
+        width: 100%;
+        height: 100%;
+    }
+}
+
+.avatar--author {
+    width: 80px;
+    height: 80px;
+
+    .avatar__img {
+        width: 100%;
+        height: auto;
+        transform-origin: top center;
+        transform: scale(1.6) translate(-1px, -1px);
+
+        // width: auto;
+        // margin-left: -10%;
+        // margin-top: 0;
+        // height: 100%;
+
+    }
+}
+
+.avatar--user {
+    height: 44px;
+    width: 44px;
+}

--- a/ArticleTemplates/assets/scss/garnett-modules/content/_meta.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/content/_meta.scss
@@ -78,6 +78,7 @@
     }
 
     &__pubdate {
+        font-size: 1.4rem;
         color: color(shade-3);
         font-family: $agate-sans;
     }

--- a/ArticleTemplates/assets/scss/garnett-modules/content/_meta.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/content/_meta.scss
@@ -53,8 +53,8 @@
     }
 
     .avatar--author {
-        margin: base-px(0, .75, 0, 0);
-        float: left;
+        margin: base-px(0, 0, 0, 1);
+        float: right;
     }
 
     &__misc {

--- a/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
@@ -67,6 +67,11 @@
         }
     }
 
+    // Circle avatar colours
+    .avatar {
+        background-color: $p-inverted;
+    }
+
     // Pull quotes
     .prose .element-pullquote blockquote {
         &:before,
@@ -87,6 +92,10 @@
 
 }
 
+
+// CSS for reversible pillar colours, this means we can
+// use $kicker colours to mean $p-kicker or $p-inverted
+// depending on context
 @mixin pillar-reversible($kicker, $feature, $soft, $inverted, $background) {
     // Author names
     .byline,

--- a/ArticleTemplates/assets/scss/garnett-style-sync.scss
+++ b/ArticleTemplates/assets/scss/garnett-style-sync.scss
@@ -14,7 +14,7 @@
 // Modules
 @import 'modules/advert-slot';
 @import 'garnett-modules/alerts';
-@import 'modules/avatar';
+@import 'garnett-modules/avatar';
 @import 'modules/bullet';
 @import 'garnett-modules/cutout';
 @import 'garnett-modules/figure';


### PR DESCRIPTION
This moves the author byline icon circle to the right, so all the text is left-aligned, and adds pillar colour to the icon background.