### PR TITLE
Add background to opinion articles

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-pillar/_opinion.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_opinion.scss
@@ -1,6 +1,6 @@
 $p-kicker: #ed6300;
 $p-feature-headline: #f5be2c;
-$p-soft: #dbc19a;
+$p-soft: #fef9f5;
 $p-inverted: #ff7f0f;
 $p-liveblog-background: #f5be2c;
 $p-media-background: #161616;
@@ -14,6 +14,36 @@ $p-media-background: #161616;
         $p-liveblog-background,
         $p-media-background
     );
+
+    // Light background in opinion articles
+    &:not(.garnett--type-media) {
+
+        .article__header .cutout__container,
+        .article__body,
+        .article__meta,
+        .tags {
+            background-color: $p-soft;
+        }
+
+        @include mq($to: col4) {
+            .article__header {
+                background-color: $p-soft;
+            }
+        }
+        @include mq($from: col4) {
+            .article__header {
+                .article-kicker,
+                .standfirst__inner,
+                .meta,
+                .main-media {
+                    background-color: $p-soft;
+                }
+            }
+            &:not(.garnett--type-comment, .garnett--type-immersive) .article__header .headline {
+                background-color: $p-soft;
+            }
+        }
+    }
 }
 
 // Comment articles in news showuld have opinion colours

--- a/ArticleTemplates/assets/scss/garnett-type/_comment.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_comment.scss
@@ -1,7 +1,14 @@
 .garnett--type-comment {
 
-    .headline {
-        font-weight: 200;
+
+    .article__header {
+        .headline,
+        .article-kicker {
+            background-color: transparent;
+        }
+        .headline {
+            font-weight: 200;
+        }
     }
 
     .meta {


### PR DESCRIPTION
This adds a light salmon background to opinion articles — not just comment, everything except media

**Before**

<img src='https://user-images.githubusercontent.com/4561/35914309-bb1395a6-0bfa-11e8-91fd-caa9ba18014b.png' width=375>


**After**

<img src='https://user-images.githubusercontent.com/4561/35914306-b7f4ab12-0bfa-11e8-865a-70e3c268b6ee.png' width=375>
