### PR TITLE
Comment separator line is good now

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-modules/_keyline.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/_keyline.scss
@@ -24,8 +24,8 @@
 // four-line keyline
 .keyline-4 {
     position: relative;
-    padding-top: 18px !important;
-    
+    padding-top: 16px !important;
+
     &:before {
         content: '';
         height: 12px;

--- a/ArticleTemplates/assets/scss/garnett-modules/content/_meta.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/content/_meta.scss
@@ -103,16 +103,17 @@
         margin-left: base-px(.5);
         border-left: 1px solid color(brightness-86);
         margin-bottom: base-px(.5);
+        margin-top: base-px(-0.5);
         a {
             position: relative;
             display: block;
             margin: base-px(0, -.5, 0, 0);
-            padding: base-px(1.75, .5, .5, 1);
+            padding: base-px(2.25, .5, 0, 1);
             min-width: 36px;
         }
         [data-icon] {
             position: absolute;
-            top: 0;
+            top: base-px(.5);
             right: 4px;
         }
         .screen-readable {

--- a/ArticleTemplates/assets/scss/garnett-modules/content/_meta.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/content/_meta.scss
@@ -100,6 +100,7 @@
         font-weight: 600;
         font-size: 1.8rem;
         line-height: 1.8rem;
+        margin-left: base-px(.5);
         border-left: 1px solid color(brightness-86);
         margin-bottom: base-px(.5);
         a {

--- a/ArticleTemplates/assets/scss/garnett-type/_media-all.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_media-all.scss
@@ -29,6 +29,10 @@
         }
     }
 
+    .meta__published__comments {
+        border-color: color(brightness-46);
+    }
+
     .section,
     .article-kicker,
     .headline,


### PR DESCRIPTION
Moves the comment separator line up a little. Makes the line colour match `keyline` colour on media. Tidies up padding a little.

**Before**
<img src=https://user-images.githubusercontent.com/4561/38685195-39f7f59c-3e69-11e8-9d95-dd1c1f53500f.png width=375>

**After**
<img src=https://user-images.githubusercontent.com/4561/38685184-3788a25c-3e69-11e8-83e0-b5101ee9d3e1.png width=375>
