### PR TITLE
Removed bottom margin

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-layout/_article.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_article.scss
@@ -1,6 +1,5 @@
 .article {
     overflow: hidden;
-    margin-bottom: base-px(4);
 
     @include mq($from: col4) {
         background-color: color(shade-5);


### PR DESCRIPTION
My bottom is causing a white gap at the bottom of all articles. 

# before 
<img width="375" alt="screen shot 2018-03-06 at 14 24 20" src="https://user-images.githubusercontent.com/14570016/37037464-3fc1ebea-214a-11e8-901d-82557177289a.png">

# after 
<img width="375" alt="screen shot 2018-03-06 at 14 24 02" src="https://user-images.githubusercontent.com/14570016/37037463-3fa83f56-214a-11e8-9ee2-be0e45ed8088.png">
