### PR TITLE
Tags in special reports

### DIFF
--- a/ArticleTemplates/assets/scss/base/_colour.scss
+++ b/ArticleTemplates/assets/scss/base/_colour.scss
@@ -137,9 +137,6 @@ $gu-colours: (
     /* Editorial */
     tone-editorial: #005689,
     tone-editorial-bg: #efefec,
-    /* Tags */
-    global-tags: #f1f1f1,
-    blogs-tags: #e0e0e0,
     /* Section Container */
     global-section-band: #ececec,
     /* Sponsor by Band */

--- a/ArticleTemplates/assets/scss/garnett-layout/_base-tone.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_base-tone.scss
@@ -109,7 +109,7 @@ body {
     .tags {
         .inline-list__item {
             &.more-button a {
-                @include tag-more-button(color(brightness-7), color(global-tags));
+                @include tag-more-button(color(brightness-7), color(brightness-96));
             }
         }
     }

--- a/ArticleTemplates/assets/scss/garnett-modules/_key-events.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/_key-events.scss
@@ -1,5 +1,5 @@
 .key-events {
-    background: color(global-tags);
+    background: color(brightness-96);
     border-bottom: 2px solid color(tone-sandy-light);
     margin: 0 auto;
     max-width: 1200px;

--- a/ArticleTemplates/assets/scss/garnett-modules/_tags.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/_tags.scss
@@ -72,11 +72,11 @@
         margin: 4px;
         text-overflow: ellipsis;
         max-width: 18.75rem;
-        @include tag-button(color(brightness-7), color(global-tags));
+        @include tag-button(color(brightness-7), color(brightness-96));
     }
 
     &.more-button a {
         background-color: transparent !important;
-        @include tag-more-button(color(brightness-7), darken(color(global-tags), 10%));
+        @include tag-more-button(color(brightness-7), darken(color(brightness-96), 10%));
     }
 }

--- a/ArticleTemplates/assets/scss/garnett-tones/_tone--deadblog.scss
+++ b/ArticleTemplates/assets/scss/garnett-tones/_tone--deadblog.scss
@@ -142,11 +142,11 @@
 
         .inline-list__item {
             a {
-                @include tag-button(color(brightness-7), color(blogs-tags));
+                @include tag-button(color(brightness-7), color(brightness-93));
             }
 
             &.more-button a {
-                @include tag-more-button(color(brightness-7), darken(color(blogs-tags), 10%));
+                @include tag-more-button(color(brightness-7), darken(color(brightness-93), 10%));
             }
         }
     }

--- a/ArticleTemplates/assets/scss/garnett-tones/_tone--special.scss
+++ b/ArticleTemplates/assets/scss/garnett-tones/_tone--special.scss
@@ -61,7 +61,12 @@
         }
     }
 
-    .tags__list-item a {
-       @include tag-button(color(brightness-7), color(brightness-86));
-   }
+    .tags__list-item {
+        a {
+            @include tag-button(color(brightness-7), color(brightness-86));
+        }
+        &.more-button a {
+            @include tag-more-button(color(brightness-7), darken(color(brightness-86), 10%));
+        }
+    }
 }

--- a/ArticleTemplates/assets/scss/garnett-tones/_tone--special.scss
+++ b/ArticleTemplates/assets/scss/garnett-tones/_tone--special.scss
@@ -60,4 +60,8 @@
             color: color(tone-highlight);
         }
     }
+
+    .tags__list-item a {
+       @include tag-button(color(brightness-7), color(brightness-86));
+   }
 }

--- a/ArticleTemplates/assets/scss/garnett-type/_live.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_live.scss
@@ -168,11 +168,11 @@
 
                 .inline-list__item {
                     a {
-                        @include tag-button(color(brightness-7), color(blogs-tags));
+                        @include tag-button(color(brightness-7), color(brightness-93));
                     }
 
                     &.more-button a {
-                        @include tag-more-button(color(brightness-7), darken(color(blogs-tags), 10%));
+                        @include tag-more-button(color(brightness-7), darken(color(brightness-93), 10%));
                     }
                 }
             }

--- a/ArticleTemplates/assets/scss/modules/_key-events.scss
+++ b/ArticleTemplates/assets/scss/modules/_key-events.scss
@@ -1,5 +1,5 @@
 .key-events {
-    background: color(global-tags);
+    background: color(brightness-96);
     border-bottom: 2px solid color(tone-sandy-light);
     border-top: 4px solid color(tone-live-accent);
     margin: 0 auto;

--- a/ArticleTemplates/assets/scss/modules/_tags.scss
+++ b/ArticleTemplates/assets/scss/modules/_tags.scss
@@ -74,11 +74,11 @@
         margin: 4px;
         text-overflow: ellipsis;
         max-width: 18.75rem;
-        @include tag-button(color(brightness-7), color(global-tags));
+        @include tag-button(color(brightness-7), color(brightness-96));
     }
 
     &.more-button a {
         background-color: transparent !important;
-        @include tag-more-button(color(brightness-7), darken(color(global-tags), 10%));
+        @include tag-more-button(color(brightness-7), darken(color(brightness-96), 10%));
     }
 }

--- a/ArticleTemplates/assets/scss/tones/_tone--comment.scss
+++ b/ArticleTemplates/assets/scss/tones/_tone--comment.scss
@@ -63,7 +63,7 @@
     .tags {
         .inline-list__item {
             &.more-button a {
-                @include tag-more-button(color(brightness-7), color(global-tags));
+                @include tag-more-button(color(brightness-7), color(brightness-96));
             }
         }
     }

--- a/ArticleTemplates/assets/scss/tones/_tone--deadblog.scss
+++ b/ArticleTemplates/assets/scss/tones/_tone--deadblog.scss
@@ -174,11 +174,11 @@
 
         .inline-list__item {
             a {
-                @include tag-button(color(brightness-7), color(blogs-tags));
+                @include tag-button(color(brightness-7), color(brightness-93));
             }
 
             &.more-button a {
-                @include tag-more-button(color(brightness-7), darken(color(blogs-tags), 10%));
+                @include tag-more-button(color(brightness-7), darken(color(brightness-93), 10%));
             }
         }
     }

--- a/ArticleTemplates/assets/scss/tones/_tone--live.scss
+++ b/ArticleTemplates/assets/scss/tones/_tone--live.scss
@@ -281,11 +281,11 @@
 
                 .inline-list__item {
                     a {
-                        @include tag-button(color(brightness-7), color(blogs-tags));
+                        @include tag-button(color(brightness-7), color(brightness-93));
                     }
 
                     &.more-button a {
-                        @include tag-more-button(color(brightness-7), darken(color(blogs-tags), 10%));
+                        @include tag-more-button(color(brightness-7), darken(color(brightness-93), 10%));
                     }
                 }
             }


### PR DESCRIPTION
With the special report page background becoming a little darker, tag button backgrounds became hard to see. This restores their visibility.

This PR also removes some tag-specific colour vairables that shouldn't be necessary anymore

<img src='https://user-images.githubusercontent.com/4561/39197278-02f219b6-47dc-11e8-984b-5adbdc4de562.jpeg' width=375>
