### PR TITLE
fix element-interactive embed bug

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/common.js
+++ b/ArticleTemplates/assets/js/bootstraps/common.js
@@ -24,8 +24,6 @@ define([
     var trackCommentContainerView = true;
         
     function init() {
-        console.log('**');
-
         fastClick.attach(document.body); // polyfill to remove click delays on browsers with touch
         formatImages();
         figcaptionToggle();

--- a/ArticleTemplates/assets/scss/garnett-layout/_article--shared.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_article--shared.scss
@@ -41,14 +41,6 @@
         // Interactives within article body
         .element-interactive {
             width: auto;
-
-            @include mq(col2, col3) {
-                width: calc(#{(100% / (100% - cols($base-3, 3))) * 100%} - #{base-px(1)});
-            }
-
-            @include mq($from: col3) {
-                width: calc(#{(100% / (100% - cols($base-4, 4))) * 100%} - #{base-px(1)});
-            }
         }
 
         .element-video:not(.element-youtube) {

--- a/test/fixtures/comment-opinion-interactive.html
+++ b/test/fixtures/comment-opinion-interactive.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en-US">
+   <head>
+      <title>Article</title>
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
+      <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="../../ArticleTemplates/assets/css/fonts-ios.css" />
+      <link rel="stylesheet" type="text/css" media="all" href="../../ArticleTemplates/assets/css/garnett-style-sync.css" />
+      <style>/* <-- */
+         /* --> */
+      </style>
+      <script type="text/javascript">
+         window.GU = window.GU || {};
+      </script>
+      <script type="text/javascript" src="../../ArticleTemplates/assets/build/polyfills/promise.js"></script>
+      <script type="text/javascript" src="../../ArticleTemplates/assets/build/polyfills/requestAnimationFrame.js"></script>
+      <script type="text/javascript" src="../../ArticleTemplates/assets/build/bootstrap.js"></script>
+   </head>
+   <body class="garnett--type-comment garnett--pillar-opinion tone--comment font-size-4 ios  advert-config--tablet  " data-content-type="article" data-ads-enabled="mpu" data-ads-enable-hiding="true" data-ads-config="tablet" style="margin-top: 0px;" data-font-size="4" data-template-directory="../../ArticleTemplates/" data-page-id="commentisfree/2018/jun/06/the-untold-story-of-the-death-of-the-nbn" data-mpu-after-paragraphs="3" data-use-ads-ready="true" data-content-section="National broadband network (NBN)">
+      <div class="article article--comment" id="comment-article-container">
+         <div class="article__header cutout" id="comment-header">
+            <div class="section section__container hide-garnett" id="section">
+               <div class="content__container">
+                  <div class="content__labels__container">
+                     <div class="content__labels">National broadband network (NBN)</div>
+                     <div class="content__series-label content__labels"></div>
+                  </div>
+                  <div class="comment-count">
+                     <a href="x-gu://showcomments">
+                     <span data-icon="&#xe03c;" aria-hidden="true"></span><span id="comment-count">93 </span>
+                     <span class="screen-readable">Comments</span>
+                     </a>
+                  </div>
+               </div>
+            </div>
+            <div class="cutout__container" id="cutout-container">
+               <div class="cutout__image" style="background-image: url(https://i.guim.co.uk/img/uploads/2017/10/06/First-Dog-on-the-Moon,_L.png?w=600&h=360&quality=35&sig-ignores-params=true&s=a0b222cc7c06c6dbe32a6f5443e39be0);"></div>
+               <div class="article-kicker show-garnett">
+                  <div class='article-kicker__section'>National broadband network (NBN)</div>
+                  <div class='article-kicker__series'>
+                     <span class='article-kicker__highlight'></span>
+                  </div>
+               </div>
+               <h1 class="headline selectable" id="headline">
+                  The untold story of the death of the NBN
+                  <div class="headline__byline"><span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/first-dog-on-the-moon">First Dog on the Moon</a></span></div>
+               </h1>
+            </div>
+            <div class="standfirst selectable" id="standfirst">
+               <div class="standfirst__inner">
+                  <p>Some of us mistakenly thought the purpose of the NBN was so everyone in the country could use the internet as much as they needed</p>
+                  <ul>
+                     <li><a href="x-gu://item/mobile.guardianapis.com/us/items/commentisfree/2014/jun/16/-sp-first-dog-on-the-moon-subscribe-by-email">Sign up here to get an email</a> whenever First Dog cartoons are published</li>
+                     <li><a href="http://firstshoponthemoon.com/">Get all your needs met at the First Dog shop</a> if what you need is First Dog merchandise and prints</li>
+                  </ul>
+               </div>
+            </div>
+            <div class="meta keyline" id="meta">
+               <div class="meta__misc">
+                  <div class="meta__published__comments">
+                     <div class="comment-count">
+                        <a href="x-gu://showcomments">
+                        <span data-icon="&#xe03c;" aria-hidden="true"></span><span id="comment-count">93 </span>
+                        <span class="screen-readable">Comments</span>
+                        </a>
+                     </div>
+                  </div>
+                  <p class="meta__pubdate hide-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">08:30 GMT+1 Wednesday, 06 June 2018</span></p>
+                  <div class='meta__published show-garnett'>
+                     <div class="meta__published__date show-garnett"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">08:30 GMT+1 Wednesday, 06 June 2018</span></div>
+                  </div>
+                  <a class="alerts " href="x-gu://follow/tag-contributor///profile/first-dog-on-the-moon" data-follow-alert-id="tag-contributor///profile/first-dog-on-the-moon">
+                  <span class="alerts__state--unfollow">
+                  <span data-icon="&#xe087;" aria-hidden="true"></span>
+                  <span class="alerts__label">Follow First Dog on the Moon</span>
+                  </span>
+                  <span class="alerts__state--follow">
+                  <span data-icon="&#xe097;" aria-hidden="true"></span>
+                  <span class="alerts__label">Following First Dog on the Moon</span>
+                  </span>
+                  </a>
+               </div>
+            </div>
+            <div class="main-media main-media--hidden-caption" id="main-media">
+            </div>
+         </div>
+         <div class="article__body" id="comment-body">
+            <div class="from-content-api prose resizable selectable" id="comment-body-blocks">
+               <figure class="element element-interactive interactive" data-interactive="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js" data-canonical-url="https://interactive.guim.co.uk/2016/03/comics-master-2016/embed/embed.html?srcs-mobile=https://media.guim.co.uk/c029dd2175252b12644ab2c577d0128328551d2c/0_0_1835_3014/609.jpg+https://media.guim.co.uk/c029dd2175252b12644ab2c577d0128328551d2c/0_3028_1835_4445/413.jpg+https://media.guim.co.uk/c029dd2175252b12644ab2c577d0128328551d2c/0_7473_1835_3155/582.jpg&amp;ratios-mobile=164.4736842105263+242.71844660194174+171.82130584192439&amp;srcs-desktop=https://media.guim.co.uk/a665d1aae7035d4457fbe680e34c0141c3c31861/0_0_3508_6132/1144.jpg&amp;ratios-desktop=174.82517482517483&amp;credit=Cartoon%20by%20First%20Dog%20on%20the%20Moon&amp;background=9933cc&amp;vpadding=1" data-alt="The untold story of the death of the NBN"> 
+                  <a href="https://interactive.guim.co.uk/2016/03/comics-master-2016/embed/embed.html?srcs-mobile=https://media.guim.co.uk/c029dd2175252b12644ab2c577d0128328551d2c/0_0_1835_3014/609.jpg+https://media.guim.co.uk/c029dd2175252b12644ab2c577d0128328551d2c/0_3028_1835_4445/413.jpg+https://media.guim.co.uk/c029dd2175252b12644ab2c577d0128328551d2c/0_7473_1835_3155/582.jpg&amp;ratios-mobile=164.4736842105263+242.71844660194174+171.82130584192439&amp;srcs-desktop=https://media.guim.co.uk/a665d1aae7035d4457fbe680e34c0141c3c31861/0_0_3508_6132/1144.jpg&amp;ratios-desktop=174.82517482517483&amp;credit=Cartoon%20by%20First%20Dog%20on%20the%20Moon&amp;background=9933cc&amp;vpadding=1">The untold story of the death of the NBN</a> 
+               </figure>
+            </div>
+         </div>
+         <div class="tags" id="tags">
+            <span class="screen-readable">Tags:</span>
+            <ul class="inline-list tags__inline-list" id="tag-list"></ul>
+         </div>
+      </div>
+      <section class="related-content">
+         <div class="related-content__wrapper">
+            <h2 class="related-content__header">
+               Related Stories
+            </h2>
+            <div class="loading loading--related" data-icon="&#xe00C;"></div>
+            <div class="block block--failed" id="related-module-failed-block">
+               <div class="block__body">
+                  <p>Related stories are currently unavailable. Please try again later.</p>
+               </div>
+            </div>
+         </div>
+      </section>
+      <div class="container container__outbrain" id="outbrain">
+         <div class="OUTBRAIN outbrainImage" data-widget-id="<%=widgetCode%>" data-src="https://www.theguardian.com/commentisfree/2018/jun/06/the-untold-story-of-the-death-of-the-nbn" data-ob-template="guardian" data-ob-user-id="710CF3DA-EE53-4DA7-9B96-6E7C98D26FAA"></div>
+         <div class="OUTBRAIN outbrainText" data-widget-id="<%=widgetCode%>" data-src="https://www.theguardian.com/commentisfree/2018/jun/06/the-untold-story-of-the-death-of-the-nbn" data-ob-template="guardian" data-ob-user-id="710CF3DA-EE53-4DA7-9B96-6E7C98D26FAA"></div>
+      </div>
+      <!--- Pulling this in here after the outbrain styles so we can override them -->
+      <link rel="stylesheet" type="text/css" media="all" href="../../ArticleTemplates/assets/css/outbrain.css" />
+      <section class="comments comments--module comments-93">
+         <div class="comments__wrapper">
+            <div class="comments__header">
+               <h2 class="comments__title">
+                  <a class="comments__link" href="x-gu://showcomments">
+                  Comments <span class="comments__count">93</span>
+                  </a>
+               </h2>
+               <p class="comments__closed">Comments are closed</p>
+               <a class="comments__post touchpoint touchpoint--primary" href="x-gu://leavecomment">
+               <span class="touchpoint__label">Post a comment</span>
+               <span class="touchpoint__button" data-icon="&#xe03d;" aria-hidden="true"></span>
+               </a>
+            </div>
+            <div class="comments__container">
+               <div class="comments__block comments__block--empty">
+                  <p>
+                     Open for comments. <a href="x-gu://leavecomment">Be the first to join the debate</a>
+                  </p>
+               </div>
+               <div class="comments__block comments__block--failed">
+                  <p>
+                     Comments are currently unavailable. Please try again later.
+                  </p>
+               </div>
+               <div class="comments__block comments__block--loading loading" data-icon="&#xe00C;"></div>
+            </div>
+            <div class="comments__footer">
+               <a class="comments__viewmore touchpoint touchpoint--secondary" href="x-gu://showcomments">
+               <span class="comments__viewmore--label touchpoint__label">View more</span>
+               <span class="comments__viewmore--button touchpoint__button" data-icon="&#xe00b;" aria-hidden="true"></span>
+               </a>
+            </div>
+         </div>
+      </section>
+      <script type="text/javascript">
+         (function () {
+             var atoms = {};
+             function readAtoms() {
+                 
+             }
+             readAtoms.call(atoms);
+             GU.bootstrap.init({
+                 asyncStylesFilename: "garnett-style-async",
+                 sectionTone: "comment",
+                 isAdvertising: "" ? true : false,
+                 fontSize: "font-size-4",
+                 platform: "ios",
+                 isOffline: "" ? true : false,
+                 contentType: "article",
+                 adsEnabled: "mpu",
+                 adsEnableHiding: "true" === "true",
+                 adsConfig: "tablet",
+                 actionBarHeight: "0",
+                 fontSize: "4",
+                 templatesDirectory: "../../ArticleTemplates/",
+                 pageId: "commentisfree/2018/jun/06/the-untold-story-of-the-death-of-the-nbn",
+                 mpuAfterParagraphs: "3",
+                 useAdsReady: "true" === "true",
+                 section: "National broadband network (NBN)",
+                 tests: '',
+                 nativeYoutubeEnabled: "" === "true" ? true : false,
+                 disableEnhancedTweets: "" === "true" ? true : false,
+                 atoms: atoms,
+                 hasEpic: "" === "true"
+             });
+         }());
+      </script>
+   </body>
+</html>


### PR DESCRIPTION
`.element-interactive` emdeds in articles were wider than the width of the viewport on larger devices (eg. iPad), resulting in the lefthand side of the immersive being partially hidden.

An example can be seen in the bug report: https://trello.com/c/R11K2GIS/28-apps-garnett-related-article-embed-bug

This was caused by a `width` being set on these elements in `_article--shared.scss`. Removing this width means the`.element-interactive` inherits the style `width:auto`.

Fixed example...

![screen shot 2018-06-06 at 10 45 15](https://user-images.githubusercontent.com/1590704/41031197-044b9658-6978-11e8-8a1a-ef603e71820a.png)
