### PR TITLE
Liveblog background

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
@@ -237,15 +237,13 @@
         .section,
         .article-kicker,
         .headline,
-        .standfirst,
-        .standfirst__inner,
         .main-media,
         .touchpoint--primary:not(.comments__post) .touchpoint__button {
-            background-color: $p-liveblog-background;
+            background-color: $p-kicker;
         }
 
         .avatar {
-            background-color: $p-kicker;
+            background-color: $p-feature-headline;
         }
 
         @include mq($from: col4) {
@@ -290,6 +288,8 @@
                 }
             }
 
+            .standfirst,
+            .standfirst__inner,
             .meta {
                 background-color: $p-liveblog-background;
             }

--- a/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
@@ -293,6 +293,9 @@
             .meta {
                 background-color: $p-liveblog-background;
             }
+            .meta__published__comments {
+                border-left-color: rgba(color(shade-4), .5);
+            }
         }
 
         .key-events {

--- a/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
@@ -361,9 +361,6 @@
             border-top-color: $soft;
         }
 
-        .comment-count a {
-            color: $kicker;
-        }
     }
 
 }

--- a/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
@@ -249,7 +249,7 @@
         @include mq($from: col4) {
             .article__header,
             .standfirst {
-                background-color: darken($p-kicker, 5%);
+                background-color: darken($p-liveblog-background, 5%);
             }
         }
 
@@ -290,7 +290,8 @@
 
             .standfirst,
             .standfirst__inner,
-            .meta {
+            .meta,
+            .main-media {
                 background-color: $p-liveblog-background;
             }
             .meta__published__comments {

--- a/ArticleTemplates/assets/scss/garnett-pillar/_news.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_news.scss
@@ -2,7 +2,7 @@ $p-kicker: #c70000;
 $p-feature-headline: #880105;
 $p-soft: #f6f6f6;
 $p-inverted: #ff4e36;
-$p-liveblog-background: #880105;
+$p-liveblog-background: #ae0000;
 $p-media-background: #161616;
 
 

--- a/ArticleTemplates/assets/scss/garnett-type/_live.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_live.scss
@@ -51,15 +51,49 @@
             .standfirst,
             .sponsorship {
                 @include mq(col2, col3) {
-                    margin-left: cols($base-3, 4);
+                    padding-left: cols($base-3, 4);
                 }
 
                 @include mq($from: col3) {
-                    margin-left: cols($base-4, 5);
+                    padding-left: cols($base-4, 5);
                 }
 
+            }
+
+            .headline,
+            .standfirst,
+            .sponsorship {
                 @include mq($from: col4) {
+                    padding-left: 0;
                     margin: 0 auto;
+                    max-width: 1200px;
+                }
+            }
+
+            .article-kicker,
+            .headline {
+                @include mq($from: col4) {
+                    padding-left: 240px;
+                    margin: 0 auto;
+                    max-width: 1200px;
+                }
+            }
+
+            .standfirst__inner,
+            .meta__misc {
+                @include mq(col2, col4) {
+                    padding-left: 0;
+                }
+                @include mq(col2, col4) {
+                    padding-left: 0;
+                }
+            }
+
+            .meta .avatar--author {
+                @include mq(col2, col4) {
+                    position: absolute;
+                    transform: translateX(-100%);
+                    margin-left: base-px(-1);
                 }
             }
 


### PR DESCRIPTION
This changes the headline background, on liveblogs, a to kicker-colour. It also updates some shades in the news pillar. Has a lot of code to get tablet to work :/

Phone — before
<img src=https://user-images.githubusercontent.com/4561/37091068-b52c627a-21fe-11e8-8525-2ce8ac97dca5.png width=375>

Phone — after
<img src=https://user-images.githubusercontent.com/4561/37091073-b7c7af08-21fe-11e8-8bad-ac6d79b317c4.png width=375>

Tablet — before
<img src=https://user-images.githubusercontent.com/4561/37091078-bbfa4342-21fe-11e8-8c5f-44e1e9b77a00.png width=512>


Tablet — after
<img src=https://user-images.githubusercontent.com/4561/37091084-be5f4ca4-21fe-11e8-8237-29d47ccee8d5.png width=512>
