### PR TITLE
Inline links in standfirst

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-modules/content/_standfirst.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/content/_standfirst.scss
@@ -24,9 +24,4 @@
     b {
         font-weight: 700;
     }
-
-    p:last-child a:last-child {
-        display: inline-block;
-        margin-bottom: base-px(.25);
-    }
 }


### PR DESCRIPTION
Currently, the last link in the standfirst is set to `inline-block`. This pushes proceeding text down onto this next line

This change makes the standfirst inline again.

## Screenshots

**before**

![screenshot 2](https://user-images.githubusercontent.com/5931528/37344128-64b69294-26c1-11e8-8a4e-777d347a1910.png)

**after**

![picture 514](https://user-images.githubusercontent.com/5931528/37344336-06ac99fe-26c2-11e8-8ba3-3988c5e883d6.png)

## Discussion

I believe the standfirst was being set to `inline-block` in order to add bottom margin if and only if _the link is at the very end of the standfirst_. However, this selector is targeting _the last link in the standfirst_, regardless of its location within the standfirst.

I'm not sure if there is a selector that can achieve the original purpose. @duarte let me know if you are happy to lose this bottom margin, or if we need to come up with an alternative.

**With margin (before this change)**

![picture 516](https://user-images.githubusercontent.com/5931528/37344837-5bb2fb0e-26c3-11e8-8b80-6ee58aac5af8.png)

**Without margin (after this change)**

![picture 515](https://user-images.githubusercontent.com/5931528/37344835-58402b72-26c3-11e8-90ee-8a1f0e986cc6.png)