### PR TITLE
Comment headline & meta tweaks

### DIFF
--- a/ArticleTemplates/articleTemplateContainerComment.html
+++ b/ArticleTemplates/articleTemplateContainerComment.html
@@ -30,10 +30,10 @@
                 <div class="meta__misc">
                     <div class="meta__published__comments">__COMMENT_CTA__</div>
                     <p class="meta__pubdate hide-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">__PUBDATE__</span></p>
-                    __ALERTS__
                     <div class='meta__published show-garnett'>
                         <div class="meta__published__date show-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">__PUBDATE__</span></div>
                     </div>
+                    __ALERTS__
                 </div>
             </div>
 

--- a/ArticleTemplates/assets/scss/garnett-modules/content/_meta.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/content/_meta.scss
@@ -101,11 +101,12 @@
             display: block;
             margin: base-px(0, -.5, 0, 0);
             padding: base-px(2, .5, .5, 1);
+            min-width: 36px;
         }
         [data-icon] {
             position: absolute;
             top: 0;
-            right: base-px(.4);
+            right: 4px;
         }
         .screen-readable {
             max-width: 0;

--- a/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
@@ -101,13 +101,6 @@
         }
     }
 
-    // Comment overrides
-    &.garnett--type-comment {
-        .headline {
-            font-weight: 400;
-        }
-    }
-
     // Analysis overrides
     &.garnett--type-analysis {
         .headline {
@@ -346,6 +339,7 @@
 
         // Author names
         .byline,
+        .headline__byline,
         .byline__author,
         .byline__author a {
             color: $kicker;

--- a/ArticleTemplates/assets/scss/garnett-type/_comment.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_comment.scss
@@ -1,5 +1,9 @@
 .garnett--type-comment {
 
+    .headline {
+        font-weight: 200;
+    }
+
     .meta {
         padding-top: 0;
         &__misc {

--- a/ArticleTemplates/assets/scss/garnett-type/_comment.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_comment.scss
@@ -45,4 +45,9 @@
             background-image: repeating-linear-gradient(currentColor, currentColor 1px, transparent 1px, transparent 3px);
         }
     }
+
+    .main-media .element-atom {
+        margin-bottom: 0;
+    }
+
 }

--- a/test/garnett-fixture/comment-arts.html
+++ b/test/garnett-fixture/comment-arts.html
@@ -43,7 +43,12 @@
                         <div class="headline__byline"><span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/alex-mckinnon">Alex McKinnon</a></span></div>
                     </h1>
                 </div>
-                <div class="meta" id="meta">
+                <div class="standfirst selectable" id="standfirst">
+                    <div class="standfirst__inner">
+                        <p>Sydney underground station’s repurposed wooden escalators are a charming anachronism in a city too eager to bulldoze its own history</p>
+                    </div>
+                </div>
+                <div class="meta keyline" id="meta">
                     <div class="meta__misc">
                         <div class="meta__published__comments">
                             <div class="comment-count">
@@ -54,6 +59,9 @@
                             </div>
                         </div>
                         <p class="meta__pubdate hide-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">04:41 GMT Tuesday, 05 December 2017</span></p>
+                        <div class='meta__published show-garnett'>
+                            <div class="meta__published__date show-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">04:41 GMT Tuesday, 05 December 2017</span></div>
+                        </div>
                         <a class="alerts " href="x-gu://follow/tag-contributor///profile/alex-mckinnon" data-follow-alert-id="tag-contributor///profile/alex-mckinnon">
                         <span class="alerts__state--unfollow">
                         <span data-icon="&#xe087;" aria-hidden="true"></span>
@@ -64,9 +72,6 @@
                         <span class="alerts__label">Following Alex McKinnon</span>
                         </span>
                         </a>
-                        <div class='meta__published show-garnett'>
-                            <div class="meta__published__date show-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">04:41 GMT Tuesday, 05 December 2017</span></div>
-                        </div>
                     </div>
                 </div>
                 <div class="main-media" id="main-media">
@@ -86,11 +91,6 @@
                             </div>
                         </div>
                     </figure>
-                </div>
-                <div class="standfirst selectable" id="standfirst">
-                    <div class="standfirst__inner">
-                        <p>Sydney underground station’s repurposed wooden escalators are a charming anachronism in a city too eager to bulldoze its own history</p>
-                    </div>
                 </div>
             </div>
             <div class="article__body" id="comment-body">
@@ -151,7 +151,7 @@
                     Related Stories
                 </h2>
                 <div class="loading loading--related" data-icon="&#xe00C;">
-                    
+
                 </div>
                 <div class="block block--failed" id="related-module-failed-block">
                     <div class="block__body">
@@ -192,7 +192,7 @@
                         </p>
                     </div>
                     <div class="comments__block comments__block--loading loading" data-icon="&#xe00C;">
-                        
+
                     </div>
                 </div>
                 <div class="comments__footer">
@@ -207,7 +207,7 @@
             (function () {
                 var atoms = {};
                 function readAtoms() {
-            
+
                 }
                 readAtoms.call(atoms);
                 GU.bootstrap.init({

--- a/test/garnett-fixture/comment-lifestyle.html
+++ b/test/garnett-fixture/comment-lifestyle.html
@@ -37,7 +37,12 @@
                         <div class="headline__byline"><span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/adaora-udoj">Adaora Udoji</a></span></div>
                     </h1>
                 </div>
-                <div class="meta" id="meta">
+                <div class="standfirst selectable" id="standfirst">
+                    <div class="standfirst__inner">
+                        <p>A recent investigative report by New York magazine found a pattern of bullying of the show’s co-hosts. It’s time leadership is held accountable</p>
+                    </div>
+                </div>
+                <div class="meta keyline" id="meta">
                     <div class="meta__misc">
                         <div class="meta__published__comments">
                             <div class="comment-count">
@@ -48,6 +53,9 @@
                             </div>
                         </div>
                         <p class="meta__pubdate hide-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">16:56 GMT Wednesday, 06 December 2017</span></p>
+                        <div class='meta__published show-garnett'>
+                            <div class="meta__published__date show-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">16:56 GMT Wednesday, 06 December 2017</span></div>
+                        </div>
                         <a class="alerts " href="x-gu://follow/tag-contributor///profile/adaora-udoj" data-follow-alert-id="tag-contributor///profile/adaora-udoj">
                         <span class="alerts__state--unfollow">
                         <span data-icon="&#xe087;" aria-hidden="true"></span>
@@ -58,14 +66,6 @@
                         <span class="alerts__label">Following Adaora Udoji</span>
                         </span>
                         </a>
-                        <div class='meta__published show-garnett'>
-                            <div class="meta__published__date show-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">16:56 GMT Wednesday, 06 December 2017</span></div>
-                        </div>
-                    </div>
-                </div>
-                <div class="standfirst selectable" id="standfirst">
-                    <div class="standfirst__inner">
-                        <p>A recent investigative report by New York magazine found a pattern of bullying of the show’s co-hosts. It’s time leadership is held accountable</p>
                     </div>
                 </div>
                 <div class="main-media" id="main-media">

--- a/test/garnett-fixture/comment-news.html
+++ b/test/garnett-fixture/comment-news.html
@@ -58,6 +58,9 @@
                             </div>
                         </div>
                         <p class="meta__pubdate hide-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">06:50 GMT Tuesday, 05 December 2017</span></p>
+                        <div class='meta__published show-garnett'>
+                            <div class="meta__published__date show-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">06:50 GMT Tuesday, 05 December 2017</span></div>
+                        </div>
                         <a class="alerts " href="x-gu://follow/tag-contributor///profile/jonathanwolff" data-follow-alert-id="tag-contributor///profile/jonathanwolff">
                         <span class="alerts__state--unfollow">
                         <span data-icon="&#xe087;" aria-hidden="true"></span>
@@ -68,9 +71,6 @@
                         <span class="alerts__label">Following Jonathan Wolff</span>
                         </span>
                         </a>
-                        <div class='meta__published show-garnett'>
-                            <div class="meta__published__date show-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">06:50 GMT Tuesday, 05 December 2017</span></div>
-                        </div>
                     </div>
                 </div>
                 <div class="main-media" id="main-media">

--- a/test/garnett-fixture/comment-opinion-nocutout.html
+++ b/test/garnett-fixture/comment-opinion-nocutout.html
@@ -51,6 +51,9 @@
                             </div>
                         </div>
                         <p class="meta__pubdate hide-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">06:00 GMT Thursday, 07 December 2017</span></p>
+                        <div class='meta__published show-garnett'>
+                            <div class="meta__published__date show-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">06:00 GMT Thursday, 07 December 2017</span></div>
+                        </div>
                         <a class="alerts " href="x-gu://follow/tag-contributor///profile/bex-bailey" data-follow-alert-id="tag-contributor///profile/bex-bailey">
                         <span class="alerts__state--unfollow">
                         <span data-icon="&#xe087;" aria-hidden="true"></span>
@@ -61,9 +64,6 @@
                         <span class="alerts__label">Following Bex Bailey</span>
                         </span>
                         </a>
-                        <div class='meta__published show-garnett'>
-                            <div class="meta__published__date show-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">06:00 GMT Thursday, 07 December 2017</span></div>
-                        </div>
                     </div>
                 </div>
                 <div class="main-media" id="main-media">

--- a/test/garnett-fixture/comment-opinion.html
+++ b/test/garnett-fixture/comment-opinion.html
@@ -60,6 +60,9 @@
                             </div>
                         </div>
                         <p class="meta__pubdate hide-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">06:00 GMT Thursday, 16 November 2017</span></p>
+                        <div class='meta__published show-garnett'>
+                            <div class="meta__published__date show-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">06:00 GMT Thursday, 16 November 2017</span></div>
+                        </div>
                         <a class="alerts " href="x-gu://follow/tag-contributor///profile/owen-jones" data-follow-alert-id="tag-contributor///profile/owen-jones">
                         <span class="alerts__state--unfollow">
                         <span data-icon="&#xe087;" aria-hidden="true"></span>
@@ -70,9 +73,6 @@
                         <span class="alerts__label">Following Owen Jones</span>
                         </span>
                         </a>
-                        <div class='meta__published show-garnett'>
-                            <div class="meta__published__date show-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">06:00 GMT Thursday, 16 November 2017</span></div>
-                        </div>
                     </div>
                 </div>
                 <div class="main-media" id="main-media">

--- a/test/garnett-fixture/comment-sport.html
+++ b/test/garnett-fixture/comment-sport.html
@@ -58,6 +58,9 @@
                             </div>
                         </div>
                         <p class="meta__pubdate hide-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">10:00 GMT Wednesday, 06 December 2017</span></p>
+                        <div class='meta__published show-garnett'>
+                            <div class="meta__published__date show-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">10:00 GMT Wednesday, 06 December 2017</span></div>
+                        </div>
                         <a class="alerts " href="x-gu://follow/tag-contributor///profile/barneyronay" data-follow-alert-id="tag-contributor///profile/barneyronay">
                         <span class="alerts__state--unfollow">
                         <span data-icon="&#xe087;" aria-hidden="true"></span>
@@ -68,9 +71,6 @@
                         <span class="alerts__label">Following Barney Ronay</span>
                         </span>
                         </a>
-                        <div class='meta__published show-garnett'>
-                            <div class="meta__published__date show-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">10:00 GMT Wednesday, 06 December 2017</span></div>
-                        </div>
                     </div>
                 </div>
                 <div class="main-media" id="main-media">


### PR DESCRIPTION
* moves timestamp above the alerts button in comment articles
* tidies up comment fixtures to reflect this and some past changes
* makes the comment headline light, and colours the byline even when there's no link
* tidies up comment count alignment