### PR TITLE
Ad position fix

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/_advert-slot.scss
@@ -1,0 +1,185 @@
+// /*doc
+// ---
+// title: Advert slot
+// name: advert-slot
+// category: Modules
+// ---
+// Create a placeholder tp allow an advert to be placed with an article.
+//
+// MPU
+//
+// ```html_example
+// <div class="advert-slot advert-slot--mpu">
+//     <div class="advert-slot__label">Advertisement</div>
+//     <div class="advert-slot__wrapper">
+//         <div class="advert-slot__wrapper__content">
+//             <!-- Advert injected here using JavaScript -->
+//         </div>
+//     </div>
+// </div>
+// ```
+//
+// */
+
+.advert-slot {
+    @include meta();
+    color: color(shade-2);
+    font-family: $agate-sans;
+    background: rgba(color(shade-3), .2);
+    display: none;
+    overflow: auto;
+
+    div,
+    img {
+        vertical-align: middle;
+    }
+
+    .advert-slot__label {
+        overflow: auto;
+        position: relative;
+    }
+
+    .advert-slot__action {
+        color: color(shade-2) !important;
+        display: none;
+        padding-right: 2.5rem;
+        position: absolute;
+        right: 0;
+
+        body[data-ads-enable-hiding='true'] & {
+            display: inline;
+        }
+
+        span[data-icon] {
+            font-size: 1.3em;
+            position: absolute;
+            right: 0;
+            top: 0;
+        }
+    }
+
+    .advert-slot__wrapper {
+        position: relative;
+        overflow: hidden;
+    }
+
+    .advert-slot__wrapper__content {
+        position: absolute;
+        bottom: 0;
+    }
+}
+
+.container__outbrain {
+    .advert-slot__action {
+        @include meta;
+        color: color(shade-2);
+        float: right;
+        font-family: $agate-sans;
+        margin: base-px(.5, 1);
+        padding-right: 20px;
+        position: relative;
+
+        span[data-icon] {
+            font-size: 1.3em;
+            position: absolute;
+            right: 0;
+            top: 0;
+        }
+    }
+}
+
+// MPU-size advert
+.advert-slot--mpu {
+    border-top: 1px solid color(shade-4);
+    display: block;
+    margin: 0 auto;
+    width: 300px;
+
+    @include mq($to: 560px) {
+        width: 100vw;
+        margin-left: base-px(-1);
+        padding-bottom: 15px;
+    }
+
+    @include mq($from: col2) {
+        margin: 0;
+        position: absolute;
+        right: 8px;
+        top: 24px;
+    }
+
+    @include mq($from: col3) {
+        right: 15px;
+    }
+
+    @include mq($from: col4) {
+        right: 20px;
+        top: 18px;
+    }
+
+    .advert-slot__label {
+        /*  Any res above 375w e.g. iPhone 6, 6 plus */
+        @include customMQ (iP6) {
+            padding-bottom: 11px;
+            padding-left: 13px;
+
+            .advert-slot__action {
+                right: base-px(1);
+            }
+        }
+
+        margin: 0 auto;
+        padding: base-px(.5, 0, 2, .5);
+
+        .advert-slot__action {
+            right: base-px(.5);
+        }
+
+        width: 100%;
+    }
+
+    .advert-slot__wrapper {
+        height: 250px;
+        margin: 0 auto;
+        padding-top: 250px;
+
+        @include mq($to: 560px) {
+            margin: 0;
+            width: 100%;
+        }
+    }
+}
+
+.advert-slot--placeholder {
+    display: none;
+
+    @include mq($from: col2, $to: col4) {
+        background: transparent;
+        display: block;
+        float: right;
+        height: 300px;
+        margin: {
+            bottom: 12px;
+            left: 18px;
+            right: -(cols($base-4, 3));
+        }
+        width: 300px;
+    }
+    @include mq($from: col3) {
+        margin-right: -(cols($base-4, 9));
+    }
+}
+
+// This class hides the pre-inserted advert for subscribers
+.advert-slot--false {
+    display: none !important;
+}
+
+// Special rules for adverts in liveblogs
+.article--liveblog .article__body {
+    .advert-slot.advert-slot--mpu {
+        float: none;
+        margin: 0 auto;
+        position: static;
+    }
+}

--- a/ArticleTemplates/assets/scss/garnett-style-sync.scss
+++ b/ArticleTemplates/assets/scss/garnett-style-sync.scss
@@ -12,7 +12,7 @@
 @import 'base/iconography';
 
 // Modules
-@import 'modules/advert-slot';
+@import 'garnett-modules/advert-slot';
 @import 'garnett-modules/alerts';
 @import 'garnett-modules/avatar';
 @import 'modules/bullet';

--- a/ArticleTemplates/assets/scss/modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/modules/_advert-slot.scss
@@ -159,14 +159,12 @@
         float: right;
         height: 300px;
         margin: {
+            top: 12px;
             bottom: 12px;
             left: 18px;
-            right: -(cols($base-4, 3));
+            right: -(cols($base-4, 5));
         }
         width: 300px;
-    }
-    @include mq($from: col3) {
-        margin-right: -(cols($base-4, 9));
     }
 }
 

--- a/ArticleTemplates/assets/scss/modules/content/_prose.scss
+++ b/ArticleTemplates/assets/scss/modules/content/_prose.scss
@@ -327,7 +327,7 @@
     }
 
     .advert-slot--placeholder + *,
-    *:first-child {
+    *:first-child:not(.advert-slot--placeholder) {
         margin-top: 0;
 
         .aside {

--- a/test/fixture/article-tone-news.html
+++ b/test/fixture/article-tone-news.html
@@ -179,14 +179,19 @@
 
 
         <script type="text/javascript">
+            var atoms = {};
+            function readAtoms() {
+            }
+            readAtoms.call(atoms);
             GU.bootstrap.init({
+                asyncStylesFilename: "style-async",
                 sectionTone: "news",
                 isAdvertising: "" ? true : false,
                 fontSize: "font-size-4",
                 platform: "ios",
                 isOffline: "" ? true : false,
                 contentType: "article",
-                adsEnabled: "",
+                adsEnabled: "true",
                 adsEnableHiding: "true" === "true" ? true : false,
                 adsConfig: "mobile",
                 actionBarHeight: "0",
@@ -197,6 +202,7 @@
                 useAdsReady: "true" === "true" ? true : false,
                 section: "UK",
                 tests: '{}',
+                atoms: atoms,
                 nativeYoutubeEnabled: "" === "true" ? true : false
             });
         </script>


### PR DESCRIPTION
Ads on tablet layouts are positioned to the top/right of the article body in the app templates. A placeholder reserves the space for the ad. This placeholder was mispositioned on iPad layouts causing the paragraph text to overlap the placeholder after this commit: https://github.com/guardian/mobile-apps-article-templates/commit/c78bef993d6da842ba90b03022344df9f5b80c0d#diff-6394f01c0d5259cee98d42521387e67d

This PR fixes the position.

**Before...**

![screenshot 1](https://user-images.githubusercontent.com/1590704/34155906-023a8f3a-e4b3-11e7-9b1a-1e96a758c649.png)

**After...**

![picture 80](https://user-images.githubusercontent.com/1590704/34155957-2391a5ec-e4b3-11e7-9317-1a7fe0cfd203.png)
