### PR TITLE
Removed negative margin & updated fixture

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-type/_guardianview.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_guardianview.scss
@@ -1,7 +1,6 @@
 .garnett--type-guardianview {
     // 8 lines instead of 4 for opinion
     .meta {
-        margin-top: -22px;
         padding-top: 22px;
 
         &:before {

--- a/test/garnett-fixture/guardianview-opinion.html
+++ b/test/garnett-fixture/guardianview-opinion.html
@@ -77,6 +77,9 @@
                   <div class="headline__byline"><span class="byline__author"><a href="x-gu://list/https://mobile.guardianapis.com/lists/tag/profile/editorial">Editorial</a></span></div>
                </h1>
             </div>
+            <div class="standfirst selectable" id="standfirst">
+                <div class="standfirst__inner"><strong>An idea whose time has come:</strong> Over the holiday season the Guardian has been examining themes that have emerged to give shape to 2018. In today’s concluding piece we look at why the world will need the EU more than ever</div>
+             </div>
             <div class="meta" id="meta">
                <div class="meta__misc">
                   <div class="meta__published__comments">
@@ -93,9 +96,6 @@
                   </div>
                </div>
             </div>
-            <div class="standfirst selectable" id="standfirst">
-                <div class="standfirst__inner"><strong>An idea whose time has come:</strong> Over the holiday season the Guardian has been examining themes that have emerged to give shape to 2018. In today’s concluding piece we look at why the world will need the EU more than ever</div>
-             </div>
              <div class="main-media main-media--hidden-caption" id="main-media">
                <figure class="element element-image figure-wide">
                   <div class="figure__inner">


### PR DESCRIPTION
Multi-rule was overlapping meta on Guardian view template.

# before
<img width="315" alt="screen shot 2018-03-06 at 15 50 20" src="https://user-images.githubusercontent.com/14570016/37042384-3b1fce7a-2156-11e8-8c65-76987391842b.png">

# after
<img width="319" alt="screen shot 2018-03-06 at 15 49 39" src="https://user-images.githubusercontent.com/14570016/37042382-3b04ecf4-2156-11e8-8181-03f48c1d9a85.png">