### PR TITLE
Fixes unreadable immersive headlines on large tablet

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-type/_immersive.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_immersive.scss
@@ -158,6 +158,7 @@
             }
 
             @include mq($from: col4) {
+                background-color: transparent;
                 margin: 0 auto;
                 max-width: 1200px;
                 padding: {

--- a/ArticleTemplates/assets/scss/garnett-type/_immersive.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_immersive.scss
@@ -140,7 +140,7 @@
             }
         }
 
-        &__headline {
+        &__headline.headline {
             color: color(shade-7);
             font-size: 3.5rem;
             line-height: 1.04;


### PR DESCRIPTION
Removes a white background from immersive headlines that was making them unreadable.