### PR TITLE
Headline weight

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-layout/_article.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_article.scss
@@ -26,6 +26,7 @@
 
     .headline {
         padding: base-px(0, 1, 2.5, 1);
+        font-weight: 500;
 
         @include mq($from: col4) {
             margin: 0 auto;

--- a/ArticleTemplates/assets/scss/garnett-layout/_article.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_article.scss
@@ -26,7 +26,6 @@
 
     .headline {
         padding: base-px(0, 1, 2.5, 1);
-        font-weight: 500;
 
         @include mq($from: col4) {
             margin: 0 auto;

--- a/ArticleTemplates/assets/scss/garnett-modules/content/_headline.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/content/_headline.scss
@@ -14,6 +14,6 @@
 .headline {
     color: color(shade-1);
     font-family: $egyptian-display;
-    font-weight: 600;
+    font-weight: 500;
     @include headline();
 }


### PR DESCRIPTION
Headlines should now default to font-weight 500 (Regular) instead of the old 600 (Semibold)