### PR TITLE
Colour sorting

### DIFF
--- a/ArticleTemplates/assets/scss/base/_colour.scss
+++ b/ArticleTemplates/assets/scss/base/_colour.scss
@@ -80,35 +80,30 @@ $gu-colours: (
     news-soft: #f6f6f6,
     news-inverted: #ff4e36,
     news-liveblog-background: #ae0000,
-    news-media-background: #161616,
 
     opinion-kicker: #e05e00,
     opinion-feature-headline: #bd5318,
     opinion-soft: #fef9f5,
     opinion-inverted: #ff7f0f,
     opinion-liveblog-background: #bd5318,
-    opinion-media-background: #161616,
 
     sport-kicker: #0084c6,
     sport-feature-headline: #005689,
     sport-soft: #e6f5ff,
     sport-inverted: #00b2ff,
     sport-liveblog-background: #005689,
-    sport-media-background: #161616,
 
     arts-kicker: #a1845c,
     arts-feature-headline: #6b5840,
     arts-soft: #f2ebdc,
     arts-inverted: #eacca0,
     arts-liveblog-background: #6b5840,
-    arts-media-background: #161616,
 
     lifestyle-kicker: #bb3b80,
     lifestyle-feature-headline: #7d0068,
     lifestyle-soft: #ffe6ec,
     lifestyle-inverted: #ffabdb,
     lifestyle-liveblog-background: #7d0068,
-    lifestyle-media-background: #161616,
 
     /* Most Regular Articles */
     tone-news: #005689,
@@ -134,6 +129,7 @@ $gu-colours: (
     /* Media */
     tone-media: #ffbb00,
     tone-media-accent: #ffd35c,
+    tone-media-background: #161616,
     /* Special */
     tone-special: #63717a,
     tone-special-accent: #ffd900,

--- a/ArticleTemplates/assets/scss/base/_colour.scss
+++ b/ArticleTemplates/assets/scss/base/_colour.scss
@@ -73,25 +73,42 @@
 // */
 
 $gu-colours: (
-    /* New Tonal colour Definitions */
 
-    /* Example Tone called "Sample"
+    // Pillar Colours
+    news-kicker: #c70000,
+    news-feature-headline: #880105,
+    news-soft: #f6f6f6,
+    news-inverted: #ff4e36,
+    news-liveblog-background: #ae0000,
+    news-media-background: #161616,
 
-    tone-sample:                    main tone colour (used throughout app on links etc.)
-    tone-sample-headline:           headline colour
-    brightness-100:                 main background of article header
-    tone-sample-standfirst:         Standfirst (below headline intro copy) text colour
-    tone-sample-standfirst-links:   Standfirst link colour
-    tone-sample-accent:             thin line at article top colour
-    tone-sample-section-label:      section label colour
-    tone-sample-series-label:       series label colour
-    tone-sample-meta-background:    meta background (base part of top container)
-    tone-sample-meta-byline:        author (byline) and comment icon colour
-    tone-sample-meta-pubdate:       publish date
-    tone-sample-media-caption-bg:   fig caption background
-    tone-sample-links:              article body text links
-    tone-sample-tags-text:          tag text colour
-    tone-sample-tags-bg:            tag lozenge background colour
+    opinion-kicker: #e05e00,
+    opinion-feature-headline: #bd5318,
+    opinion-soft: #fef9f5,
+    opinion-inverted: #ff7f0f,
+    opinion-liveblog-background: #bd5318,
+    opinion-media-background: #161616,
+
+    sport-kicker: #0084c6,
+    sport-feature-headline: #005689,
+    sport-soft: #e6f5ff,
+    sport-inverted: #00b2ff,
+    sport-liveblog-background: #005689,
+    sport-media-background: #161616,
+
+    arts-kicker: #a1845c,
+    arts-feature-headline: #6b5840,
+    arts-soft: #f2ebdc,
+    arts-inverted: #eacca0,
+    arts-liveblog-background: #6b5840,
+    arts-media-background: #161616,
+
+    lifestyle-kicker: #bb3b80,
+    lifestyle-feature-headline: #7d0068,
+    lifestyle-soft: #ffe6ec,
+    lifestyle-inverted: #ffabdb,
+    lifestyle-liveblog-background: #7d0068,
+    lifestyle-media-background: #161616,
 
     /* Most Regular Articles */
     tone-news: #005689,

--- a/ArticleTemplates/assets/scss/garnett-pillar/_arts.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_arts.scss
@@ -4,7 +4,6 @@
         color(arts-feature-headline),
         color(arts-soft),
         color(arts-inverted),
-        color(arts-liveblog-background),
-        color(arts-media-background)
+        color(arts-liveblog-background)
     );
 }

--- a/ArticleTemplates/assets/scss/garnett-pillar/_arts.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_arts.scss
@@ -1,17 +1,10 @@
-$p-kicker: #a1845c;
-$p-feature-headline: #6b5840;
-$p-soft: #f2ebdc;
-$p-inverted: #eacca0;
-$p-liveblog-background: #6b5840;
-$p-media-background: #161616;
-
 .garnett--pillar-arts {
     @include pillar-colour(
-        $p-kicker,
-        $p-feature-headline,
-        $p-soft,
-        $p-inverted,
-        $p-liveblog-background,
-        $p-media-background
+        color(arts-kicker),
+        color(arts-feature-headline),
+        color(arts-soft),
+        color(arts-inverted),
+        color(arts-liveblog-background),
+        color(arts-media-background)
     );
 }

--- a/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
@@ -6,11 +6,10 @@
 // $p-soft — no correspondence
 // $p-inverted — mediaMain and elementBackground
 // $p-liveblog-background — liveblogBackground
-// $p-media-background — 'background' override in media cards
 // in addition, MAPI includes pillar-toned liveblogBackground and liveblogMain
 
 
-@mixin pillar-colour($p-kicker, $p-feature-headline, $p-soft, $p-inverted, $p-liveblog-background, $p-media-background) {
+@mixin pillar-colour($p-kicker, $p-feature-headline, $p-soft, $p-inverted, $p-liveblog-background) {
     .element-pullquote blockquote {
         color: $p-kicker;
     }
@@ -90,7 +89,7 @@
     }
 
     // Maybe make this bit less smart and more manual later?
-    @include pillar-reversible($p-kicker, $p-feature-headline, $p-soft, $p-inverted, $p-liveblog-background);
+    @include pillar-reversible($p-kicker, $p-feature-headline, $p-soft, $p-inverted);
 
     // Feature, Review, Recipe overrides
     &.garnett--type-feature,
@@ -173,11 +172,11 @@
 
         .article__header,
         .article__body {
-            background-color: $p-media-background;
+            background-color: color(tone-media-background);
         }
         .article__header {
             @include mq($from: col4) {
-                background-color: darken($p-media-background, 5%);
+                background-color: darken(color(tone-media-background), 5%);
             }
         }
 
@@ -188,16 +187,16 @@
         .main-media,
         .meta,
         .sponsorship {
-            background-color: $p-media-background;
+            background-color: color(tone-media-background);
             color: color(brightness-86);
         }
 
         .article--audio,
         .article--visual {
-            background-color: $p-media-background;
+            background-color: color(tone-media-background);
 
             @include mq($from: col4) {
-                background-color: darken($p-media-background, 5%);
+                background-color: darken(color(tone-media-background), 5%);
             }
         }
 
@@ -206,10 +205,10 @@
                 background-color: transparent;
             }
             .audio-player__wrapper {
-                background-color: $p-media-background;
+                background-color: color(tone-media-background);
             }
             @include mq($from: col4) {
-                background-color: darken($p-media-background, 5%);
+                background-color: darken(color(tone-media-background), 5%);
             }
         }
 
@@ -222,7 +221,7 @@
             color: color(brightness-93);
         }
 
-        @include pillar-reversible($p-inverted, $p-kicker, $p-feature-headline, $p-soft, $p-media-background);
+        @include pillar-reversible($p-inverted, $p-kicker, $p-feature-headline, $p-soft);
     }
 
     // Live overrides
@@ -333,7 +332,7 @@
 // CSS for reversible pillar colours, this means we can
 // use $kicker colours to mean $p-kicker or $p-inverted
 // depending on context
-@mixin pillar-reversible($kicker, $feature, $soft, $inverted, $background) {
+@mixin pillar-reversible($kicker, $feature, $soft, $inverted) {
 
     &:not(.garnett--type-live) {
         // Section and series labels above headline

--- a/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
@@ -158,69 +158,6 @@
 
     // Media overrides
     &.garnett--type-media {
-        .keyline {
-            &:before {
-                background-color: color(brightness-46);
-            }
-        };
-
-        .keyline-4 {
-            &:before {
-                background-image: repeating-linear-gradient(color(brightness-46), color(brightness-46) 1px, transparent 1px, transparent 3px);
-            }
-        }
-
-        .article__header,
-        .article__body {
-            background-color: color(tone-media-background);
-        }
-        .article__header {
-            @include mq($from: col4) {
-                background-color: darken(color(tone-media-background), 5%);
-            }
-        }
-
-
-        .section,
-        .article-kicker,
-        .headline,
-        .main-media,
-        .meta,
-        .sponsorship {
-            background-color: color(tone-media-background);
-            color: color(brightness-86);
-        }
-
-        .article--audio,
-        .article--visual {
-            background-color: color(tone-media-background);
-
-            @include mq($from: col4) {
-                background-color: darken(color(tone-media-background), 5%);
-            }
-        }
-
-        .audio-player__container {
-            .audio-player {
-                background-color: transparent;
-            }
-            .audio-player__wrapper {
-                background-color: color(tone-media-background);
-            }
-            @include mq($from: col4) {
-                background-color: darken(color(tone-media-background), 5%);
-            }
-        }
-
-        // hide horizontal white line above video cover image
-        .element__inner {
-            background-color: inherit;
-        }
-
-        .meta__published {
-            color: color(brightness-93);
-        }
-
         @include pillar-reversible($p-inverted, $p-kicker, $p-feature-headline, $p-soft);
     }
 

--- a/ArticleTemplates/assets/scss/garnett-pillar/_lifestyle.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_lifestyle.scss
@@ -1,17 +1,10 @@
-$p-kicker: #bb3b80;
-$p-feature-headline: #7d0068;
-$p-soft: #ffe6ec;
-$p-inverted: #ffabdb;
-$p-liveblog-background: #7d0068;
-$p-media-background: #161616;
-
 .garnett--pillar-lifestyle {
     @include pillar-colour(
-        $p-kicker,
-        $p-feature-headline,
-        $p-soft,
-        $p-inverted,
-        $p-liveblog-background,
-        $p-media-background
+        color(lifestyle-kicker),
+        color(lifestyle-feature-headline),
+        color(lifestyle-soft),
+        color(lifestyle-inverted),
+        color(lifestyle-liveblog-background),
+        color(lifestyle-media-background)
     );
 }

--- a/ArticleTemplates/assets/scss/garnett-pillar/_lifestyle.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_lifestyle.scss
@@ -4,7 +4,6 @@
         color(lifestyle-feature-headline),
         color(lifestyle-soft),
         color(lifestyle-inverted),
-        color(lifestyle-liveblog-background),
-        color(lifestyle-media-background)
+        color(lifestyle-liveblog-background)
     );
 }

--- a/ArticleTemplates/assets/scss/garnett-pillar/_news.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_news.scss
@@ -4,7 +4,6 @@
         color(news-feature-headline),
         color(news-soft),
         color(news-inverted),
-        color(news-liveblog-background),
-        color(news-media-background)
+        color(news-liveblog-background)
     );
 }

--- a/ArticleTemplates/assets/scss/garnett-pillar/_news.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_news.scss
@@ -1,18 +1,10 @@
-$p-kicker: #c70000;
-$p-feature-headline: #880105;
-$p-soft: #f6f6f6;
-$p-inverted: #ff4e36;
-$p-liveblog-background: #ae0000;
-$p-media-background: #161616;
-
-
 .garnett--pillar-news {
     @include pillar-colour(
-        $p-kicker,
-        $p-feature-headline,
-        $p-soft,
-        $p-inverted,
-        $p-liveblog-background,
-        $p-media-background
+        color(news-kicker),
+        color(news-feature-headline),
+        color(news-soft),
+        color(news-inverted),
+        color(news-liveblog-background),
+        color(news-media-background)
     );
 }

--- a/ArticleTemplates/assets/scss/garnett-pillar/_opinion.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_opinion.scss
@@ -1,18 +1,11 @@
-$p-kicker: #e05e00;
-$p-feature-headline: #bd5318;
-$p-soft: #fef9f5;
-$p-inverted: #ff7f0f;
-$p-liveblog-background: #bd5318;
-$p-media-background: #161616;
-
 .garnett--pillar-opinion {
     @include pillar-colour(
-        $p-kicker,
-        $p-feature-headline,
-        $p-soft,
-        $p-inverted,
-        $p-liveblog-background,
-        $p-media-background
+        color(opinion-kicker),
+        color(opinion-feature-headline),
+        color(opinion-soft),
+        color(opinion-inverted),
+        color(opinion-liveblog-background),
+        color(opinion-media-background)
     );
 
     // Light background in opinion articles
@@ -22,12 +15,12 @@ $p-media-background: #161616;
         .article__body,
         .article__meta,
         .tags {
-            background-color: $p-soft;
+            background-color: color(opinion-soft);
         }
 
         @include mq($to: col4) {
             .article__header {
-                background-color: $p-soft;
+                background-color: color(opinion-soft);
             }
         }
         @include mq($from: col4) {
@@ -36,11 +29,11 @@ $p-media-background: #161616;
                 .standfirst__inner,
                 .meta,
                 .main-media {
-                    background-color: $p-soft;
+                    background-color: color(opinion-soft);
                 }
             }
             &:not(.garnett--type-comment, .garnett--type-immersive) .article__header .headline {
-                background-color: $p-soft;
+                background-color: color(opinion-soft);
             }
         }
     }
@@ -49,11 +42,11 @@ $p-media-background: #161616;
 // Comment articles in news showuld have opinion colours
 .garnett--type-comment.garnett--pillar-news {
     @include pillar-colour(
-        $p-kicker,
-        $p-feature-headline,
-        $p-soft,
-        $p-inverted,
-        $p-liveblog-background,
-        $p-media-background
+        color(opinion-kicker),
+        color(opinion-feature-headline),
+        color(opinion-soft),
+        color(opinion-inverted),
+        color(opinion-liveblog-background),
+        color(opinion-media-background)
     );
 }

--- a/ArticleTemplates/assets/scss/garnett-pillar/_opinion.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_opinion.scss
@@ -4,8 +4,7 @@
         color(opinion-feature-headline),
         color(opinion-soft),
         color(opinion-inverted),
-        color(opinion-liveblog-background),
-        color(opinion-media-background)
+        color(opinion-liveblog-background)
     );
 
     // Light background in opinion articles
@@ -46,7 +45,6 @@
         color(opinion-feature-headline),
         color(opinion-soft),
         color(opinion-inverted),
-        color(opinion-liveblog-background),
-        color(opinion-media-background)
+        color(opinion-liveblog-background)
     );
 }

--- a/ArticleTemplates/assets/scss/garnett-pillar/_sport.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_sport.scss
@@ -1,18 +1,11 @@
-$p-kicker: #0084c6;
-$p-feature-headline: #005689;
-$p-soft: #e6f5ff;
-$p-inverted: #00b2ff;
-$p-liveblog-background: #005689;
-$p-media-background: #161616;
-
 .garnett--pillar-sport {
     @include pillar-colour(
-        $p-kicker,
-        $p-feature-headline,
-        $p-soft,
-        $p-inverted,
-        $p-liveblog-background,
-        $p-media-background
+        color(sport-kicker),
+        color(sport-feature-headline),
+        color(sport-soft),
+        color(sport-inverted),
+        color(sport-liveblog-background),
+        color(sport-media-background)
     );
 
     // Common
@@ -24,15 +17,15 @@ $p-media-background: #161616;
     .cricket .tabs [href='#cricket__tabpanel--stats'][aria-selected=true],
     .football .tabs [href='#football__tabpanel--liveblog'][aria-selected=true],
     .football .tabs [href='#football__tabpanel--stats'][aria-selected=true] {
-        color: $p-kicker;
-        border-top-color: $p-kicker;
+        color: color(sport-kicker);
+        border-top-color: color(sport-kicker);
     }
 
     // Cricket
     .cricket .tone--deadBlog,
     .cricket .tone--liveBlog.is-live {
         .cricket-match-comp-info {
-            background-color: $p-kicker;
+            background-color: color(sport-kicker);
         }
 
         .cricket-scorecard-bullets {
@@ -40,7 +33,7 @@ $p-media-background: #161616;
                 background-color: color(tone-sandy-light);
 
                 &.cricket-scorecard-bullets--active {
-                    background-color: $p-kicker;
+                    background-color: color(sport-kicker);
                 }
             }
         }
@@ -51,7 +44,7 @@ $p-media-background: #161616;
 
         .byline,
         .byline__author a {
-            color: $p-kicker;
+            color: color(sport-kicker);
         }
 
         a.alerts {
@@ -67,14 +60,14 @@ $p-media-background: #161616;
 
     .cricket .tone--liveBlog.is-live {
         a.alerts {
-            border-color: $p-kicker;
+            border-color: color(sport-kicker);
             background-color: transparent;
-            color: $p-kicker;
+            color: color(sport-kicker);
         }
 
         a.alerts:active,
         a.alerts.following {
-            background-color: $p-kicker;
+            background-color: color(sport-kicker);
             color: color(brightness-100);
             border-color: transparent;
         }
@@ -82,6 +75,6 @@ $p-media-background: #161616;
 
     .cricket-match-comp-info {
         color: color(brightness-100);
-        background-color: $p-kicker;
+        background-color: color(sport-kicker);
     }
 }

--- a/ArticleTemplates/assets/scss/garnett-pillar/_sport.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_sport.scss
@@ -4,8 +4,7 @@
         color(sport-feature-headline),
         color(sport-soft),
         color(sport-inverted),
-        color(sport-liveblog-background),
-        color(sport-media-background)
+        color(sport-liveblog-background)
     );
 
     // Common

--- a/ArticleTemplates/assets/scss/garnett-type/_media-all.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_media-all.scss
@@ -1,9 +1,72 @@
 .garnett--type-media {
+
+    .article__header,
+    .article__body {
+        background-color: color(tone-media-background);
+    }
+    .article__header {
+        @include mq($from: col4) {
+            background-color: darken(color(tone-media-background), 5%);
+        }
+    }
+
     @include mq($from: col4) {
         .comments,
         .related-content {
             background: color(brightness-93);
         }
+    }
+
+    .keyline {
+        &:before {
+            background-color: color(brightness-46);
+        }
+    };
+
+    .keyline-4 {
+        &:before {
+            background-image: repeating-linear-gradient(color(brightness-46), color(brightness-46) 1px, transparent 1px, transparent 3px);
+        }
+    }
+
+    .section,
+    .article-kicker,
+    .headline,
+    .main-media,
+    .meta,
+    .sponsorship {
+        background-color: color(tone-media-background);
+        color: color(brightness-86);
+    }
+
+    .article--audio,
+    .article--visual {
+        background-color: color(tone-media-background);
+
+        @include mq($from: col4) {
+            background-color: darken(color(tone-media-background), 5%);
+        }
+    }
+
+    .audio-player__container {
+        .audio-player {
+            background-color: transparent;
+        }
+        .audio-player__wrapper {
+            background-color: color(tone-media-background);
+        }
+        @include mq($from: col4) {
+            background-color: darken(color(tone-media-background), 5%);
+        }
+    }
+
+    // hide horizontal white line above video cover image
+    .element__inner {
+        background-color: inherit;
+    }
+
+    .meta__published {
+        color: color(brightness-93);
     }
 
     .witness .witness__sponsor-logo {


### PR DESCRIPTION
No visual changes (🤞) just better organisation of the pillar colours file.

This stops using local variables in each pillar file, moving pillar colours to the global colour variables file. Now pillar colours can be used anywhere! Also moves the code to make media backgrounds black in all pillars from pillar colour file to the media-all file.