### PR TITLE
update fonts to use correct headline font filename

### DIFF
--- a/ArticleTemplates/assets/scss/base/_typography.scss
+++ b/ArticleTemplates/assets/scss/base/_typography.scss
@@ -7,84 +7,84 @@ $fontMap: (
         ios-src: 'url("../fonts/icons.otf")'
     ),
 
-    // Agaate
-    AS31GuardianAgaateSans1WebLight: (
-        family: 'Guardian Agaate Sans Web',
+    // Headline
+    GHGuardianHeadlineLight: (
+        family: 'Guardian Headline Web',
         weight: 200,
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Light.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Light.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Light.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Light.ttf")'
     ),
-    AS31GuardianAgaateSans1WebLightItalic: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineLightItalic: (
+        family: 'Guardian Headline Web',
         weight: 200,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-LightItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-LightItalic.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-LightItalic.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-LightItalic.ttf")'
     ),
-    AS31GuardianAgaateSans1WebRegular: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineRegular: (
+        family: 'Guardian Headline Web',
         weight: 400,
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Regular.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Regular.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Regular.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Regular.ttf")'
     ),
-    AS31GuardianAgaateSans1WebRegularItalic: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineRegularItalic: (
+        family: 'Guardian Headline Web',
         weight: 400,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-RegularItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-RegularItalic.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-RegularItalic.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-RegularItalic.ttf")'
     ),
-    AS31GuardianAgaateSans1WebMedium: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineMedium: (
+        family: 'Guardian Headline Web',
         weight: 500,
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Medium.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Medium.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Medium.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Medium.ttf")'
     ),
-    AS31GuardianAgaateSans1WebMediumItalic: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineMediumItalic: (
+        family: 'Guardian Headline Web',
         weight: 500,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-MediumItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-MediumItalic.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-MediumItalic.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-MediumItalic.ttf")'
     ),
-    AS31GuardianAgaateSans1WebSemibold: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineSemibold: (
+        family: 'Guardian Headline Web',
         weight: 600,
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Semibold.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Semibold.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Semibold.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Semibold.ttf")'
     ),
-    AS31GuardianAgaateSans1WebSemiboldItalic: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineSemiboldItalic: (
+        family: 'Guardian Headline Web',
         weight: 600,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-SemiboldItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-SemiboldItalic.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-SemiboldItalic.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-SemiboldItalic.ttf")'
     ),
-    AS31GuardianAgaateSans1WebBold: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineBold: (
+        family: 'Guardian Headline Web',
         weight: 700,
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Bold.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Bold.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Bold.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Bold.ttf")'
     ),
-    AS31GuardianAgaateSans1WebBoldItalic: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineBoldItalic: (
+        family: 'Guardian Headline Web',
         weight: 700,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-BoldItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-BoldItalic.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-BoldItalic.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-BoldItalic.ttf")'
     ),
-    AS31GuardianAgaateSans1WebBlack: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineBlack: (
+        family: 'Guardian Headline Web',
         weight: 900,
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Black.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Black.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Black.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Black.ttf")'
     ),
-    AS31GuardianAgaateSans1WebBlackItalic: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineBlackItalic: (
+        family: 'Guardian Headline Web',
         weight: 900,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-BlackItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-BlackItalic.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-BlackItalic.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-BlackItalic.ttf")'
     ),
 
 

--- a/ArticleTemplates/assets/scss/base/_typography.scss
+++ b/ArticleTemplates/assets/scss/base/_typography.scss
@@ -9,82 +9,82 @@ $fontMap: (
 
     // Headline
     GHGuardianHeadlineLight: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 200,
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Light.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Light.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Light.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Light.ttf")'
     ),
     GHGuardianHeadlineLightItalic: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 200,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-LightItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-LightItalic.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-LightItalic.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-LightItalic.ttf")'
     ),
     GHGuardianHeadlineRegular: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 400,
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Regular.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Regular.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Regular.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Regular.ttf")'
     ),
     GHGuardianHeadlineRegularItalic: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 400,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-RegularItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-RegularItalic.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-RegularItalic.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-RegularItalic.ttf")'
     ),
     GHGuardianHeadlineMedium: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 500,
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Medium.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Medium.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Medium.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Medium.ttf")'
     ),
     GHGuardianHeadlineMediumItalic: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 500,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-MediumItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-MediumItalic.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-MediumItalic.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-MediumItalic.ttf")'
     ),
     GHGuardianHeadlineSemibold: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 600,
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Semibold.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Semibold.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Semibold.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Semibold.ttf")'
     ),
     GHGuardianHeadlineSemiboldItalic: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 600,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-SemiboldItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-SemiboldItalic.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-SemiboldItalic.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-SemiboldItalic.ttf")'
     ),
     GHGuardianHeadlineBold: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 700,
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Bold.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Bold.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Bold.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Bold.ttf")'
     ),
     GHGuardianHeadlineBoldItalic: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 700,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-BoldItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-BoldItalic.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-BoldItalic.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-BoldItalic.ttf")'
     ),
     GHGuardianHeadlineBlack: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 900,
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Black.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Black.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Black.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Black.ttf")'
     ),
     GHGuardianHeadlineBlackItalic: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 900,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-BlackItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-BlackItalic.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-BlackItalic.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-BlackItalic.ttf")'
     ),
 
 

--- a/ArticleTemplates/assets/scss/garnett-base/_typography.scss
+++ b/ArticleTemplates/assets/scss/garnett-base/_typography.scss
@@ -8,83 +8,83 @@ $fontMap: (
     ),
 
     // Agaate
-    AS31GuardianAgaateSans1WebLight: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineLight: (
+        family: 'Guardian Headline Web',
         weight: 200,
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Light.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Light.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Light.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Light.ttf")'
     ),
-    AS31GuardianAgaateSans1WebLightItalic: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineLightItalic: (
+        family: 'Guardian Headline Web',
         weight: 200,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-LightItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-LightItalic.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-LightItalic.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-LightItalic.ttf")'
     ),
-    AS31GuardianAgaateSans1WebRegular: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineRegular: (
+        family: 'Guardian Headline Web',
         weight: 400,
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Regular.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Regular.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Regular.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Regular.ttf")'
     ),
-    AS31GuardianAgaateSans1WebRegularItalic: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineRegularItalic: (
+        family: 'Guardian Headline Web',
         weight: 400,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-RegularItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-RegularItalic.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-RegularItalic.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-RegularItalic.ttf")'
     ),
-    AS31GuardianAgaateSans1WebMedium: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineMedium: (
+        family: 'Guardian Headline Web',
         weight: 500,
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Medium.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Medium.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Medium.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Medium.ttf")'
     ),
-    AS31GuardianAgaateSans1WebMediumItalic: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineMediumItalic: (
+        family: 'Guardian Headline Web',
         weight: 500,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-MediumItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-MediumItalic.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-MediumItalic.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-MediumItalic.ttf")'
     ),
-    AS31GuardianAgaateSans1WebSemibold: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineSemibold: (
+        family: 'Guardian Headline Web',
         weight: 600,
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Semibold.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Semibold.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Semibold.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Semibold.ttf")'
     ),
-    AS31GuardianAgaateSans1WebSemiboldItalic: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineSemiboldItalic: (
+        family: 'Guardian Headline Web',
         weight: 600,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-SemiboldItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-SemiboldItalic.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-SemiboldItalic.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-SemiboldItalic.ttf")'
     ),
-    AS31GuardianAgaateSans1WebBold: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineBold: (
+        family: 'Guardian Headline Web',
         weight: 700,
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Bold.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Bold.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Bold.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Bold.ttf")'
     ),
-    AS31GuardianAgaateSans1WebBoldItalic: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineBoldItalic: (
+        family: 'Guardian Headline Web',
         weight: 700,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-BoldItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-BoldItalic.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-BoldItalic.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-BoldItalic.ttf")'
     ),
-    AS31GuardianAgaateSans1WebBlack: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineBlack: (
+        family: 'Guardian Headline Web',
         weight: 900,
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Black.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-Black.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Black.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Black.ttf")'
     ),
-    AS31GuardianAgaateSans1WebBlackItalic: (
-        family: 'Guardian Agaate Sans Web',
+    GHGuardianHeadlineBlackItalic: (
+        family: 'Guardian Headline Web',
         weight: 900,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-BlackItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/AS31GuardianAgaateSans1Web-BlackItalic.ttf")'
+        android-src: 'url("../garnett-fonts/GHGuardianHeadline-BlackItalic.ttf")',
+        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-BlackItalic.ttf")'
     ),
 
 

--- a/ArticleTemplates/assets/scss/garnett-base/_typography.scss
+++ b/ArticleTemplates/assets/scss/garnett-base/_typography.scss
@@ -9,82 +9,82 @@ $fontMap: (
 
     // Agaate
     GHGuardianHeadlineLight: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 200,
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Light.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Light.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Light.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Light.ttf")'
     ),
     GHGuardianHeadlineLightItalic: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 200,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-LightItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-LightItalic.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-LightItalic.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-LightItalic.ttf")'
     ),
     GHGuardianHeadlineRegular: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 400,
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Regular.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Regular.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Regular.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Regular.ttf")'
     ),
     GHGuardianHeadlineRegularItalic: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 400,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-RegularItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-RegularItalic.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-RegularItalic.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-RegularItalic.ttf")'
     ),
     GHGuardianHeadlineMedium: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 500,
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Medium.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Medium.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Medium.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Medium.ttf")'
     ),
     GHGuardianHeadlineMediumItalic: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 500,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-MediumItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-MediumItalic.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-MediumItalic.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-MediumItalic.ttf")'
     ),
     GHGuardianHeadlineSemibold: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 600,
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Semibold.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Semibold.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Semibold.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Semibold.ttf")'
     ),
     GHGuardianHeadlineSemiboldItalic: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 600,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-SemiboldItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-SemiboldItalic.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-SemiboldItalic.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-SemiboldItalic.ttf")'
     ),
     GHGuardianHeadlineBold: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 700,
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Bold.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Bold.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Bold.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Bold.ttf")'
     ),
     GHGuardianHeadlineBoldItalic: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 700,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-BoldItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-BoldItalic.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-BoldItalic.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-BoldItalic.ttf")'
     ),
     GHGuardianHeadlineBlack: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 900,
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-Black.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-Black.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Black.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Black.ttf")'
     ),
     GHGuardianHeadlineBlackItalic: (
-        family: 'Guardian Headline Web',
+        family: 'Guardian Headline',
         weight: 900,
         style: 'italic',
-        android-src: 'url("../garnett-fonts/GHGuardianHeadline-BlackItalic.ttf")',
-        ios-src: 'url("../garnett-fonts/GHGuardianHeadline-BlackItalic.ttf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-BlackItalic.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-BlackItalic.ttf")'
     ),
 
 

--- a/ArticleTemplates/assets/scss/helpers/_variables.scss
+++ b/ArticleTemplates/assets/scss/helpers/_variables.scss
@@ -1,5 +1,5 @@
 // Fonts
-$egyptian-display: 'Guardian Headline Web', 'Guardian Egyptian Web', Georgia, serif;
+$egyptian-display: 'Guardian Headline', 'Guardian Egyptian Web', Georgia, serif;
 $egyptian-text: 'Guardian Text Egyptian Web', Georgia, serif;
 $titlepiece: 'Titlepiece', 'Guardian Egyptian Web', sans-serif;
 $agate-sans: 'Guardian Agate Sans 1 Web', sans-serif;

--- a/ArticleTemplates/assets/scss/helpers/_variables.scss
+++ b/ArticleTemplates/assets/scss/helpers/_variables.scss
@@ -1,5 +1,5 @@
 // Fonts
-$egyptian-display: 'Guardian Agaate Sans Web', 'Guardian Egyptian Web', Georgia, serif;
+$egyptian-display: 'Guardian Headline Web', 'Guardian Egyptian Web', Georgia, serif;
 $egyptian-text: 'Guardian Text Egyptian Web', Georgia, serif;
 $titlepiece: 'Titlepiece', 'Guardian Egyptian Web', sans-serif;
 $agate-sans: 'Guardian Agate Sans 1 Web', sans-serif;


### PR DESCRIPTION
We're no longer using the `agaate` font files. This PR update the app's templates to use the correct file names.