### PR TITLE
Handle Horizontal Swipe on Audio slider

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/audio.js
+++ b/ArticleTemplates/assets/js/bootstraps/audio.js
@@ -81,10 +81,16 @@ define([
 
     function audioSlider() {
         document.addEventListener('touchstart', function () {
+            if (GU.opts.platform === 'android') {
+                window.GuardianJSInterface.registerRelatedCardsTouch(true);
+            }
             down = 1;
         }, false);
 
         document.addEventListener('touchend', function () {
+            if (GU.opts.platform === 'android') {
+                window.GuardianJSInterface.registerRelatedCardsTouch(false);
+            }
             down = 0;
         }, false);
 


### PR DESCRIPTION
On Android the template needs to inform the native layer that a horizontal swipe has begun/ended, the Android layer will ignore horizontal swiping when this occurs, meaning users can use the slider on Audio templates. `GuardianJSInterface.registerRelatedCardsTouch` is the interface the JS can call to do this.