### PR TITLE
Speed up unit tests by using fake timers

### DIFF
--- a/test/spec/unit/bootstraps/liveblogTest.js
+++ b/test/spec/unit/bootstraps/liveblogTest.js
@@ -6,7 +6,8 @@ define([
     'use strict';
 
     describe('ArticleTemplates/assets/js/bootstraps/liveblog', function () {
-        var liveblog,
+        var clock,
+            liveblog,
             container,
             sandbox,
             liveblogBody;
@@ -20,6 +21,8 @@ define([
 
         beforeEach(function (done) {
             var injector = new Squire();
+
+            clock = sinon.useFakeTimers();
 
             container = document.createElement('div');
             container.id = 'container';
@@ -91,6 +94,7 @@ define([
             delete window.GU;
 
             sandbox.restore();
+            clock.restore();
         });
 
         describe('init()', function () {
@@ -149,7 +153,7 @@ define([
                 expect(window.addEventListener).to.have.been.calledWith('scroll');
             });
 
-            it('add click listener on load more element', function (done) {
+            it('add click listener on load more element', function () {
                 var event,
                     loadingElem = document.createElement('div'),
                     loadMoreElem = document.createElement('div');
@@ -169,14 +173,12 @@ define([
                 event.initEvent('click', true, true);
                 loadMoreElem.dispatchEvent(event);
 
-                setTimeout(function () {
-                    expect(loadMoreElem.style.display).not.to.eql('block');
-                    expect(loadingElem.classList.contains('loading--visible')).to.eql(true);
-                    expect(utilMock.signalDevice).to.have.been.calledOnce;
-                    expect(utilMock.signalDevice).to.have.been.calledWith('showmore');
+                clock.tick(1500)
 
-                    done();
-                }, 1000);
+                expect(loadMoreElem.style.display).not.to.eql('block');
+                expect(loadingElem.classList.contains('loading--visible')).to.eql(true);
+                expect(utilMock.signalDevice).to.have.been.calledOnce;
+                expect(utilMock.signalDevice).to.have.been.calledWith('showmore');
             });
 
             it('does not setup liveblogTime interval if the minute', function () {

--- a/test/spec/unit/modules/adsTest.js
+++ b/test/spec/unit/modules/adsTest.js
@@ -6,7 +6,8 @@ define([
     'use strict';
 
     describe('ArticleTemplates/assets/js/modules/ads', function () {
-        var ads,
+        var clock,
+            ads,
             sandbox,
             container;
 
@@ -14,6 +15,8 @@ define([
 
         beforeEach(function (done) {
             var injector = new Squire();
+
+            clock = sinon.useFakeTimers();
 
             sandbox = sinon.sandbox.create();
 
@@ -68,6 +71,7 @@ define([
             delete window.GuardianJSInterface;
 
             sandbox.restore();
+            clock.restore();
         });
 
         describe('init(config)', function () {
@@ -213,7 +217,7 @@ define([
                     };
                 });
 
-                it('call signalDevice with ad_moved if position has changed', function (done) {
+                it('call signalDevice with ad_moved if position has changed', function () {
                     var advertSlotWrapper;
 
                     ads.init(config);
@@ -222,20 +226,18 @@ define([
 
                     advertSlotWrapper.style.top = '50px';
 
-                    setTimeout(function () {
-                        expect(utilMock.signalDevice).to.have.been.calledOnce;
-                        expect(utilMock.signalDevice).to.have.been.calledWith('ad_moved');
-                        done();
-                    }, 1100);
+                    clock.tick(1100);
+
+                    expect(utilMock.signalDevice).to.have.been.calledOnce;
+                    expect(utilMock.signalDevice).to.have.been.calledWith('ad_moved');
                 });
 
-                it('do not call signalDevice with ad_moved if position has not changed', function (done) {
+                it('do not call signalDevice with ad_moved if position has not changed', function () {
                     ads.init(config);
 
-                    setTimeout(function () {
-                        expect(utilMock.signalDevice).to.not.have.been.called;
-                        done();
-                    }, 1100);
+                    clock.tick(1100);
+
+                    expect(utilMock.signalDevice).to.not.have.been.called;
                 });
             });
         });
@@ -263,13 +265,11 @@ define([
                 };
             });
 
-            it('inserts liveblog ads after 2nd and 7th blocks', function (done) {
+            it('inserts liveblog ads after 2nd and 7th blocks', function () {
                 ads.init(config);
 
                 expect(articleBody.children[2].classList.contains('advert-slot--mpu')).to.eql(true);
                 expect(articleBody.children[8].classList.contains('advert-slot--mpu')).to.eql(true);
-
-                done();
             });
 
             it('if reset true replaces liveblog ads and calls signalDevice with ad_moved', function () {
@@ -333,12 +333,10 @@ define([
 
 
 
-            it('inserts liveblog ad after the 3rd block instead', function (done) {
+            it('inserts liveblog ad after the 3rd block instead', function () {
                 ads.init(config);
 
                 expect(articleBody.children[4].classList.contains('advert-slot--mpu')).to.eql(true);
-
-                done();
             });
         });
 
@@ -361,21 +359,19 @@ define([
                 };
             });
 
-            it('if first run and android updates ad position', function (done) {
+            it('if first run and android updates ad position', function () {
                 GU.opts.platform = 'android';
 
                 ads.init(config);
 
                 window.initMpuPoller();
 
-                setTimeout(function () {
-                    expect(window.GuardianJSInterface.mpuAdsPosition).to.have.been.calledOnce;
+                clock.tick(1100);
 
-                    done();
-                }, 1100);
+                expect(window.GuardianJSInterface.mpuAdsPosition).to.have.been.calledOnce;
             });
 
-            it('if second run, android and position has changed update ad position', function (done) {
+            it('if second run, android and position has changed update ad position', function () {
                 GU.opts.platform = 'android';
 
                 ads.init(config);
@@ -384,25 +380,21 @@ define([
 
                 advertSlotWrapper.style.top = '50px';
 
-                setTimeout(function () {
-                    expect(window.GuardianJSInterface.mpuAdsPosition).to.have.been.calledTwice;
-                    
-                    done();
-                }, 1100);
+                clock.tick(1100);
+
+                expect(window.GuardianJSInterface.mpuAdsPosition).to.have.been.calledTwice;
             });
 
-            it('if second run, android and position has not changed does not update ad position', function (done) {
+            it('if second run, android and position has not changed does not update ad position', function () {
                 GU.opts.platform = 'android';
 
                 ads.init(config);
 
                 window.initMpuPoller();
 
-                setTimeout(function () {
-                    expect(window.GuardianJSInterface.mpuAdsPosition).to.have.been.calledOnce;
-                    
-                    done();
-                }, 1100);
+                clock.tick(1100);
+
+                expect(window.GuardianJSInterface.mpuAdsPosition).to.have.been.calledOnce;
             });
         });
 

--- a/test/spec/unit/modules/commentsTest.js
+++ b/test/spec/unit/modules/commentsTest.js
@@ -6,7 +6,8 @@ define([
     'use strict';
 
     describe('ArticleTemplates/assets/js/modules/comments', function () {
-        var comments,
+        var clock,
+            comments,
             sandbox,
             container;
 
@@ -17,6 +18,8 @@ define([
             var injector = new Squire();
 
             sandbox = sinon.sandbox.create();
+
+            clock = sinon.useFakeTimers();
 
             container = document.createElement('div');
             container.id = 'container';
@@ -47,6 +50,7 @@ define([
             delete window.applyNativeFunctionCall;
 
             sandbox.restore();
+            clock.restore();
         });
 
         describe('init()', function () {
@@ -204,7 +208,7 @@ define([
                     expect(discussionBlockElem.classList.contains('block--discussion-thread--checked')).to.eql(true);
                 });
 
-                it('can handle click on more replies button', function (done) {
+                it('can handle click on more replies button', function () {
                     var event,
                         moreRepliesButton,
                         discussionBlockElem = buildDiscussionBlockElem(false, 10);
@@ -222,15 +226,13 @@ define([
                     event.initEvent('click', true, true);
                     moreRepliesButton.dispatchEvent(event);
 
-                    setTimeout(function () {
-                        expect(moreRepliesButton.style.display).to.eql('none');
-                        expect(discussionBlockElem.classList.contains('expand')).to.eql(true);
+                    clock.tick(500);
 
-                        done();
-                    }, 500);
+                    expect(moreRepliesButton.style.display).to.eql('none');
+                    expect(discussionBlockElem.classList.contains('expand')).to.eql(true);
                 });
 
-                it('ignores click on comment child which matches querySelector: a', function (done) {
+                it('ignores click on comment child which matches querySelector: a', function () {
                     var event,
                         childElem,
                         commentElem = document.createElement('div'),
@@ -254,14 +256,12 @@ define([
                     event.initEvent('click', true, true);
                     childElem.dispatchEvent(event);
 
-                    setTimeout(function () {
-                        expect(commentElem.firstElementChild.classList.contains('comment--open')).to.eql(true);
+                    clock.tick(500);
 
-                        done();
-                    }, 500);
+                    expect(commentElem.firstElementChild.classList.contains('comment--open')).to.eql(true);
                 });
 
-                it('ignores click on comment child which matches querySelector: .more--comments', function (done) {
+                it('ignores click on comment child which matches querySelector: .more--comments', function () {
                     var event,
                         childElem,
                         commentElem = document.createElement('div'),
@@ -285,14 +285,12 @@ define([
                     event.initEvent('click', true, true);
                     childElem.dispatchEvent(event);
 
-                    setTimeout(function () {
-                        expect(commentElem.firstElementChild.classList.contains('comment--open')).to.eql(true);
+                    clock.tick(500);
 
-                        done();
-                    }, 500);
+                    expect(commentElem.firstElementChild.classList.contains('comment--open')).to.eql(true);
                 });
 
-                it('ignores click on comment child which matches querySelector: .comment__reply', function (done) {
+                it('ignores click on comment child which matches querySelector: .comment__reply', function () {
                     var event,
                         childElem,
                         commentElem = document.createElement('div'),
@@ -316,14 +314,12 @@ define([
                     event.initEvent('click', true, true);
                     childElem.dispatchEvent(event);
 
-                    setTimeout(function () {
-                        expect(commentElem.firstElementChild.classList.contains('comment--open')).to.eql(true);
+                    clock.tick(500);
 
-                        done();
-                    }, 500);
+                    expect(commentElem.firstElementChild.classList.contains('comment--open')).to.eql(true);
                 });
 
-                it('ignores click on comment child which matches querySelector: .comment__recommend', function (done) {
+                it('ignores click on comment child which matches querySelector: .comment__recommend', function () {
                     var event,
                         childElem,
                         commentElem = document.createElement('div'),
@@ -347,14 +343,12 @@ define([
                     event.initEvent('click', true, true);
                     childElem.dispatchEvent(event);
 
-                    setTimeout(function () {
-                        expect(commentElem.firstElementChild.classList.contains('comment--open')).to.eql(true);
+                    clock.tick(500);
 
-                        done();
-                    }, 500);
+                    expect(commentElem.firstElementChild.classList.contains('comment--open')).to.eql(true);
                 });
 
-                it('can handle click on comment child which matches querySelector: .comment__header', function (done) {
+                it('can handle click on comment child which matches querySelector: .comment__header', function () {
                     var event,
                         childElem,
                         commentElem = document.createElement('div'),
@@ -376,14 +370,12 @@ define([
                     event.initEvent('click', true, true);
                     childElem.dispatchEvent(event);
 
-                    setTimeout(function () {
-                        expect(commentElem.firstElementChild.classList.contains('comment--open')).to.eql(false);
+                    clock.tick(500);
 
-                        done();
-                    }, 500);
+                    expect(commentElem.firstElementChild.classList.contains('comment--open')).to.eql(false);
                 });
 
-                it('can handle click on comment child which matches querySelector: .comment__body', function (done) {
+                it('can handle click on comment child which matches querySelector: .comment__body', function () {
                     var event,
                         childElem,
                         commentElem = document.createElement('div'),
@@ -405,14 +397,12 @@ define([
                     event.initEvent('click', true, true);
                     childElem.dispatchEvent(event);
 
-                    setTimeout(function () {
-                        expect(commentElem.firstElementChild.classList.contains('comment--open')).to.eql(false);
+                    clock.tick(500);
 
-                        done();
-                    }, 500);
+                    expect(commentElem.firstElementChild.classList.contains('comment--open')).to.eql(false);
                 });
 
-                it('can close other comments on click if they are open', function (done) {
+                it('can close other comments on click if they are open', function () {
                     var event,
                         childElem,
                         commentElem = document.createElement('div'),
@@ -436,12 +426,10 @@ define([
                     event.initEvent('click', true, true);
                     childElem.dispatchEvent(event);
 
-                    setTimeout(function () {
-                        expect(otherCommentElem.firstElementChild.classList.contains('comment--open')).to.eql(false);
-                        expect(commentElem.firstElementChild.classList.contains('comment--open')).to.eql(true);
+                    clock.tick(500);
 
-                        done();
-                    }, 500);
+                    expect(otherCommentElem.firstElementChild.classList.contains('comment--open')).to.eql(false);
+                    expect(commentElem.firstElementChild.classList.contains('comment--open')).to.eql(true);
                 });
             });
         });

--- a/test/spec/unit/modules/moreTagsTest.js
+++ b/test/spec/unit/modules/moreTagsTest.js
@@ -6,7 +6,8 @@ define([
     'use strict';
 
     describe('ArticleTemplates/assets/js/modules/more-tags', function () {
-        var moreTags,
+        var clock,
+            moreTags,
             container,
             getTagsHTML = function (count) {
                 var i,
@@ -24,6 +25,8 @@ define([
         beforeEach(function (done) {
             var injector = new Squire();
 
+            clock = sinon.useFakeTimers();
+
             container = document.createElement('div');
             container.id = 'container';
             document.body.appendChild(container);
@@ -37,6 +40,7 @@ define([
 
         afterEach(function () {
             document.body.removeChild(container);
+            clock.restore();
         });
 
         describe('init()', function () {
@@ -77,7 +81,7 @@ define([
                 }
             });
 
-            it('show tags on click of more button', function (done) {
+            it('show tags on click of more button', function () {
                 var moreTagsContainer,
                     event = document.createEvent('HTMLEvents'),
                     lastInlineListItem;
@@ -97,12 +101,10 @@ define([
                 event.initEvent('click', true, true);
                 moreTagsContainer.dispatchEvent(event);
 
-                setTimeout(function () {
-                    expect(moreTagsContainer.style.display).to.eql('none');
-                    expect(lastInlineListItem.classList.contains('hide-tags')).to.eql(false);
+                clock.tick(200)
 
-                    done();
-                }, 250);
+                expect(moreTagsContainer.style.display).to.eql('none');
+                expect(lastInlineListItem.classList.contains('hide-tags')).to.eql(false);
             });
         });
     });

--- a/test/spec/unit/modules/youtubeTest.js
+++ b/test/spec/unit/modules/youtubeTest.js
@@ -10,10 +10,11 @@ define([
      * causing tests to intermittently fail on CircleCI.
      * Skipping for now, but we should revisit.
      */
-    describe.skip('ArticleTemplates/assets/js/modules/youtube', function () {
-        this.timeout(15000);
+    describe('ArticleTemplates/assets/js/modules/youtube', function () {
+        // this.timeout(15000);
 
-        var youtube,
+        var clock,
+            youtube,
             scriptAdded,
             sandbox,
             container,
@@ -83,6 +84,8 @@ define([
 
         beforeEach(function (done) {
             var injector = new Squire();
+
+            clock = sinon.useFakeTimers();
 
             sandbox = sinon.sandbox.create();
 
@@ -168,6 +171,7 @@ define([
             delete window.GuardianJSInterface;
 
             sandbox.restore();
+            clock.restore();
         });
 
         it('does not add youtube script if no youtube iframe on page', function () {
@@ -243,7 +247,7 @@ define([
             expect(iframe.parentNode.classList.contains('show-video')).to.eql(true);
         });
 
-        it('plays video on placeholder click and hides placeholder', function (done) {
+        it('plays video on placeholder click and hides placeholder', function () {
             var videoWrapper = getVideoWrapper('video1');
 
             container.appendChild(videoWrapper);
@@ -253,15 +257,13 @@ define([
             window.YT.players[0].onReady('video1');
             startVideoWithTap(videoWrapper, window.YT.players[0]);
 
-            setTimeout(function () {
-                expect(videoWrapper.classList.contains('show-video')).to.eql(true);
-                expect(videoWrapper.classList.contains('hide-placeholder')).to.eql(true);
+            clock.tick(500);
 
-                done();
-            }, 500);
+            expect(videoWrapper.classList.contains('show-video')).to.eql(true);
+            expect(videoWrapper.classList.contains('hide-placeholder')).to.eql(true);
         });
 
-        it('plays native video on touchpoint click if nativeYoutubeEnabled is true', function (done) {
+        it('plays native video on touchpoint click if nativeYoutubeEnabled is true', function () {
             var videoWrapper = getVideoWrapper('video1');
 
             container.appendChild(videoWrapper);
@@ -273,13 +275,11 @@ define([
             window.YT.players[0].onReady('video1');
             startVideoWithTap(videoWrapper, window.YT.players[0], true);
 
-            setTimeout(function () {
-                expect(videoWrapper.classList.contains('show-video')).to.eql(false);
-                expect(videoWrapper.classList.contains('hide-placeholder')).to.eql(false);
-                expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:start'}));
+            clock.tick(500);
 
-                done();
-            }, 500);
+            expect(videoWrapper.classList.contains('show-video')).to.eql(false);
+            expect(videoWrapper.classList.contains('hide-placeholder')).to.eql(false);
+            expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:start'}));
         });
 
         it('initialiseVideos if scriptReady when checkForVideos called', function () {
@@ -316,7 +316,7 @@ define([
                 expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:start'}));
             });
 
-            it('handles onPlayerStateChange when PLAYING from PAUSED position', function (done) {
+            it('handles onPlayerStateChange when PLAYING from PAUSED position', function () {
                 var videoWrapper = getVideoWrapper('video1');
 
                 container.appendChild(videoWrapper);
@@ -327,25 +327,23 @@ define([
                 window.YT.players[0].onReady('video1');
                 setPlayerState('PLAYING', window.YT.players[0]);
 
-                setTimeout(function () {
-                    // Pause Video
-                    setPlayerState('PAUSED', window.YT.players[0]);
+                clock.tick(500);
 
-                    // Restart Video
-                    setPlayerState('PLAYING', window.YT.players[0]);
+                // Pause Video
+                setPlayerState('PAUSED', window.YT.players[0]);
 
-                    expect(Player.prototype.getCurrentTime).to.have.been.called;
-                    expect(utilMock.signalDevice).to.have.been.calledOnce;
-                    expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:start'}));
+                // Restart Video
+                setPlayerState('PLAYING', window.YT.players[0]);
 
-                    // End video to kill progress tracker
-                    setPlayerState('ENDED', window.YT.players[0]);
+                expect(Player.prototype.getCurrentTime).to.have.been.called;
+                expect(utilMock.signalDevice).to.have.been.calledOnce;
+                expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:start'}));
 
-                    done();
-                }, 500);
+                // End video to kill progress tracker
+                setPlayerState('ENDED', window.YT.players[0]);
             });
 
-            it('handles onPlayerStateChange and tracks progress', function (done) {
+            it('handles onPlayerStateChange and tracks progress', function () {
                 var videoWrapper = getVideoWrapper('video1');
 
                 container.appendChild(videoWrapper);
@@ -356,19 +354,17 @@ define([
                 window.YT.players[0].onReady('video1');
                 setPlayerState('PLAYING', window.YT.players[0]);
 
-                setTimeout(function () {
-                    expect(utilMock.signalDevice).to.have.been.called;
-                    expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:start'}));
-                    expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:25'}));
+                clock.tick(8000);
 
-                    // End video to kill progress tracker
-                    setPlayerState('ENDED', window.YT.players[0]);
+                expect(utilMock.signalDevice).to.have.been.called;
+                expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:start'}));
+                expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:25'}));
 
-                    done();
-                }, 8000);
+                // End video to kill progress tracker
+                setPlayerState('ENDED', window.YT.players[0]);
             });
 
-            it('pauses video when other video begins and track new video', function (done) {
+            it('pauses video when other video begins and track new video', function () {
                 var videoWrapper1 = getVideoWrapper('video1'),
                     videoWrapper2 = getVideoWrapper('video2');
 
@@ -385,22 +381,19 @@ define([
                 window.YT.players[1].onReady('video2');
                 setPlayerState('PLAYING', window.YT.players[1]);
 
-                setTimeout(function () {
-                    // End video to kill progress tracker
-                    setPlayerState('ENDED', window.YT.players[1]);
+                clock.tick(8000);
 
-                    expect(utilMock.signalDevice).to.have.been.called;
-                    expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:start'}));
-                    expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video2', eventType:'video:content:start'}));
-                    expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video2', eventType:'video:content:25'}));
-                    expect(window.YT.players.length).to.eql(2);
-                    expect(Player.prototype.pauseVideo).to.have.been.calledTwice;
+                setPlayerState('ENDED', window.YT.players[1]);
 
-                    done();
-                }, 8000);
+                expect(utilMock.signalDevice).to.have.been.called;
+                expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:start'}));
+                expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video2', eventType:'video:content:start'}));
+                expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video2', eventType:'video:content:25'}));
+                expect(window.YT.players.length).to.eql(2);
+                expect(Player.prototype.pauseVideo).to.have.been.calledTwice;
             });
 
-            it('handles onPlayerStateChange when PAUSED', function (done) {
+            it('handles onPlayerStateChange when PAUSED', function () {
                 var videoWrapper = getVideoWrapper('video1');
 
                 container.appendChild(videoWrapper);
@@ -414,18 +407,16 @@ define([
                 // Pause video
                 setPlayerState('PAUSED', window.YT.players[0]);
 
-                setTimeout(function () {
-                    expect(utilMock.signalDevice).to.have.been.calledOnce;
-                    expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:start'}));
+                clock.tick(8000);
 
-                    // End video to kill progress tracker
-                    setPlayerState('ENDED', window.YT.players[0]);
+                expect(utilMock.signalDevice).to.have.been.calledOnce;
+                expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:start'}));
 
-                    done();
-                }, 8000);
+                // End video to kill progress tracker
+                setPlayerState('ENDED', window.YT.players[0]);
             });
 
-            it('handles onPlayerStateChange when ENDED', function (done) {
+            it('handles onPlayerStateChange when ENDED', function () {
                 var videoWrapper = getVideoWrapper('video1');
 
                 videoWrapper.classList.add('hide-placeholder');
@@ -437,14 +428,12 @@ define([
 
                 setPlayerState('ENDED', window.YT.players[0]);
 
-                setTimeout(function () {
-                    expect(videoWrapper.classList.contains('hide-placeholder')).to.eql(false);
-                    expect(videoWrapper.classList.contains('show-video')).to.eql(false);
-                    expect(utilMock.signalDevice).to.have.been.calledOnce;
-                    expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:end'}));
+                clock.tick(1500);
 
-                    done();
-                }, 1500);
+                expect(videoWrapper.classList.contains('hide-placeholder')).to.eql(false);
+                expect(videoWrapper.classList.contains('show-video')).to.eql(false);
+                expect(utilMock.signalDevice).to.have.been.calledOnce;
+                expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:end'}));
             });
         });
 
@@ -468,7 +457,7 @@ define([
                 expect(window.GuardianJSInterface.trackAction).not.to.have.been.called;
             });
 
-            it('handles onPlayerStateChange when PLAYING from start', function (done) {
+            it('handles onPlayerStateChange when PLAYING from start', function () {
                 var videoWrapper = getVideoWrapper('video1');
 
                 container.appendChild(videoWrapper);
@@ -482,11 +471,9 @@ define([
                 expect(Player.prototype.getCurrentTime).to.have.been.called;
                 expect(window.GuardianJSInterface.trackAction).to.have.been.calledOnce;
                 expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:start'}));
-
-                done();
             });
 
-            it('handles onPlayerStateChange when PLAYING from PAUSED position', function (done) {
+            it('handles onPlayerStateChange when PLAYING from PAUSED position', function () {
                 var videoWrapper = getVideoWrapper('video1');
 
                 container.appendChild(videoWrapper);
@@ -497,25 +484,22 @@ define([
                 window.YT.players[0].onReady('video1');
                 setPlayerState('PLAYING', window.YT.players[0]);
 
-                setTimeout(function () {
-                    // Pause Video
-                    setPlayerState('PAUSED', window.YT.players[0]);
+                clock.tick(500);
 
-                    // Restart Video
-                    setPlayerState('PLAYING', window.YT.players[0]);
+                setPlayerState('PAUSED', window.YT.players[0]);
 
-                    expect(Player.prototype.getCurrentTime).to.have.been.called;
-                    expect(window.GuardianJSInterface.trackAction).to.have.been.calledOnce;
-                    expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:start'}));
+                // Restart Video
+                setPlayerState('PLAYING', window.YT.players[0]);
 
-                    // End video to kill progress tracker
-                    setPlayerState('ENDED', window.YT.players[0]);
+                expect(Player.prototype.getCurrentTime).to.have.been.called;
+                expect(window.GuardianJSInterface.trackAction).to.have.been.calledOnce;
+                expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:start'}));
 
-                    done();
-                }, 500);
+                // End video to kill progress tracker
+                setPlayerState('ENDED', window.YT.players[0]);
             });
 
-            it('handles onPlayerStateChange and tracks progress', function (done) {
+            it('handles onPlayerStateChange and tracks progress', function () {
                 var videoWrapper = getVideoWrapper('video1');
 
                 container.appendChild(videoWrapper);
@@ -526,19 +510,17 @@ define([
                 window.YT.players[0].onReady('video1');
                 setPlayerState('PLAYING', window.YT.players[0]);
 
-                setTimeout(function () {
-                    expect(window.GuardianJSInterface.trackAction).to.have.been.called;
-                    expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:start'}));
-                    expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:25'}));
+                clock.tick(8000);
 
-                    // End video to kill progress tracker
-                    setPlayerState('ENDED', window.YT.players[0]);
+                expect(window.GuardianJSInterface.trackAction).to.have.been.called;
+                expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:start'}));
+                expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:25'}));
 
-                    done();
-                }, 8000);
+                // End video to kill progress tracker
+                setPlayerState('ENDED', window.YT.players[0]);
             });
 
-            it('pauses video when other video begins and track new video', function (done) {
+            it('pauses video when other video begins and track new video', function () {
                 var videoWrapper1 = getVideoWrapper('video1'),
                     videoWrapper2 = getVideoWrapper('video2');
 
@@ -555,22 +537,20 @@ define([
                 window.YT.players[1].onReady('video2');
                 setPlayerState('PLAYING', window.YT.players[1]);
 
-                setTimeout(function () {
-                    // End video to kill progress tracker
-                    setPlayerState('ENDED', window.YT.players[1]);
+                clock.tick(8000);
 
-                    expect(window.GuardianJSInterface.trackAction).to.have.been.called;
-                    expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:start'}));
-                    expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video2', eventType:'video:content:start'}));
-                    expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video2', eventType:'video:content:25'}));
-                    expect(window.YT.players.length).to.eql(2);
-                    expect(Player.prototype.pauseVideo).to.have.been.calledTwice;
+                // End video to kill progress tracker
+                setPlayerState('ENDED', window.YT.players[1]);
 
-                    done();
-                }, 8000);
+                expect(window.GuardianJSInterface.trackAction).to.have.been.called;
+                expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:start'}));
+                expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video2', eventType:'video:content:start'}));
+                expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video2', eventType:'video:content:25'}));
+                expect(window.YT.players.length).to.eql(2);
+                expect(Player.prototype.pauseVideo).to.have.been.calledTwice;
             });
 
-            it('handles onPlayerStateChange when PAUSED', function (done) {
+            it('handles onPlayerStateChange when PAUSED', function () {
                 var videoWrapper = getVideoWrapper('video1');
 
                 container.appendChild(videoWrapper);
@@ -584,18 +564,16 @@ define([
                 // Pause video
                 setPlayerState('PAUSED', window.YT.players[0]);
 
-                setTimeout(function () {
-                    expect(window.GuardianJSInterface.trackAction).to.have.been.calledOnce;
-                    expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:start'}));
+                clock.tick(8000);
 
-                    // End video to kill progress tracker
-                    setPlayerState('ENDED', window.YT.players[0]);
+                expect(window.GuardianJSInterface.trackAction).to.have.been.calledOnce;
+                expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:start'}));
 
-                    done();
-                }, 8000);
+                // End video to kill progress tracker
+                setPlayerState('ENDED', window.YT.players[0]);
             });
 
-            it('handles onPlayerStateChange when ENDED', function (done) {
+            it('handles onPlayerStateChange when ENDED', function () {
                 var videoWrapper = getVideoWrapper('video1');
 
                 videoWrapper.classList.add('hide-placeholder');
@@ -607,14 +585,12 @@ define([
 
                 setPlayerState('ENDED', window.YT.players[0]);
 
-                setTimeout(function () {
-                    expect(videoWrapper.classList.contains('hide-placeholder')).to.eql(false);
-                    expect(videoWrapper.classList.contains('show-video')).to.eql(false);
-                    expect(window.GuardianJSInterface.trackAction).to.have.been.calledOnce;
-                    expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:end'}));
+                clock.tick(1500);
 
-                    done();
-                }, 1500);
+                expect(videoWrapper.classList.contains('hide-placeholder')).to.eql(false);
+                expect(videoWrapper.classList.contains('show-video')).to.eql(false);
+                expect(window.GuardianJSInterface.trackAction).to.have.been.calledOnce;
+                expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:end'}));
             });
         });
     });


### PR DESCRIPTION
The unit tests previously used `setTimeout` to test asynchronous code, this meant the tests were sloooooooow. I've replaced all setTimeouts and now use `sinon`'s implementation of `useFakeTimers`. The tests are much faster now , previously they took 15+ seconds 😖 now they take 2 seconds :boom: