### PR TITLE
Handle Horizontal Swipe on Audio slider: Take 2

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/audio.js
+++ b/ArticleTemplates/assets/js/bootstraps/audio.js
@@ -81,21 +81,30 @@ define([
 
     function audioSlider() {
         document.addEventListener('touchstart', function () {
-            if (GU.opts.platform === 'android') {
-                window.GuardianJSInterface.registerRelatedCardsTouch(true);
-            }
             down = 1;
         }, false);
 
         document.addEventListener('touchend', function () {
-            if (GU.opts.platform === 'android') {
-                window.GuardianJSInterface.registerRelatedCardsTouch(false);
-            }
             down = 0;
         }, false);
 
         /* Caution: Hot Mess */
+        MobileRangeSlider.prototype.start = function () {
+            if (GU.opts.platform === 'android') {
+                window.GuardianJSInterface.registerRelatedCardsTouch(true);
+            }
+
+            this.addEvents("move");
+            this.addEvents("end");
+            this.handle(event);
+        };
+
+        /* Caution: Hot Mess */
         MobileRangeSlider.prototype.end = function () {
+            if (GU.opts.platform === 'android') {
+                window.GuardianJSInterface.registerRelatedCardsTouch(false);
+            }
+
             this.removeEvents('move');
             this.removeEvents('end');
 


### PR DESCRIPTION
I reverted this PR https://github.com/guardian/mobile-apps-article-templates/pull/741 because the `registerRelatedCardsTouch` calls were fired when swiping on the `document` which was too general. They should only be fired on swiping use the `MobileRangeSlider`.

The `MobileRangeSlider` (3rd party lib) doesn't provide a nice API for passing callbacks on scroll start and scroll end, however the prototype has the functions 'start' & 'end'. 

I've overridden these functions on the prototype so they retain their existing behaviour but also call `registerRelatedCardsTouch`. We were already doing this for `MobileRangeSlider.prototype.end`.