### PR TITLE
Fix comments bug

### DIFF
--- a/ArticleTemplates/commentsTemplate.html
+++ b/ArticleTemplates/commentsTemplate.html
@@ -6,6 +6,7 @@
         <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
         <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="__TEMPLATES_DIRECTORY__assets/css/fonts-__PLATFORM__.css" />
         <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__SYNC_STYLES__.css" />
+        <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__ASYNC_STYLES__.css" />
         <script type="text/javascript">
             window.GU = window.GU || {};
         </script>

--- a/ArticleTemplates/commentsTemplatePreview.html
+++ b/ArticleTemplates/commentsTemplatePreview.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
     <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="__TEMPLATES_DIRECTORY__assets/css/fonts-__PLATFORM__.css" />
     <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__SYNC_STYLES__.css" />
-    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/style-async.css" />
+    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__ASYNC_STYLES__.css" />
 </head>
 
 <body class="__FONT_SIZE__"  data-template-directory="__TEMPLATES_DIRECTORY__">

--- a/ArticleTemplates/footballFixturesTemplate.html
+++ b/ArticleTemplates/footballFixturesTemplate.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="initial-scale=1, maximum-scale=1">
     <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="__TEMPLATES_DIRECTORY__assets/css/fonts-__PLATFORM__.css" />
     <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__SYNC_STYLES__.css" />
-    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/style-async.css" />
+    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__ASYNC_STYLES__.css" />
 </head>
 
 <body class="__PLATFORM__ __FONT_SIZE__ __IS_OFFLINE__" data-content-type="footballFixtures" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">

--- a/ArticleTemplates/simpleBodyTemplate.html
+++ b/ArticleTemplates/simpleBodyTemplate.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
     <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="__TEMPLATES_DIRECTORY__assets/css/fonts-__PLATFORM__.css" />
     <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__SYNC_STYLES__.css" />
-    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/style-async.css" />
+    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__ASYNC_STYLES__.css" />
 </head>
 
 <body class="__FONT_SIZE__" data-template-directory="__TEMPLATES_DIRECTORY__">

--- a/ArticleTemplates/simpleBodyTemplatePrepopCancelAppleSubscription.html
+++ b/ArticleTemplates/simpleBodyTemplatePrepopCancelAppleSubscription.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
     <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="__TEMPLATES_DIRECTORY__assets/css/fonts-__PLATFORM__.css" />
     <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__SYNC_STYLES__.css" />
-    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/style-async.css" />
+    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__ASYNC_STYLES__.css" />
 </head>
 
 <body class="__FONT_SIZE__" data-template-directory="__TEMPLATES_DIRECTORY__">

--- a/ArticleTemplates/simpleBodyTemplatePrepopCancelDigipackSubscription.html
+++ b/ArticleTemplates/simpleBodyTemplatePrepopCancelDigipackSubscription.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
     <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="__TEMPLATES_DIRECTORY__assets/css/fonts-__PLATFORM__.css" />
     <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__SYNC_STYLES__.css" />
-    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/style-async.css" />
+    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__ASYNC_STYLES__.css" />
 </head>
 
 <body class="__FONT_SIZE__" data-template-directory="__TEMPLATES_DIRECTORY__">

--- a/ArticleTemplates/simpleBodyTemplatePrepopCancelSubscriptionAndroid.html
+++ b/ArticleTemplates/simpleBodyTemplatePrepopCancelSubscriptionAndroid.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
     <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="__TEMPLATES_DIRECTORY__assets/css/fonts-__PLATFORM__.css" />
     <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__SYNC_STYLES__.css" />
-    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/style-async.css" />
+    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__ASYNC_STYLES__.css" />
 </head>
 
 <body class="__FONT_SIZE__" data-template-directory="__TEMPLATES_DIRECTORY__">

--- a/ArticleTemplates/simpleBodyTemplatePrepopCredits.html
+++ b/ArticleTemplates/simpleBodyTemplatePrepopCredits.html
@@ -7,7 +7,7 @@
     <meta name="format-detection" content="telephone=no">
     <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="__TEMPLATES_DIRECTORY__assets/css/fonts-__PLATFORM__.css" />
     <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__SYNC_STYLES__.css" />
-    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/style-async.css" />
+    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__ASYNC_STYLES__.css" />
 </head>
 
 <body class="__FONT_SIZE__" data-template-directory="__TEMPLATES_DIRECTORY__">

--- a/test/garnett-fixture/comments.html
+++ b/test/garnett-fixture/comments.html
@@ -1,0 +1,72 @@
+<html lang="en-US">
+
+<head>
+	<title>Comments</title>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="initial-scale=1, maximum-scale=1">
+	<link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="../../ArticleTemplates/assets/css/fonts-ios.css">
+	<link rel="stylesheet" type="text/css" media="all" href="../../ArticleTemplates/assets/css/garnett-style-sync.css">
+	<link rel="stylesheet" type="text/css" media="all" href="../../ArticleTemplates/assets/css/garnett-style-async.css">
+	<script type="text/javascript">
+		window.GU = window.GU || {};
+	</script>
+	<script type="text/javascript" src="../../ArticleTemplates/assets/build/polyfills/promise.js"></script>
+        <script type="text/javascript" src="../../ArticleTemplates/assets/build/polyfills/requestAnimationFrame.js"></script>
+        <script type="text/javascript" src="../../ArticleTemplates/assets/build/bootstrap.js"></script>
+</head>
+
+<body class="tone--liveBlog font-size-4 ios " data-font-size="4" data-template-directory="../../ArticleTemplates/" data-page-id="world/live/2016/may/27/g7-summit-japan-obama-historic-visit-hiroshima-live">
+	<section class="comments comments--page comments-467">
+		<div class="comments__wrapper">
+			<div class="comments__header">
+				<h3 class="comments__count">467</h3>
+
+				<h1 class="comments__headline headline">G7 summit: Obama makes historic visit to Hiroshima</h1>
+
+				<a href="x-gu://newestfirst" class="comments__ordering">
+					<span data-icon="" aria-hidden="true"></span> Oldest First
+				</a>
+
+				<p class="comments__closed">Comments are closed</p>
+
+				<a class="comments__post touchpoint touchpoint--primary" href="x-gu://leavecomment">
+					<span class="touchpoint__label">Post a comment</span>
+					<span class="touchpoint__button" data-icon="" aria-hidden="true"></span>
+				</a>
+			</div>
+			<div class="comments__container">
+				<div class="comments__block comments__block--empty">
+					<p>
+						Open for comments. <a href="x-gu://leavecomment">Be the first to join the debate</a>
+					</p>
+				</div>
+				<div class="comments__block comments__block--failed">
+					<p>
+						Comments are currently unavailable. Please try again later.
+					</p>
+				</div>
+				<div class="comments__block comments__block--loading loading">
+					<img src="../../ArticleTemplates/assets/img/loading.gif" alt="Loading…">
+				</div>
+			</div>
+		</div>
+	</section>
+	<script type="text/javascript">
+		GU.bootstrap.init({
+		    sectionTone: "liveBlog",
+		    fontSize: "font-size-4",
+		    platform: "ios",
+		    isOffline: "" ? true : false,
+		    contentType: "comments",
+		    adsConfig: "mobile",
+		    fontSize: "4",
+		    templatesDirectory: "../../ArticleTemplates/",
+		    pageId: "world/live/2016/may/27/g7-summit-japan-obama-historic-visit-hiroshima-live",
+		    skipStyle: true,
+		    nativeYoutubeEnabled: "" === "true" ? true : false
+		});
+	</script>
+
+</body>
+
+</html>


### PR DESCRIPTION
The comments template needs the 'async' styles added as a `<link>`, this `<link>` was accidentally removed as part of this PR https://github.com/guardian/mobile-apps-article-templates/pull/686. 

This PR adds the `<link>` back into the head of `commentsTemplate.html`, using the placeholder `__ASYNC_STYLES__` for the filename.

It also updates a number of other HTML templates to use the placeholder `__ASYNC_STYLES__`.