### PR TITLE
Update main media caption styles

### DIFF
--- a/ArticleTemplates/articleTemplateContainer.html
+++ b/ArticleTemplates/articleTemplateContainer.html
@@ -10,6 +10,10 @@
                 </div>
             </div>
 
+            <div class="main-media main-media--hidden-caption" id="main-media">
+                __MAIN_MEDIA__
+            </div>
+
             <div class="article-kicker show-garnett">
                 <div class='article-kicker__section'>__SECTION__</div>
                 <div class='article-kicker__series'>__SERIES__</div>
@@ -19,10 +23,6 @@
 
             <div class="standfirst selectable">
                 <div class="standfirst__inner">__STANDFIRST__</div>
-            </div>
-
-            <div class="main-media main-media--hidden-caption" id="main-media">
-                __MAIN_MEDIA__
             </div>
 
             <div class="meta keyline-4" id="meta">

--- a/ArticleTemplates/articleTemplateContainer.html
+++ b/ArticleTemplates/articleTemplateContainer.html
@@ -21,7 +21,7 @@
                 <div class="standfirst__inner">__STANDFIRST__</div>
             </div>
 
-            <div class="main-media" id="main-media">
+            <div class="main-media main-media--hidden-caption" id="main-media">
                 __MAIN_MEDIA__
             </div>
 

--- a/ArticleTemplates/articleTemplateContainerComment.html
+++ b/ArticleTemplates/articleTemplateContainerComment.html
@@ -37,7 +37,7 @@
                 </div>
             </div>
 
-            <div class="main-media" id="main-media">
+            <div class="main-media main-media--hidden-caption" id="main-media">
                 __MAIN_MEDIA__
             </div>
 

--- a/ArticleTemplates/assets/scss/garnett-layout/_article.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_article.scss
@@ -39,7 +39,7 @@
 
     .standfirst {
         &__inner {
-            padding: base-px(.5, 1, 1.5, 1);
+            padding: base-px(.5, 1, .5, 1);
         }
 
         &__inner:empty {

--- a/ArticleTemplates/assets/scss/garnett-modules/content/_main-media.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/content/_main-media.scss
@@ -111,8 +111,8 @@
     .main-media__caption__icon {
         line-height: 30px;
         text-align: center;
-        background-color: rgba(0, 0, 0, .33);
-        color: color(tone-8);
+        background-color: rgba(0, 0, 0, .5);
+        color: color(shade-8);
         width: 32px;
         height: 32px;
         display: inline-block;
@@ -122,8 +122,9 @@
         border-radius: 100%;
         z-index: 11;
 
+        &:hover,
         &:active {
-            background-color: rgba(0, 0, 0, .8);
+            background-color: color(shade-1);
         }
     }
 

--- a/ArticleTemplates/assets/scss/garnett-modules/content/_main-media.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/content/_main-media.scss
@@ -146,6 +146,7 @@
         &.is-visible {
             @extend %screen-visable;
             position: absolute;
+            left: 0;
             display: block;
             min-height: 44px;
             max-height: 999px;

--- a/ArticleTemplates/assets/scss/garnett-modules/content/_standfirst.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/content/_standfirst.scss
@@ -24,4 +24,9 @@
     b {
         font-weight: 400;
     }
+
+    p:last-child a:last-child {
+        display: inline-block;
+        margin-bottom: base-px(.25);
+    }
 }

--- a/test/garnett-fixture/analysis-news-specialreport.html
+++ b/test/garnett-fixture/analysis-news-specialreport.html
@@ -27,21 +27,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="article-kicker show-garnett">
-                    <div class='article-kicker__section'>politics</div>
-                    <div class='article-kicker__series'><a href="x-gu://list/mobile.guardianapis.com/lists/tag/news/series/panama-papers">Panama Papers: a special investigation</a></div>
-                </div>
-                <h1 class="headline selectable" id="headline">Where does David Cameron’s money come from? </h1>
-                <div class="standfirst selectable">
-                    <div class="standfirst__inner">
-                        <p>In the wake of Panama Papers disclosures, the prime minister has been fending off questions about his finances. Analysis shows his wealth is derived from a network of inherited wealth and family companies</p>
-                        <ul>
-                            <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/news/2016/apr/07/david-cameron-admits-he-profited-fathers-offshore-fund-panama-papers">David Cameron admits he profited from father’s offshore fund</a><br /></li>
-                            <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/news/2016/apr/07/banks-must-declare-links-panama-papers-law-firm-mossack-fonseca">Banks told to declare links to Mossack Fonseca by next week</a></li>
-                            <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/world/2016/apr/06/panama-papers-all-revelations-so-far-data-leak">All the Guardian’s Panama Papers revelations so far</a></li>
-                        </ul>
-                    </div>
-                </div>
                 <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 59.994072%;">
@@ -57,6 +42,21 @@
                             </p>
                         </figcaption>
                     </figure>
+                </div>
+                <div class="article-kicker show-garnett">
+                    <div class='article-kicker__section'>politics</div>
+                    <div class='article-kicker__series'><a href="x-gu://list/mobile.guardianapis.com/lists/tag/news/series/panama-papers">Panama Papers: a special investigation</a></div>
+                </div>
+                <h1 class="headline selectable" id="headline">Where does David Cameron’s money come from? </h1>
+                <div class="standfirst selectable">
+                    <div class="standfirst__inner">
+                        <p>In the wake of Panama Papers disclosures, the prime minister has been fending off questions about his finances. Analysis shows his wealth is derived from a network of inherited wealth and family companies</p>
+                        <ul>
+                            <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/news/2016/apr/07/david-cameron-admits-he-profited-fathers-offshore-fund-panama-papers">David Cameron admits he profited from father’s offshore fund</a><br /></li>
+                            <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/news/2016/apr/07/banks-must-declare-links-panama-papers-law-firm-mossack-fonseca">Banks told to declare links to Mossack Fonseca by next week</a></li>
+                            <li><a href="x-gu://item/mobile.guardianapis.com/uk/items/world/2016/apr/06/panama-papers-all-revelations-so-far-data-leak">All the Guardian’s Panama Papers revelations so far</a></li>
+                        </ul>
+                    </div>
                 </div>
                 <div class="meta keyline-4" id="meta">
                     <div class="meta__misc">

--- a/test/garnett-fixture/analysis-news-specialreport.html
+++ b/test/garnett-fixture/analysis-news-specialreport.html
@@ -42,7 +42,7 @@
                         </ul>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 59.994072%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/152a9c6667a2ff39f7cec3eaef55f4e1ddb89f0f/0_131_3372_2023/master/3372.jpg/ea7b765832e137ec80e26a3ba4dfa2ce?width=750&height=-&quality=35">
@@ -145,7 +145,7 @@
                     Related Stories
                 </h2>
                 <div class="loading loading--related" data-icon="&#xe00C;">
-                    
+
                 </div>
                 <div class="block block--failed" id="related-module-failed-block">
                     <div class="block__body">
@@ -164,7 +164,7 @@
             (function () {
                 var atoms = {};
                 function readAtoms() {
-            
+
                 }
                 readAtoms.call(atoms);
                 GU.bootstrap.init({

--- a/test/garnett-fixture/analysis-news-video.html
+++ b/test/garnett-fixture/analysis-news-video.html
@@ -37,7 +37,7 @@
                         <p>The chancellor’s untimely slip carried echoes of Lamont’s remark that people out of work was a price worth paying</p>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-atom" data-atom-id="173a55a3-fca5-4c5c-82e6-69cefadf8e94" data-atom-type="media">
                         <div class="element element-video element-youtube __YOUTUBE_MEDIA_SDK_CLASS_NAME__">
                             <div style="font-size:0" class="element__inner">
@@ -116,7 +116,7 @@
                     Related Stories
                 </h2>
                 <div class="loading loading--related" data-icon="&#xe00C;">
-                    
+
                 </div>
                 <div class="block block--failed" id="related-module-failed-block">
                     <div class="block__body">
@@ -135,7 +135,7 @@
             (function () {
                 var atoms = {};
                 function readAtoms() {
-            
+
                 }
                 readAtoms.call(atoms);
                 GU.bootstrap.init({

--- a/test/garnett-fixture/analysis-news-video.html
+++ b/test/garnett-fixture/analysis-news-video.html
@@ -27,16 +27,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="article-kicker show-garnett">
-                    <div class='article-kicker__section'>politics</div>
-                    <div class='article-kicker__series'></div>
-                </div>
-                <h1 class="headline selectable" id="headline">Hammond's 'no unemployed' gaffe fuels belief that Tories don't care </h1>
-                <div class="standfirst selectable">
-                    <div class="standfirst__inner">
-                        <p>The chancellor’s untimely slip carried echoes of Lamont’s remark that people out of work was a price worth paying</p>
-                    </div>
-                </div>
                 <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-atom" data-atom-id="173a55a3-fca5-4c5c-82e6-69cefadf8e94" data-atom-type="media">
                         <div class="element element-video element-youtube __YOUTUBE_MEDIA_SDK_CLASS_NAME__">
@@ -54,6 +44,16 @@
                             </div>
                         </div>
                     </figure>
+                </div>
+                <div class="article-kicker show-garnett">
+                    <div class='article-kicker__section'>politics</div>
+                    <div class='article-kicker__series'></div>
+                </div>
+                <h1 class="headline selectable" id="headline">Hammond's 'no unemployed' gaffe fuels belief that Tories don't care </h1>
+                <div class="standfirst selectable">
+                    <div class="standfirst__inner">
+                        <p>The chancellor’s untimely slip carried echoes of Lamont’s remark that people out of work was a price worth paying</p>
+                    </div>
                 </div>
                 <div class="meta keyline-4" id="meta">
                     <div class="meta__misc">

--- a/test/garnett-fixture/analysis-news.html
+++ b/test/garnett-fixture/analysis-news.html
@@ -39,7 +39,7 @@
                         <p>The 21st century’s new global superpower is not just Zimbabwe’s ‘all-weather friend’ and top trade partner, close ties go back to the 1970s liberation era </p>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.000004%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/1e54cc731d62bb089d4b74f70d51a0663ee5bcc6/0_62_3000_1800/master/3000.jpg/8d3bd2a238a5bf54317d9c401763dbac?width=750&height=-&quality=35">
@@ -94,7 +94,7 @@
                     <figure class="element element-atom" data-atom-id="0520eec7-cc8a-4035-b3a6-7ce27de8d998" data-atom-type="timeline">
                         <details data-snippet-id="0520eec7-cc8a-4035-b3a6-7ce27de8d998" data-snippet-type="timeline" class="atom atom--snippet atom--snippet--timeline">
                             <summary class="atom--snippet__header">
-                                <span class="atom--snippet__label">Timeline</span> 
+                                <span class="atom--snippet__label">Timeline</span>
                                 <h4 class="atom--snippet__headline">Zimbabwe timeline: the week that led to Mugabe's detention</h4>
                                 <button class="atom__button atom__button--large atom__button--rounded atom--snippet__handle" aria-hidden="true">
                                     <span class="is-on">
@@ -189,7 +189,7 @@
                     <figure class="element element-atom" data-atom-id="831d9119-a65a-43ca-a6e3-aaa0677d07bb" data-atom-type="profile">
                         <details data-snippet-id="831d9119-a65a-43ca-a6e3-aaa0677d07bb" data-snippet-type="profile" class="atom atom--snippet atom--snippet--profile">
                             <summary class="atom--snippet__header">
-                                <span class="atom--snippet__label">Profile</span> 
+                                <span class="atom--snippet__label">Profile</span>
                                 <h4 class="atom--snippet__headline">Who is Emmerson Mnangagwa?</h4>
                                 <button class="atom__button atom__button--large atom__button--rounded atom--snippet__handle" aria-hidden="true">
                                     <span class="is-on">
@@ -272,7 +272,7 @@
                     Related Stories
                 </h2>
                 <div class="loading loading--related" data-icon="&#xe00C;">
-                    
+
                 </div>
                 <div class="block block--failed" id="related-module-failed-block">
                     <div class="block__body">

--- a/test/garnett-fixture/analysis-news.html
+++ b/test/garnett-fixture/analysis-news.html
@@ -29,16 +29,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="article-kicker show-garnett">
-                    <div class='article-kicker__section'>world</div>
-                    <div class='article-kicker__series'></div>
-                </div>
-                <h1 class="headline selectable" id="headline">Zimbabwe: was Mugabe's fall a result of China flexing its muscle? </h1>
-                <div class="standfirst selectable">
-                    <div class="standfirst__inner">
-                        <p>The 21st century’s new global superpower is not just Zimbabwe’s ‘all-weather friend’ and top trade partner, close ties go back to the 1970s liberation era </p>
-                    </div>
-                </div>
                 <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.000004%;">
@@ -54,6 +44,16 @@
                             </p>
                         </figcaption>
                     </figure>
+                </div>
+                <div class="article-kicker show-garnett">
+                    <div class='article-kicker__section'>world</div>
+                    <div class='article-kicker__series'></div>
+                </div>
+                <h1 class="headline selectable" id="headline">Zimbabwe: was Mugabe's fall a result of China flexing its muscle? </h1>
+                <div class="standfirst selectable">
+                    <div class="standfirst__inner">
+                        <p>The 21st century’s new global superpower is not just Zimbabwe’s ‘all-weather friend’ and top trade partner, close ties go back to the 1970s liberation era </p>
+                    </div>
                 </div>
                 <div class="meta keyline-4" id="meta">
                     <div class="meta__misc">

--- a/test/garnett-fixture/analysis-opinion.html
+++ b/test/garnett-fixture/analysis-opinion.html
@@ -41,7 +41,7 @@
                 <div class="standfirst selectable">
                     <div class="standfirst__inner">Egypt’s recent history shows that indiscriminate military responses to terror only escalate the situation</div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 59.981770%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/e171cbc248fb66e657fc5fe352a2c04b74f4ae37/158_0_2194_1316/master/2194.jpg/b883bd5bbc0a0c558f9369ab9f96f8a6?width=750&height=-&quality=35">
@@ -117,7 +117,7 @@
                     Related Stories
                 </h2>
                 <div class="loading loading--related" data-icon="&#xe00C;">
-                    
+
                 </div>
                 <div class="block block--failed" id="related-module-failed-block">
                     <div class="block__body">
@@ -158,7 +158,7 @@
                         </p>
                     </div>
                     <div class="comments__block comments__block--loading loading" data-icon="&#xe00C;">
-                        
+
                     </div>
                 </div>
                 <div class="comments__footer">
@@ -173,7 +173,7 @@
             (function () {
                 var atoms = {};
                 function readAtoms() {
-            
+
                 }
                 readAtoms.call(atoms);
                 GU.bootstrap.init({

--- a/test/garnett-fixture/analysis-opinion.html
+++ b/test/garnett-fixture/analysis-opinion.html
@@ -33,14 +33,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="article-kicker show-garnett">
-                    <div class='article-kicker__section'>opinion</div>
-                    <div class='article-kicker__series'></div>
-                </div>
-                <h1 class="headline selectable" id="headline">The ‘iron fist’ response to terror attacks in Egypt never works </h1>
-                <div class="standfirst selectable">
-                    <div class="standfirst__inner">Egypt’s recent history shows that indiscriminate military responses to terror only escalate the situation</div>
-                </div>
                 <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 59.981770%;">
@@ -56,6 +48,14 @@
                             </p>
                         </figcaption>
                     </figure>
+                </div>
+                <div class="article-kicker show-garnett">
+                    <div class='article-kicker__section'>opinion</div>
+                    <div class='article-kicker__series'></div>
+                </div>
+                <h1 class="headline selectable" id="headline">The ‘iron fist’ response to terror attacks in Egypt never works </h1>
+                <div class="standfirst selectable">
+                    <div class="standfirst__inner">Egypt’s recent history shows that indiscriminate military responses to terror only escalate the situation</div>
                 </div>
                 <div class="meta keyline-4" id="meta">
                     <div class="meta__misc">

--- a/test/garnett-fixture/article-arts.html
+++ b/test/garnett-fixture/article-arts.html
@@ -43,7 +43,7 @@
                         <p>The neo-soul singer described the award, previously won by Adele and Sam Smith, as ‘such a special way to end the year’</p>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 59.989994%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/0f9a1179a321d571b31f041c4b137ee1c33bb818/664_921_3999_2399/master/3999.jpg/e34c00e0f6368a76c0dea966a786c2c3?width=750&height=-&quality=35">
@@ -117,7 +117,7 @@
                     Related Stories
                 </h2>
                 <div class="loading loading--related" data-icon="&#xe00C;">
-                    
+
                 </div>
                 <div class="block block--failed" id="related-module-failed-block">
                     <div class="block__body">
@@ -158,7 +158,7 @@
                         </p>
                     </div>
                     <div class="comments__block comments__block--loading loading" data-icon="&#xe00C;">
-                        
+
                     </div>
                 </div>
                 <div class="comments__footer">
@@ -173,7 +173,7 @@
             (function () {
                 var atoms = {};
                 function readAtoms() {
-            
+
                 }
                 readAtoms.call(atoms);
                 GU.bootstrap.init({

--- a/test/garnett-fixture/article-arts.html
+++ b/test/garnett-fixture/article-arts.html
@@ -33,16 +33,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="article-kicker show-garnett">
-                    <div class='article-kicker__section'>music</div>
-                    <div class='article-kicker__series'></div>
-                </div>
-                <h1 class="headline selectable" id="headline">Jorja Smith wins 2018 Brits critics' choice award </h1>
-                <div class="standfirst selectable">
-                    <div class="standfirst__inner">
-                        <p>The neo-soul singer described the award, previously won by Adele and Sam Smith, as ‘such a special way to end the year’</p>
-                    </div>
-                </div>
                 <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 59.989994%;">
@@ -58,6 +48,16 @@
                             </p>
                         </figcaption>
                     </figure>
+                </div>
+                <div class="article-kicker show-garnett">
+                    <div class='article-kicker__section'>music</div>
+                    <div class='article-kicker__series'></div>
+                </div>
+                <h1 class="headline selectable" id="headline">Jorja Smith wins 2018 Brits critics' choice award </h1>
+                <div class="standfirst selectable">
+                    <div class="standfirst__inner">
+                        <p>The neo-soul singer described the award, previously won by Adele and Sam Smith, as ‘such a special way to end the year’</p>
+                    </div>
                 </div>
                 <div class="meta keyline-4" id="meta">
                     <div class="meta__misc">

--- a/test/garnett-fixture/article-lifestyle.html
+++ b/test/garnett-fixture/article-lifestyle.html
@@ -27,16 +27,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="article-kicker show-garnett">
-                    <div class='article-kicker__section'>lifestyle</div>
-                    <div class='article-kicker__series'></div>
-                </div>
-                <h1 class="headline selectable" id="headline">Only amateurs here? A day in Ethiopia's exercise hub </h1>
-                <div class="standfirst selectable">
-                    <div class="standfirst__inner">
-                        <p>I came to Adis Abbaba to run on the terraces of this crescent-shaped ‘square’. But, in the shadow of Haile Gebrselassie, I couldn’t see the locals for dust</p>
-                    </div>
-                </div>
                 <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.019840%;">
@@ -52,6 +42,16 @@
                             </p>
                         </figcaption>
                     </figure>
+                </div>
+                <div class="article-kicker show-garnett">
+                    <div class='article-kicker__section'>lifestyle</div>
+                    <div class='article-kicker__series'></div>
+                </div>
+                <h1 class="headline selectable" id="headline">Only amateurs here? A day in Ethiopia's exercise hub </h1>
+                <div class="standfirst selectable">
+                    <div class="standfirst__inner">
+                        <p>I came to Adis Abbaba to run on the terraces of this crescent-shaped ‘square’. But, in the shadow of Haile Gebrselassie, I couldn’t see the locals for dust</p>
+                    </div>
                 </div>
                 <div class="meta keyline-4" id="meta">
                     <div class="meta__misc">

--- a/test/garnett-fixture/article-lifestyle.html
+++ b/test/garnett-fixture/article-lifestyle.html
@@ -37,7 +37,7 @@
                         <p>I came to Adis Abbaba to run on the terraces of this crescent-shaped ‘square’. But, in the shadow of Haile Gebrselassie, I couldn’t see the locals for dust</p>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.019840%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/8e6aef5d9e0328d8130692e84d6aab17dcde0bef/0_348_4032_2420/master/4032.jpg/4d18023a91ef0d009f3e3adcd69de3e3?width=750&height=-&quality=35">
@@ -143,7 +143,7 @@
                     Related Stories
                 </h2>
                 <div class="loading loading--related" data-icon="&#xe00C;">
-                    
+
                 </div>
                 <div class="block block--failed" id="related-module-failed-block">
                     <div class="block__body">
@@ -162,7 +162,7 @@
             (function () {
                 var atoms = {};
                 function readAtoms() {
-            
+
                 }
                 readAtoms.call(atoms);
                 GU.bootstrap.init({

--- a/test/garnett-fixture/article-news-specialreport.html
+++ b/test/garnett-fixture/article-news-specialreport.html
@@ -27,16 +27,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="article-kicker show-garnett">
-                    <div class='article-kicker__section'>film</div>
-                    <div class='article-kicker__series'><a href="x-gu://list/mobile.guardianapis.com/lists/tag/news/series/panama-papers">Panama Papers: a special investigation</a></div>
-                </div>
-                <h1 class="headline selectable" id="headline">Pedro Almodóvar on Panama Papers: I'm one of the least important names cited </h1>
-                <div class="standfirst selectable">
-                    <div class="standfirst__inner">
-                        <p>The director claimed that the Spanish press have overplayed his role in the leak and that more investigation is needed – as well as describing himself as a ‘housewife’ and ‘not a sacred cow’</p>
-                    </div>
-                </div>
                 <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.026043%;">
@@ -52,6 +42,16 @@
                             </p>
                         </figcaption>
                     </figure>
+                </div>
+                <div class="article-kicker show-garnett">
+                    <div class='article-kicker__section'>film</div>
+                    <div class='article-kicker__series'><a href="x-gu://list/mobile.guardianapis.com/lists/tag/news/series/panama-papers">Panama Papers: a special investigation</a></div>
+                </div>
+                <h1 class="headline selectable" id="headline">Pedro Almodóvar on Panama Papers: I'm one of the least important names cited </h1>
+                <div class="standfirst selectable">
+                    <div class="standfirst__inner">
+                        <p>The director claimed that the Spanish press have overplayed his role in the leak and that more investigation is needed – as well as describing himself as a ‘housewife’ and ‘not a sacred cow’</p>
+                    </div>
                 </div>
                 <div class="meta keyline-4" id="meta">
                     <div class="meta__misc">

--- a/test/garnett-fixture/article-news-specialreport.html
+++ b/test/garnett-fixture/article-news-specialreport.html
@@ -37,7 +37,7 @@
                         <p>The director claimed that the Spanish press have overplayed his role in the leak and that more investigation is needed – as well as describing himself as a ‘housewife’ and ‘not a sacred cow’</p>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.026043%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/5eb47af6840db5362e01173149e9467bd65fa824/0_58_3072_1844/master/3072.jpg/7f9013c91ce36773023f1a1f610e08c8?width=750&height=-&quality=35">
@@ -122,7 +122,7 @@
                     Related Stories
                 </h2>
                 <div class="loading loading--related" data-icon="&#xe00C;">
-                    
+
                 </div>
                 <div class="block block--failed" id="related-module-failed-block">
                     <div class="block__body">
@@ -141,7 +141,7 @@
             (function () {
                 var atoms = {};
                 function readAtoms() {
-            
+
                 }
                 readAtoms.call(atoms);
                 GU.bootstrap.init({

--- a/test/garnett-fixture/article-news.html
+++ b/test/garnett-fixture/article-news.html
@@ -27,16 +27,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="article-kicker show-garnett">
-                    <div class='article-kicker__section'>cities</div>
-                    <div class='article-kicker__series'><a href="x-gu://list/mobile.guardianapis.com/lists/tag/cities/series/sao-paulo-live">São Paulo live</a></div>
-                </div>
-                <h1 class="headline selectable" id="headline">'It's not just extra-rich and extra-poor': Paulistanos respond to São Paulo Live </h1>
-                <div class="standfirst selectable">
-                    <div class="standfirst__inner">
-                        <p>We are grateful to everyone whose ideas and opinions made our weeklong in S&atilde;o Paulo series richer. Here are some of the thoughts – and criticisms – you shared</p>
-                    </div>
-                </div>
+
                 <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.018467%;">
@@ -53,6 +44,18 @@
                         </figcaption>
                     </figure>
                 </div>
+
+                <div class="article-kicker show-garnett">
+                    <div class='article-kicker__section'>cities</div>
+                    <div class='article-kicker__series'><a href="x-gu://list/mobile.guardianapis.com/lists/tag/cities/series/sao-paulo-live">São Paulo live</a></div>
+                </div>
+                <h1 class="headline selectable" id="headline">'It's not just extra-rich and extra-poor': Paulistanos respond to São Paulo Live </h1>
+                <div class="standfirst selectable">
+                    <div class="standfirst__inner">
+                        <p>We are grateful to everyone whose ideas and opinions made our weeklong in S&atilde;o Paulo series richer. Here are some of the thoughts – and criticisms – you shared</p>
+                    </div>
+                </div>
+
                 <div class="meta keyline-4" id="meta">
                     <div class="meta__misc">
                         <div class="meta__published__comments">

--- a/test/garnett-fixture/article-news.html
+++ b/test/garnett-fixture/article-news.html
@@ -37,7 +37,7 @@
                         <p>We are grateful to everyone whose ideas and opinions made our weeklong in S&atilde;o Paulo series richer. Here are some of the thoughts – and criticisms – you shared</p>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.018467%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/1930db3f49bc4af9b55d433e356af3564bc2bb09/126_0_3249_1950/master/3249.jpg/5e032851f30121d847f2e5bbb3e6920e?width=750&height=-&quality=35">
@@ -91,13 +91,13 @@
             <div class="article__body" id="article-body">
                 <div class="from-content-api prose resizable selectable" id="article-body-blocks">
                     <p>“It is a great white concrete dream, or nightmare,” wrote Patrick Semple, a Guardian Cities reader, of S&atilde;o Paulo, his home since February. “It is a fabulous party, infuriating and starkly beautiful. It is more expensive than London, yet people can get by on the street.</p>
-                    <figure class="element element-image" data-media-id="2d8f782da55a7f54b7f3146e7da306752cc7ae29"> 
-                        <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/2d8f782da55a7f54b7f3146e7da306752cc7ae29/0_214_2081_2604/master/2081.jpg/d850f27c8a9308f86ddd153c18287e46?width=#{width}&height=#{height}&quality=#{quality}"><img src="https://media.guim.co.uk/2d8f782da55a7f54b7f3146e7da306752cc7ae29/0_214_2081_2604/799.jpg" alt="At the end of December the Home Office issued this mock-up of what the new passport could look like." width="799" height="1000" class="gu-image" /></a> 
-                        <figcaption> 
-                            <span class="element-image__caption">At the end of December the Home Office issued this mock-up of what the new passport could look like.</span> 
-                            <span class="element-image__credit">Photograph: Home Office/PA</span> 
-                        </figcaption> 
-                    </figure> 
+                    <figure class="element element-image" data-media-id="2d8f782da55a7f54b7f3146e7da306752cc7ae29">
+                        <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/2d8f782da55a7f54b7f3146e7da306752cc7ae29/0_214_2081_2604/master/2081.jpg/d850f27c8a9308f86ddd153c18287e46?width=#{width}&height=#{height}&quality=#{quality}"><img src="https://media.guim.co.uk/2d8f782da55a7f54b7f3146e7da306752cc7ae29/0_214_2081_2604/799.jpg" alt="At the end of December the Home Office issued this mock-up of what the new passport could look like." width="799" height="1000" class="gu-image" /></a>
+                        <figcaption>
+                            <span class="element-image__caption">At the end of December the Home Office issued this mock-up of what the new passport could look like.</span>
+                            <span class="element-image__credit">Photograph: Home Office/PA</span>
+                        </figcaption>
+                    </figure>
                     <p>“It is noisy, all the time: the school day starts at half-past six, the bars close at 3am, music is as ubiquitous as the car fumes. The roads are ruinous. When it rains, rivers erupt in the gutters; when it’s hot they fill up with people. From high up, the city at night looks like God’s chandelier has just crashed to earth.”</p>
                     <aside class="element element-rich-link element--thumbnail">
                         <p> <span>Related: </span><a href="x-gu://item/mobile.guardianapis.com/uk/items/cities/2017/dec/01/sao-paulo-exclusively-for-business-by-business-at-expense-of-urban-poor">S&atilde;o Paulo 'exclusively for business, by business' at expense of urban poor</a> </p>
@@ -239,7 +239,7 @@
                     Related Stories
                 </h2>
                 <div class="loading loading--related" data-icon="&#xe00C;">
-                    
+
                 </div>
                 <div class="block block--failed" id="related-module-failed-block">
                     <div class="block__body">
@@ -258,7 +258,7 @@
             (function () {
                 var atoms = {};
                 function readAtoms() {
-            
+
                 }
                 readAtoms.call(atoms);
                 GU.bootstrap.init({

--- a/test/garnett-fixture/article-sport.html
+++ b/test/garnett-fixture/article-sport.html
@@ -33,19 +33,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="article-kicker show-garnett">
-                    <div class='article-kicker__section'>sport</div>
-                    <div class='article-kicker__series'></div>
-                </div>
-                <h1 class="headline selectable" id="headline">Verstappen says rulemakers 'killing the sport' after 'stupid' penalty </h1>
-                <div class="standfirst selectable">
-                    <div class="standfirst__inner">
-                        <ul>
-                            <li>Verstappen lost podium place after five-second penalty for going off track</li>
-                            <li>Three-time world champion Lauda said penalty the ‘worst I’ve ever seen’</li>
-                        </ul>
-                    </div>
-                </div>
                 <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 59.994663%;">
@@ -61,6 +48,19 @@
                             </p>
                         </figcaption>
                     </figure>
+                </div>
+                <div class="article-kicker show-garnett">
+                    <div class='article-kicker__section'>sport</div>
+                    <div class='article-kicker__series'></div>
+                </div>
+                <h1 class="headline selectable" id="headline">Verstappen says rulemakers 'killing the sport' after 'stupid' penalty </h1>
+                <div class="standfirst selectable">
+                    <div class="standfirst__inner">
+                        <ul>
+                            <li>Verstappen lost podium place after five-second penalty for going off track</li>
+                            <li>Three-time world champion Lauda said penalty the ‘worst I’ve ever seen’</li>
+                        </ul>
+                    </div>
                 </div>
                 <div class="meta keyline-4" id="meta">
                     <div class="meta__misc">

--- a/test/garnett-fixture/article-sport.html
+++ b/test/garnett-fixture/article-sport.html
@@ -46,7 +46,7 @@
                         </ul>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 59.994663%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/abb93774a747dbb13494939feb48a1cdb8b703f9/0_218_3747_2248/master/3747.jpg/932db27731830aaa79c765eba4d53b56?width=750&height=-&quality=35">
@@ -128,7 +128,7 @@
                     Related Stories
                 </h2>
                 <div class="loading loading--related" data-icon="&#xe00C;">
-                    
+
                 </div>
                 <div class="block block--failed" id="related-module-failed-block">
                     <div class="block__body">
@@ -169,7 +169,7 @@
                         </p>
                     </div>
                     <div class="comments__block comments__block--loading loading" data-icon="&#xe00C;">
-                        
+
                     </div>
                 </div>
                 <div class="comments__footer">
@@ -184,7 +184,7 @@
             (function () {
                 var atoms = {};
                 function readAtoms() {
-            
+
                 }
                 readAtoms.call(atoms);
                 GU.bootstrap.init({

--- a/test/garnett-fixture/comment-arts.html
+++ b/test/garnett-fixture/comment-arts.html
@@ -69,7 +69,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-atom" data-atom-id="197b2a03-3886-4eea-9398-2f5f54dca14f" data-atom-type="media">
                         <div class="element element-video element-youtube __YOUTUBE_MEDIA_SDK_CLASS_NAME__">
                             <div style="font-size:0" class="element__inner">
@@ -151,7 +151,7 @@
                     Related Stories
                 </h2>
                 <div class="loading loading--related" data-icon="&#xe00C;">
-                    
+
                 </div>
                 <div class="block block--failed" id="related-module-failed-block">
                     <div class="block__body">
@@ -192,7 +192,7 @@
                         </p>
                     </div>
                     <div class="comments__block comments__block--loading loading" data-icon="&#xe00C;">
-                        
+
                     </div>
                 </div>
                 <div class="comments__footer">
@@ -207,7 +207,7 @@
             (function () {
                 var atoms = {};
                 function readAtoms() {
-            
+
                 }
                 readAtoms.call(atoms);
                 GU.bootstrap.init({

--- a/test/garnett-fixture/comment-lifestyle.html
+++ b/test/garnett-fixture/comment-lifestyle.html
@@ -68,7 +68,7 @@
                         <p>A recent investigative report by New York magazine found a pattern of bullying of the show’s co-hosts. It’s time leadership is held accountable</p>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.000004%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/cbd180f46d3ef21afa33fcfdcb8edbf9367a2b62/0_100_3000_1800/master/3000.jpg/4b179f6d08ea661aa3856d752b3ae5a9?width=750&height=-&quality=35">

--- a/test/garnett-fixture/comment-news.html
+++ b/test/garnett-fixture/comment-news.html
@@ -73,7 +73,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.007973%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/25712f654acaee4e39e3755bcbdfe2690c3d752e/0_465_5016_3010/master/5016.jpg/de970d88828af2b664c220297e40ea91?width=750&height=-&quality=35">

--- a/test/garnett-fixture/comment-opinion-multipleauthors.html
+++ b/test/garnett-fixture/comment-opinion-multipleauthors.html
@@ -63,7 +63,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 59.993034%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/adc1e4630c8ffd76a61b3ffdf7d51ce8a07543b9/789_180_2872_1723/master/2872.jpg/2224cb5f187830427e974e428d27eaae?width=750&height=-&quality=35">

--- a/test/garnett-fixture/comment-opinion-nocutout.html
+++ b/test/garnett-fixture/comment-opinion-nocutout.html
@@ -66,7 +66,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.000004%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/4c03d80b1b26f9b7aef1774af50043a7cc4ecb63/0_844_3500_2100/master/3500.jpg/da07d8acf424a224fec6093539305ece?width=750&height=-&quality=35">

--- a/test/garnett-fixture/comment-opinion.html
+++ b/test/garnett-fixture/comment-opinion.html
@@ -75,7 +75,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.018860%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/f274273e05d362105ef8a28f3e8375976fb565e9/0_69_2121_1273/master/2121.jpg/5deccd087bed2dcf232d4f34510726db?width=750&height=-&quality=35">

--- a/test/garnett-fixture/comment-sport.html
+++ b/test/garnett-fixture/comment-sport.html
@@ -73,7 +73,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.018875%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/c9e2fccab982ee4dd4c3e2bd23c7b3d90b36dd7c/0_231_3179_1908/master/3179.jpg/e4915e118ce842d451dd8ef7a97fdee7?width=750&height=-&quality=35">

--- a/test/garnett-fixture/guardianview-opinion.html
+++ b/test/garnett-fixture/guardianview-opinion.html
@@ -96,7 +96,7 @@
             <div class="standfirst selectable" id="standfirst">
                 <div class="standfirst__inner"><strong>An idea whose time has come:</strong> Over the holiday season the Guardian has been examining themes that have emerged to give shape to 2018. In today’s concluding piece we look at why the world will need the EU more than ever</div>
              </div>
-             <div class="main-media" id="main-media">
+             <div class="main-media main-media--hidden-caption" id="main-media">
                <figure class="element element-image figure-wide">
                   <div class="figure__inner">
                      <div class="element__inner" style="padding-bottom: 60%;">

--- a/test/garnett-fixture/recipe-lifestyle.html
+++ b/test/garnett-fixture/recipe-lifestyle.html
@@ -43,7 +43,7 @@
                         <p>Bao seem to be everywhere right now, thanks both to the street food revolution and social media, so here’s a vegan take on this very tasty filled bun</p>
                     </div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.005386%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/48b15bcae3ff2ec920818a2059459fb4fda6dd95/0_570_3713_2228/master/3713.jpg/bf3ad8c77497396776cd9f398e629373?width=750&height=-&quality=35">
@@ -123,7 +123,7 @@
                     Related Stories
                 </h2>
                 <div class="loading loading--related" data-icon="&#xe00C;">
-                    
+
                 </div>
                 <div class="block block--failed" id="related-module-failed-block">
                     <div class="block__body">
@@ -164,7 +164,7 @@
                         </p>
                     </div>
                     <div class="comments__block comments__block--loading loading" data-icon="&#xe00C;">
-                        
+
                     </div>
                 </div>
                 <div class="comments__footer">
@@ -179,7 +179,7 @@
             (function () {
                 var atoms = {};
                 function readAtoms() {
-            
+
                 }
                 readAtoms.call(atoms);
                 GU.bootstrap.init({

--- a/test/garnett-fixture/recipe-lifestyle.html
+++ b/test/garnett-fixture/recipe-lifestyle.html
@@ -33,16 +33,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="article-kicker show-garnett">
-                    <div class='article-kicker__section'>lifestyle</div>
-                    <div class='article-kicker__series'><a href="x-gu://list/mobile.guardianapis.com/lists/tag/lifeandstyle/series/the-new-vegan">The new vegan</a></div>
-                </div>
-                <h1 class="headline selectable" id="headline">Meera Sodha’s recipe for vegan mushroom bao </h1>
-                <div class="standfirst selectable">
-                    <div class="standfirst__inner">
-                        <p>Bao seem to be everywhere right now, thanks both to the street food revolution and social media, so here’s a vegan take on this very tasty filled bun</p>
-                    </div>
-                </div>
                 <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.005386%;">
@@ -58,6 +48,16 @@
                             </p>
                         </figcaption>
                     </figure>
+                </div>
+                <div class="article-kicker show-garnett">
+                    <div class='article-kicker__section'>lifestyle</div>
+                    <div class='article-kicker__series'><a href="x-gu://list/mobile.guardianapis.com/lists/tag/lifeandstyle/series/the-new-vegan">The new vegan</a></div>
+                </div>
+                <h1 class="headline selectable" id="headline">Meera Sodha’s recipe for vegan mushroom bao </h1>
+                <div class="standfirst selectable">
+                    <div class="standfirst__inner">
+                        <p>Bao seem to be everywhere right now, thanks both to the street food revolution and social media, so here’s a vegan take on this very tasty filled bun</p>
+                    </div>
                 </div>
                 <div class="meta keyline-4" id="meta">
                     <div class="meta__misc">

--- a/test/garnett-fixture/review-opinion.html
+++ b/test/garnett-fixture/review-opinion.html
@@ -72,7 +72,7 @@
                 <div class="standfirst selectable" id="standfirst">
                     <div class="standfirst__inner">There's a lot of talk about the new site where you can essentially make big lists of things and pictures that you like. But what does it look like from the inside?</div>
                 </div>
-                <div class="main-media" id="main-media">
+                <div class="main-media main-media--hidden-caption" id="main-media">
                     <figure class="element element-image figure-wide">
                         <div class="element__inner" style="padding-bottom: 60.000004%;">
                             <a href="x-gu://gallery/https://mobile.guardianapis.com/img/static/sys-images/Guardian/Pix/pictures/2010/4/8/1270745424448/Finn-Juhl-interior-modern-001.jpg/5673bd876aedfe8dd9209caa275a0a8a?width=750&height=-&quality=35">


### PR DESCRIPTION
This uses the feature style `main-media--hidden-caption` on article and comment templates.

**Before**
<img src="https://user-images.githubusercontent.com/4561/35150013-63494594-fd10-11e7-9a6d-317765116131.png" width="375">


**After**
<img src="https://user-images.githubusercontent.com/4561/35150017-667e89a4-fd10-11e7-8f6a-cbf8c4924f8b.png" width="375">

