### PR TITLE
Byline img overlap

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-layout/_article--comment.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_article--comment.scss
@@ -6,6 +6,11 @@
             clear: left;
             overflow: hidden;
             width: 100%;
+
+            @include mq($from: col4) {
+                margin: 0 auto;
+                max-width: 1200px;
+            }
         }
 
         .headline__byline {

--- a/ArticleTemplates/assets/scss/garnett-layout/_base-tone.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_base-tone.scss
@@ -29,23 +29,6 @@ body {
             }
         }
 
-        .cutout {
-            &__container {
-                background-color: color(shade-7);
-                @include mq($from: col4) {
-                    margin: 0 auto;
-                    max-width: 1200px;
-                }
-            }
-            &__image {
-                z-index: 21;
-                background-size: auto 160px;
-                @include mq($from: col2) {
-                    background-size: auto 220px;
-                }
-            }
-        }
-
         .meta__misc {
             @include mq($from: col4) {
                 padding: {

--- a/ArticleTemplates/assets/scss/garnett-modules/_cutout.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/_cutout.scss
@@ -17,33 +17,17 @@
 
 .cutout {
     .cutout__container {
-        @include mq($to: col1) {
-            min-height: 245px;
-            padding-right: cols($base-1, 1);
-        }
-
-        @include mq(col1, col2) {
-            min-height: 280px;
-            padding-right: cols($base-2, 2);
-        }
-
-        @include mq(col2, col3) {
-            min-height: 320px;
-        }
-
-        @include mq($from: col3) {
-            min-height: 320px;
-        }
-
         @include mq($from: col4) {
-            margin: 0 auto;
             min-height: 220px;
-            max-width: 1200px;
         }
 
         .headline {
             position: relative;
             z-index: 30;
+
+            @include mq($to: col2) {
+                padding-bottom: base-px(6);
+            }
 
             @include mq($from: col4) {
                 margin: 0;
@@ -51,34 +35,29 @@
         }
     }
 
+    .headline__byline {
+        @include mq($to: col2) {
+            margin-right: 50%;
+        }
+    }
+
     .cutout__image {
         background-repeat: no-repeat;
         background-position: bottom right;
-        background-size: 50%;
+        background-size: auto 160px;
         bottom: 0;
         left: 0;
         position: absolute;
-        right: -10%;
+        right: -40px;
         top: 0;
         z-index: 1;
 
-        @include mq($from: col1) {
-            background-size: 45%;
-            right: -7%
-        }
-
         @include mq($from: col2) {
-            background-size: 40%;
-        }
-
-        @include mq($from: col3) {
-            background-size: 30%;
-            right: -5%;
+            background-size: auto 200px;
         }
 
         @include mq($from: col4) {
-            background-size: contain;
-            right: 10%;
+            right: 40px;
         }
     }
 }

--- a/ArticleTemplates/assets/scss/garnett-modules/_cutout.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/_cutout.scss
@@ -37,7 +37,7 @@
 
     .headline__byline {
         @include mq($to: col2) {
-            margin-right: 50%;
+            margin-right: 110px;
         }
     }
 


### PR DESCRIPTION
As the big hairy cat person* illustrates here: under some circumstances the byline/headline can overlay the byline cutout.

# before
<img width="321" alt="screen shot 2018-03-06 at 16 00 31" src="https://user-images.githubusercontent.com/14570016/37097002-4a41f24a-2212-11e8-83bd-192b4a3f44bd.png">

# after
<img width="319" alt="screen shot 2018-03-07 at 14 18 24" src="https://user-images.githubusercontent.com/14570016/37097079-78797520-2212-11e8-8480-eaea1277dd10.png">

<img width="319" alt="screen shot 2018-03-07 at 14 32 45" src="https://user-images.githubusercontent.com/14570016/37098013-b38ff538-2214-11e8-99c9-46bff2e4d3e5.png">

*All byline cutouts combined
