### PR TITLE
Softer link underlines

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
+++ b/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
@@ -116,14 +116,14 @@ $meta-lead: 2.2rem;
         padding-bottom: .2em;
 
         // Underline via gradient background
-        background-image: linear-gradient(rgba($color-accent, .25) 0%, $color-accent 100%);
+        background-image: linear-gradient(rgba($color, .33) 0%, rgba($color, .33) 100%);
         background-repeat: repeat-x;
         background-size: 1px 1px;
         background-position: 0 bottom;
 
         // Tweak position + thickness for high res (1.75x and up) displays
         @media (-webkit-min-device-pixel-ratio: 1.75), (min-resolution: 168dpi) {
-            background-image: linear-gradient(rgba($color-accent, .25) 0%, $color-accent 100%);
+            background-image: linear-gradient(rgba($color, .33) 0%, rgba($color, .33) 100%);
             background-position: 0 93%;
         }
 


### PR DESCRIPTION
**Before**
<img src=https://user-images.githubusercontent.com/4561/39567284-665d16f0-4eb6-11e8-971a-76a01d947a3d.png width=375>

**After**
<img src=https://user-images.githubusercontent.com/4561/39567281-63f72c84-4eb6-11e8-8098-1d1c149da8a6.png width=375>

