### PR TITLE
The lost PR: highlight all links in standfirsts

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
@@ -273,7 +273,7 @@
         .prose,
         .standfirst {
             // text links
-            p, li {
+            &, p, li {
                 @include text-underline($kicker, $feature);
             }
         }

--- a/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/garnett-pillar/_colour.scss
@@ -273,9 +273,7 @@
         .prose,
         .standfirst {
             // text links
-            &, p, li {
-                @include text-underline($kicker, $feature);
-            }
+            @include text-underline($kicker, $feature);
         }
 
         table {


### PR DESCRIPTION
Fixes link highlighting bug in templates.

Occasionally standfirsts come in from MAPI without a `<p>` tag wrapper. When this happened, links were not getting underlines — and now they will.