### PR TITLE
Liveblog standfirst spacing & typeface

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-type/_live.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_live.scss
@@ -51,6 +51,8 @@
                 font-size: 1.6rem;
                 line-height: 2rem;
                 padding-bottom: base-px(2.5);
+                font-family: $egyptian-text;
+
                 li:before {
                     margin-right: 6px;
                 }

--- a/ArticleTemplates/assets/scss/garnett-type/_live.scss
+++ b/ArticleTemplates/assets/scss/garnett-type/_live.scss
@@ -50,6 +50,7 @@
                 font-weight: 600;
                 font-size: 1.6rem;
                 line-height: 2rem;
+                padding-bottom: base-px(2.5);
                 li:before {
                     margin-right: 6px;
                 }


### PR DESCRIPTION
Adds some padding below the liveblog standfirst, and changes the typeface to text egyptian

**Before**
<img src=https://user-images.githubusercontent.com/4561/39567677-b44c64fa-4eb7-11e8-955a-6e33b29df183.png width=375>

**After**
<img src=https://user-images.githubusercontent.com/4561/39567695-c059f172-4eb7-11e8-916e-7bb82709d34a.png width=375>

