### PR TITLE
Add new templates for collections (AA-14)

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-style-sync.scss
+++ b/ArticleTemplates/assets/scss/garnett-style-sync.scss
@@ -68,6 +68,7 @@
 @import 'garnett-type/media-video';
 @import 'garnett-type/guardianview';
 @import 'garnett-type/matchreport';
+@import 'garnett-type/collection';
 
 
 // Pillars

--- a/ArticleTemplates/assets/scss/garnett-type/_collection.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_collection.scss
@@ -1,10 +1,16 @@
 .garnett--type-collection {
+    h3 {
+	padding-bottom: 0.25em ;
+        border-bottom: dashed 1px #979797;
+    }
+    
     h3, p {
 	margin-bottom: 0.5em;
     }
     
     .collection-block {
-	border-bottom: solid 1px #cccccc;
-	margin-bottom: 0.5em;
+	border-bottom: solid 1px #979797;
+	padding-bottom: 2em;
+	margin-bottom: 0.15em;
     }
 }

--- a/ArticleTemplates/assets/scss/garnett-type/_collection.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_collection.scss
@@ -5,5 +5,6 @@
     
     .collection-block {
 	border-bottom: solid 1px #cccccc;
+	margin-bottom: 0.5em;
     }
 }

--- a/ArticleTemplates/assets/scss/garnett-type/_collection.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_collection.scss
@@ -1,0 +1,9 @@
+.garnett--type-collection {
+    h3, p {
+	margin-bottom: 0.5em;
+    }
+    
+    .collection-block {
+	border-bottom: solid 1px #cccccc;
+    }
+}

--- a/ArticleTemplates/collectionBlockTemplate.html
+++ b/ArticleTemplates/collectionBlockTemplate.html
@@ -1,10 +1,10 @@
-<div class="collection-block-container" style="border: solid 1px #ccc; padding: 10px; margin: 10px;">
-    <h2>
-        <a href="__BLOCK_LINK__"><span class="collection-sub-item-title-line-1">__BLOCK_TITLE_1__</span><br/>
-        <span class="collection-sub-item-title-line-2">__BLOCK_TITLE_2__</span></a>
-    </h2>
+<div class="collection-block">
+    <h3 class="collection-block-title">
+        <a href="__BLOCK_LINK__"><span class="collection-sub-item-title-line-1" style="color: __BLOCK_TITLE_1_COLOUR__;">__BLOCK_TITLE_1__</span>
+        <span class="collection-sub-item-title-line-2" style="color: __BLOCK_TITLE_2_COLOUR__;">__BLOCK_TITLE_2__</span></a>
+    </h3>
     __BLOCK_BODY__
-    <p>
+    <p class="collection-read-full-container">
         <a class="collection-read-full-link" href="__BLOCK_LINK__">Read full article</a>
     </p>
 </div>

--- a/ArticleTemplates/collectionBlockTemplate.html
+++ b/ArticleTemplates/collectionBlockTemplate.html
@@ -1,0 +1,10 @@
+<div class="collection-block-container" style="border: solid 1px #ccc; padding: 10px; margin: 10px;">
+    <h2>
+        <a href="__BLOCK_LINK__"><span class="collection-sub-item-title-line-1">__BLOCK_TITLE_1__</span><br/>
+        <span class="collection-sub-item-title-line-2">__BLOCK_TITLE_2__</span></a>
+    </h2>
+    __BLOCK_BODY__
+    <p>
+        <a class="collection-read-full-link" href="__BLOCK_LINK__">Read full article</a>
+    </p>
+</div>

--- a/ArticleTemplates/collectionBlockTemplate.html
+++ b/ArticleTemplates/collectionBlockTemplate.html
@@ -5,6 +5,6 @@
     </h3>
     __BLOCK_BODY__
     <p class="collection-read-full-container">
-        <a class="collection-read-full-link" href="__BLOCK_LINK__">Read full article</a>
+        <a class="collection-read-full-link" href="__BLOCK_LINK__">Read full article <span data-icon="→" aria-hidden="true"></span></a>
     </p>
 </div>

--- a/ArticleTemplates/collectionTemplate.html
+++ b/ArticleTemplates/collectionTemplate.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html lang="en-US">
 <head>
-    <title>Interactive</title>
+    <title>Collection</title>
     <meta charset="UTF-8" />
     <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
     <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="__TEMPLATES_DIRECTORY__assets/css/fonts-__PLATFORM__.css" />
-    <!--<link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/interactive.css" />-->
     <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__SYNC_STYLES__.css" />
     <script type="text/javascript">
         window.GU = window.GU || {};
@@ -15,7 +14,7 @@
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/bootstrap.js"></script>
 </head>
 
-<body class="__FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ __DISPLAY_HINT__" data-fullscreen-interactive data-content-type="interactive" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-page-id="__PAGE_ID__" data-template-directory="__TEMPLATES_DIRECTORY__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
+<body class="__FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ __DISPLAY_HINT__" data-content-type="collection" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-page-id="__PAGE_ID__" data-template-directory="__TEMPLATES_DIRECTORY__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
 
     __BODY__
 
@@ -25,7 +24,7 @@
             fontSize: "__FONT_SIZE__",
             platform: "__PLATFORM__",
             isOffline: "__IS_OFFLINE__" ? true : false,
-            contentType: "interactive",
+            contentType: "collection",
             adsEnabled: "__ADS_ENABLED__",
             adsEnableHiding: "__ADS_ENABLE_HIDING__" === "true",
             adsConfig: "__ADS_CONFIG__",

--- a/ArticleTemplates/collectionTemplate.html
+++ b/ArticleTemplates/collectionTemplate.html
@@ -14,9 +14,15 @@
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/bootstrap.js"></script>
 </head>
 
-<body class="__FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ __DISPLAY_HINT__" data-content-type="collection" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-page-id="__PAGE_ID__" data-template-directory="__TEMPLATES_DIRECTORY__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
+<body class="garnett--type-collection garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="article" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__" data-content-section="__SECTION__">
 
-    __BODY__
+    <div class="article article--feature" id="feature-article-container">
+        <div class="article__body" id="feature-body">
+            <div class="from-content-api prose resizable selectable" id="feature-body-blocks">
+	        __BODY__
+	    </div>
+        </div>
+    </div>
 
     <script type="text/javascript">
         GU.bootstrap.init({             

--- a/ArticleTemplates/collectionTemplate.html
+++ b/ArticleTemplates/collectionTemplate.html
@@ -16,9 +16,9 @@
 
 <body class="garnett--type-collection garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="article" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__" data-content-section="__SECTION__">
 
-    <div class="article article--feature" id="feature-article-container">
-        <div class="article__body" id="feature-body">
-            <div class="from-content-api prose resizable selectable" id="feature-body-blocks">
+    <div class="article article--standard" id="standard-article-container">
+        <div class="article__body" id="article-body">
+            <div class="from-content-api prose resizable selectable" id="article-body-blocks">
 	        __BODY__
 	    </div>
         </div>

--- a/ArticleTemplates/collectionTemplate.html
+++ b/ArticleTemplates/collectionTemplate.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+    <title>Interactive</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
+    <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="__TEMPLATES_DIRECTORY__assets/css/fonts-__PLATFORM__.css" />
+    <!--<link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/interactive.css" />-->
+    <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/__SYNC_STYLES__.css" />
+    <script type="text/javascript">
+        window.GU = window.GU || {};
+    </script>
+    <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/polyfills/promise.js"></script>
+    <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/polyfills/requestAnimationFrame.js"></script>
+    <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/bootstrap.js"></script>
+</head>
+
+<body class="__FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ __DISPLAY_HINT__" data-fullscreen-interactive data-content-type="interactive" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-page-id="__PAGE_ID__" data-template-directory="__TEMPLATES_DIRECTORY__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
+
+    __BODY__
+
+    <script type="text/javascript">
+        GU.bootstrap.init({             
+            asyncStylesFilename: "__ASYNC_STYLES__",
+            fontSize: "__FONT_SIZE__",
+            platform: "__PLATFORM__",
+            isOffline: "__IS_OFFLINE__" ? true : false,
+            contentType: "interactive",
+            adsEnabled: "__ADS_ENABLED__",
+            adsEnableHiding: "__ADS_ENABLE_HIDING__" === "true",
+            adsConfig: "__ADS_CONFIG__",
+            actionBarHeight: "__ACTIONBARHEIGHT__",
+            fontSize: "__FONT_SIZE_INT__",
+            templatesDirectory: "__TEMPLATES_DIRECTORY__",
+            pageId: "__PAGE_ID__",
+            mpuAfterParagraphs: "__MPU_AFTER_PARAGRAPHS__",
+            useAdsReady: "__ADS_FAST_CALLBACK__" === "true",
+            tests: '__TEST_SPEC__',
+            nativeYoutubeEnabled: "__NATIVE_YOUTUBE_ENABLED__" === "true",
+            disableEnhancedTweets: "__DISABLE_ENHANCED_TWEETS__" === "true",
+            hasEpic: "__HAS_EPIC__" === "true"
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds two new templates the apps can use to render a new type of content which we're calling a "collection". This will eventually look something like the design below provided by @blongden73. The image at the top and title are native, everything below is rendered using these HTML templates.

Not shown below are the "Read full article ->" links that should appear at the end of each "block", I have put those in the template though.

`collectionsTemplate.html` is a copy of `interactiveTemplate.html` but with the `interactives.css` swapped for the CSS used in `articleTemplate.html`.

I will need to add to the CSS later, but I wanted to open this PR now to try and get feedback on the general direction, if possible?

![collection_expanded](https://user-images.githubusercontent.com/951849/37397385-5ea5cf34-2773-11e8-95b7-0e8ae6898110.jpg)
