### PR TITLE
Fix issues with embed video links

### DIFF
--- a/ArticleTemplates/assets/js/modules/youtube.js
+++ b/ArticleTemplates/assets/js/modules/youtube.js
@@ -254,8 +254,7 @@ define([
     }
 
     function onPlayerPlaying(id) {
-        var placeholderParent,
-            currentTime = Math.round(players[id].player.getCurrentTime());
+        var placeholderParent;
 
         stopPlayers(id);
         setProgressTracker(id);

--- a/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
+++ b/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
@@ -110,7 +110,7 @@ $meta-lead: 2.2rem;
 
 // Link Underline Style
 @mixin text-underline($color, $color-accent) {
-    a {
+    a:not(.video-URL) {
         color: $color;
         text-decoration: none;
         padding-bottom: .2em;

--- a/ArticleTemplates/assets/scss/garnett-modules/content/_meta.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/content/_meta.scss
@@ -103,7 +103,7 @@
         margin-left: base-px(.5);
         border-left: 1px solid color(brightness-86);
         margin-bottom: base-px(.5);
-        margin-top: base-px(-0.5);
+        margin-top: base-px(-.5);
         a {
             position: relative;
             display: block;

--- a/test/fixtures/article-news.html
+++ b/test/fixtures/article-news.html
@@ -126,14 +126,42 @@
                     <p>A common misconception of S&atilde;o Paulo is that people are either super poor and live in favelas, or they are super wealthy and fly in helicopters. I am a middle-class Paulistana who worked hard to go to university and worked hard after that to get a job overseas, in London.</p>
                     <p>It has always been difficult to explain where I come from; that S&atilde;o Paulo has many middle-class neighbourhoods with people living normal lives like those of the middle-class in Europe or the US; that the dichotomy of ultra- rich or miserably poor is not true.</p>
                     <p>This difficulty comes of the middle class being ignored by international media, except when they protest loud enough. It would only be fair to Paulistanos that S&atilde;o Paulo be given a more balanced treatment, reflective of the city’s complex reality. <em>Anonymous</em></p>
-                    <figure class="element element-image element--showcase" data-media-id="c9dab8ae952665993b68f1f698aa7e4578a5df87">
+                    <!-- <figure class="element element-image element--showcase" data-media-id="c9dab8ae952665993b68f1f698aa7e4578a5df87">
                         <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/c9dab8ae952665993b68f1f698aa7e4578a5df87/0_0_3264_2448/master/3264.jpg/129f2d56fabf5d9e4aff7cae68817bab?width=#{width}&height=#{height}&quality=#{quality}"><img src="https://media.guim.co.uk/c9dab8ae952665993b68f1f698aa7e4578a5df87/0_0_3264_2448/1000.jpg" alt="Red blossoms reach out towards the city of S&atilde;o Paulo from the Copan building." width="1000" height="750" class="gu-image" /></a>
                         <figcaption>
                             <span class="element-image__caption">“A city of smoke, city of concrete – and yet there is hope,” wrote student Isabela Chan, who took this photograph of blossoms reaching towards the sun from the roof of the Copan building. “In the background, a myriad of buildings appear to be part of a natural landscape, showing how nature coexists with this megalopolis.”</span>
                             <span class="element-image__credit">Photograph: Isabela Chan</span>
                         </figcaption>
                     </figure>
-                    <p></p>
+                    <p></p> -->
+                    <figure class="element element-placeholder">
+                        <a class="element__inner video-URL" href="x-gu://playvideo/cdn.theguardian.tv/HLS/2016/10/08/161008RobertDeNiro.m3u8">
+                        <img src="https://i.guim.co.uk/img/media/68bd9c6609a0212c9a1d5db4d75195002474b275/0_696_4116_2469/4116.jpg?w=600&h=360&quality=35&sig-ignores-params=true&s=1d690cceab36b017deef24c7803493a3"/>
+                        <span class="element-placeholder__button touchpoint">
+                        <span class="touchpoint__button video-play-button" data-icon="&#xe04b;" aria-hidden="true"></span>
+                        <span class="touchpoint__label"><span class="screen-readable">Play Video. Duration: </span>00:56</span>
+                        </span>
+                        </a>
+                        <figcaption>
+                            <span class="element-video__caption"><span data-icon="&#xe043;" class="figure__caption__icon" aria-hidden="true"></span>Robert De Niro: ‘I’d like to punch Donald Trump in the face’</span>
+                        </figcaption>
+                    </figure>
+                    <figure class="element element-atom" data-atom-id="173a55a3-fca5-4c5c-82e6-69cefadf8e94" data-atom-type="media">
+                        <div class="element element-video element-youtube __YOUTUBE_MEDIA_SDK_CLASS_NAME__">
+                            <div style="font-size:0" class="element__inner">
+                                <div class="youtube-media__placeholder">
+                                    <div class="youtube-media__placeholder__img" style="background-image: url(https://mobile.guardianapis.com/img/media/4abfc0d85e5aac5d4c0cfd785c5113948a874d4b/187_34_1733_975/master/1733.jpg/78ff05a43954bc9d2ee971d17b044bf4?width=750&height=450&quality=35)"></div>
+                                    <div class="youtube-media__touchpoint touchpoint">
+                                        <span class="element-placeholder__button">
+                                        <span class="touchpoint__button video-play-button" data-icon="" aria-hidden="true"></span>
+                                        <span class="touchpoint__label"><span class="screen-readable">Play Video. Duration: </span>01:07</span>
+                                        </span>
+                                    </div>
+                                </div>
+                                <iframe id="gu-video-youtube-173a55a3-fca5-4c5c-82e6-69cefadf8e94" class="youtube-media" src="https://www.youtube.com/embed/3wyFS7j0sYI?modestbranding=1&amp;showinfo=0&amp;rel=0&amp;enablejsapi=1" frameborder="0" allowfullscreen=""></iframe>
+                            </div>
+                        </div>
+                    </figure>
                     <h2>‘S&atilde;o Paulo’s middle class is what makes it a great city’</h2>
                     <p>On <a href="x-gu://item/mobile.guardianapis.com/uk/items/cities/2017/nov/27/sao-paulo-future-inequality-occupations-homeless-movements-mtst-workers">the report by Leonardo Sakamato</a> – a reporter who uses statistics from Movimento dos Trabalhadores Sem Teto (Homeless Workers’ Movement) is a reporter who has not checked their sources properly. MTST is a political movement. If there is one thing they don’t care about, it is the living conditions of poor people. MTST is deeply connected to the Partido dos Trabalhadores (Workers’ Party) – they only invade land that will cause an political impact.</p>
                     <p>The picture drawn by Sakamoto is definitely not accurate. OK, S&atilde;o Paulo has inequalities, but it is not as described. There are lots of middle-class neighbourhoods – it is not just extra-rich versus extra-poor. This is what makes S&atilde;o Paulo a great city. If this reporter has this view of S&atilde;o Paulo, I wonder what he has to say about Rio de Janeiro or Salvador.<em> Luiza Manguino</em></p>

--- a/test/fixtures/article-news.html
+++ b/test/fixtures/article-news.html
@@ -146,44 +146,10 @@
                             <span class="element-video__caption"><span data-icon="&#xe043;" class="figure__caption__icon" aria-hidden="true"></span>Robert De Niro: ‘I’d like to punch Donald Trump in the face’</span>
                         </figcaption>
                     </figure>
-                    <figure class="element element-atom" data-atom-id="173a55a3-fca5-4c5c-82e6-69cefadf8e94" data-atom-type="media">
-                        <div class="element element-video element-youtube __YOUTUBE_MEDIA_SDK_CLASS_NAME__">
-                            <div style="font-size:0" class="element__inner">
-                                <div class="youtube-media__placeholder">
-                                    <div class="youtube-media__placeholder__img" style="background-image: url(https://mobile.guardianapis.com/img/media/4abfc0d85e5aac5d4c0cfd785c5113948a874d4b/187_34_1733_975/master/1733.jpg/78ff05a43954bc9d2ee971d17b044bf4?width=750&height=450&quality=35)"></div>
-                                    <div class="youtube-media__touchpoint touchpoint">
-                                        <span class="element-placeholder__button">
-                                        <span class="touchpoint__button video-play-button" data-icon="" aria-hidden="true"></span>
-                                        <span class="touchpoint__label"><span class="screen-readable">Play Video. Duration: </span>01:07</span>
-                                        </span>
-                                    </div>
-                                </div>
-                                <iframe id="gu-video-youtube-173a55a3-fca5-4c5c-82e6-69cefadf8e94" class="youtube-media" src="https://www.youtube.com/embed/3wyFS7j0sYI?modestbranding=1&amp;showinfo=0&amp;rel=0&amp;enablejsapi=1" frameborder="0" allowfullscreen=""></iframe>
-                            </div>
-                        </div>
-                    </figure>
                     <h2>‘S&atilde;o Paulo’s middle class is what makes it a great city’</h2>
                     <p>On <a href="x-gu://item/mobile.guardianapis.com/uk/items/cities/2017/nov/27/sao-paulo-future-inequality-occupations-homeless-movements-mtst-workers">the report by Leonardo Sakamato</a> – a reporter who uses statistics from Movimento dos Trabalhadores Sem Teto (Homeless Workers’ Movement) is a reporter who has not checked their sources properly. MTST is a political movement. If there is one thing they don’t care about, it is the living conditions of poor people. MTST is deeply connected to the Partido dos Trabalhadores (Workers’ Party) – they only invade land that will cause an political impact.</p>
                     <p>The picture drawn by Sakamoto is definitely not accurate. OK, S&atilde;o Paulo has inequalities, but it is not as described. There are lots of middle-class neighbourhoods – it is not just extra-rich versus extra-poor. This is what makes S&atilde;o Paulo a great city. If this reporter has this view of S&atilde;o Paulo, I wonder what he has to say about Rio de Janeiro or Salvador.<em> Luiza Manguino</em></p>
                     <h2>‘S&atilde;o Paulo is not making any strides towards prosperity for all’</h2>
-                    <figure class="element element-comment" data-canonical-url="https://discussion.theguardian.com/comment-permalink/108832883">
-                        <div class="d2-comment-embedded" itemscope="" itemtype="http://schema.org/Comment">
-                            <div class="d2-left-col">
-                                <a href="https://profile.theguardian.com/user/id/2589588" title="View Brazilnut’s profile"> <img class="d2-avatar" src="https://avatar.guim.co.uk/user/2589588" height="40" width="40" alt="User avatar for Brazilnut" /> </a>
-                            </div>
-                            <div class="d2-right-col">
-                                <div itemscope="" itemprop="author" itemtype="http://schema.org/Person">
-                                    <a class="d2-username" href="https://profile.theguardian.com/user/id/2589588" title="View Brazilnut’s profile" itemprop="url"> <span itemprop="givenName">Brazilnut</span> </a>
-                                </div>
-                                <div class="d2-permalink">
-                                    <a class="d2-datetime" href="https://discussion.theguardian.com/comment-permalink/108832883" title="Link to this comment" itemprop="datePublished">27 November 2017 10:21am</a>
-                                </div>
-                                <div class="d2-body" itemprop="text">
-                                    <p>...... prosperity for all. Which S&atilde;o Paulo does the writer refer to? S&atilde;o Paulo in Brazil, violent and crime ridden, along with the rest of the country, is not making any strides towards prosperity for all. Just prosperity for those who rule the country at every level from municipal up to and including the President and the federal government. Until corruption is stamped out, and with a system that protects corrupt politicos it is hard to see how this will be achieved, there will never be prosperity for all.</p>
-                                </div>
-                            </div>
-                        </div>
-                    </figure>
                     <h2>‘Favela fires are the failure of the government’</h2>
                     <p>I’m a documentary maker from S&atilde;o Paulo. I made <a href="http://www.videocamp.com/pt/movies/limpam-com-fogo">a feature film about fires</a> in the favelas. Those that are more frequently destroyed by fire are closer to the centre of the city, where the land is more densely occupied, and worth more. These communities are frowned upon, both because residents fear that slums will result in more crime in the neighbourhood and bring down the values of their homes. It’s the very old-fashioned prejudice of rich folk everywhere against the poor. In S&atilde;o Paulo, it means the favelas do not evolve beyond dwellings made mostly of cardboard and wood.</p>
                     <p>Slums further away from the city centre become more urbanised over time, and are made of brick and cement and as such less susceptible to fire. This is the social mechanism at work in this correlation between land value and fire. What sparks the fire is not all that relevant – most are caused by accidents or electrical short circuits. The real question is why these people were allowed to live in homes made of flammable material for so long, with no action from the authorities to prevent fire. This is why the “government finds no link”, <a href="x-gu://item/mobile.guardianapis.com/uk/items/cities/2017/nov/27/revealed-fires-sao-paulo-favelas-higher-value-land">as you reported</a>. It’s the failure of the government that these communities remain in misery. <em>Conrado Ferrato</em></p>

--- a/test/fixtures/article-news.html
+++ b/test/fixtures/article-news.html
@@ -126,30 +126,36 @@
                     <p>A common misconception of S&atilde;o Paulo is that people are either super poor and live in favelas, or they are super wealthy and fly in helicopters. I am a middle-class Paulistana who worked hard to go to university and worked hard after that to get a job overseas, in London.</p>
                     <p>It has always been difficult to explain where I come from; that S&atilde;o Paulo has many middle-class neighbourhoods with people living normal lives like those of the middle-class in Europe or the US; that the dichotomy of ultra- rich or miserably poor is not true.</p>
                     <p>This difficulty comes of the middle class being ignored by international media, except when they protest loud enough. It would only be fair to Paulistanos that S&atilde;o Paulo be given a more balanced treatment, reflective of the city’s complex reality. <em>Anonymous</em></p>
-                    <!-- <figure class="element element-image element--showcase" data-media-id="c9dab8ae952665993b68f1f698aa7e4578a5df87">
+                    <figure class="element element-image element--showcase" data-media-id="c9dab8ae952665993b68f1f698aa7e4578a5df87">
                         <a href="x-gu://gallery/https://mobile.guardianapis.com/img/media/c9dab8ae952665993b68f1f698aa7e4578a5df87/0_0_3264_2448/master/3264.jpg/129f2d56fabf5d9e4aff7cae68817bab?width=#{width}&height=#{height}&quality=#{quality}"><img src="https://media.guim.co.uk/c9dab8ae952665993b68f1f698aa7e4578a5df87/0_0_3264_2448/1000.jpg" alt="Red blossoms reach out towards the city of S&atilde;o Paulo from the Copan building." width="1000" height="750" class="gu-image" /></a>
                         <figcaption>
                             <span class="element-image__caption">“A city of smoke, city of concrete – and yet there is hope,” wrote student Isabela Chan, who took this photograph of blossoms reaching towards the sun from the roof of the Copan building. “In the background, a myriad of buildings appear to be part of a natural landscape, showing how nature coexists with this megalopolis.”</span>
                             <span class="element-image__credit">Photograph: Isabela Chan</span>
                         </figcaption>
                     </figure>
-                    <p></p> -->
-                    <figure class="element element-placeholder">
-                        <a class="element__inner video-URL" href="x-gu://playvideo/cdn.theguardian.tv/HLS/2016/10/08/161008RobertDeNiro.m3u8">
-                        <img src="https://i.guim.co.uk/img/media/68bd9c6609a0212c9a1d5db4d75195002474b275/0_696_4116_2469/4116.jpg?w=600&h=360&quality=35&sig-ignores-params=true&s=1d690cceab36b017deef24c7803493a3"/>
-                        <span class="element-placeholder__button touchpoint">
-                        <span class="touchpoint__button video-play-button" data-icon="&#xe04b;" aria-hidden="true"></span>
-                        <span class="touchpoint__label"><span class="screen-readable">Play Video. Duration: </span>00:56</span>
-                        </span>
-                        </a>
-                        <figcaption>
-                            <span class="element-video__caption"><span data-icon="&#xe043;" class="figure__caption__icon" aria-hidden="true"></span>Robert De Niro: ‘I’d like to punch Donald Trump in the face’</span>
-                        </figcaption>
-                    </figure>
+                    <p></p>
                     <h2>‘S&atilde;o Paulo’s middle class is what makes it a great city’</h2>
                     <p>On <a href="x-gu://item/mobile.guardianapis.com/uk/items/cities/2017/nov/27/sao-paulo-future-inequality-occupations-homeless-movements-mtst-workers">the report by Leonardo Sakamato</a> – a reporter who uses statistics from Movimento dos Trabalhadores Sem Teto (Homeless Workers’ Movement) is a reporter who has not checked their sources properly. MTST is a political movement. If there is one thing they don’t care about, it is the living conditions of poor people. MTST is deeply connected to the Partido dos Trabalhadores (Workers’ Party) – they only invade land that will cause an political impact.</p>
                     <p>The picture drawn by Sakamoto is definitely not accurate. OK, S&atilde;o Paulo has inequalities, but it is not as described. There are lots of middle-class neighbourhoods – it is not just extra-rich versus extra-poor. This is what makes S&atilde;o Paulo a great city. If this reporter has this view of S&atilde;o Paulo, I wonder what he has to say about Rio de Janeiro or Salvador.<em> Luiza Manguino</em></p>
                     <h2>‘S&atilde;o Paulo is not making any strides towards prosperity for all’</h2>
+                    <figure class="element element-comment" data-canonical-url="https://discussion.theguardian.com/comment-permalink/108832883">
+                        <div class="d2-comment-embedded" itemscope="" itemtype="http://schema.org/Comment">
+                            <div class="d2-left-col">
+                                <a href="https://profile.theguardian.com/user/id/2589588" title="View Brazilnut’s profile"> <img class="d2-avatar" src="https://avatar.guim.co.uk/user/2589588" height="40" width="40" alt="User avatar for Brazilnut" /> </a>
+                            </div>
+                            <div class="d2-right-col">
+                                <div itemscope="" itemprop="author" itemtype="http://schema.org/Person">
+                                    <a class="d2-username" href="https://profile.theguardian.com/user/id/2589588" title="View Brazilnut’s profile" itemprop="url"> <span itemprop="givenName">Brazilnut</span> </a>
+                                </div>
+                                <div class="d2-permalink">
+                                    <a class="d2-datetime" href="https://discussion.theguardian.com/comment-permalink/108832883" title="Link to this comment" itemprop="datePublished">27 November 2017 10:21am</a>
+                                </div>
+                                <div class="d2-body" itemprop="text">
+                                    <p>...... prosperity for all. Which S&atilde;o Paulo does the writer refer to? S&atilde;o Paulo in Brazil, violent and crime ridden, along with the rest of the country, is not making any strides towards prosperity for all. Just prosperity for those who rule the country at every level from municipal up to and including the President and the federal government. Until corruption is stamped out, and with a system that protects corrupt politicos it is hard to see how this will be achieved, there will never be prosperity for all.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </figure>
                     <h2>‘Favela fires are the failure of the government’</h2>
                     <p>I’m a documentary maker from S&atilde;o Paulo. I made <a href="http://www.videocamp.com/pt/movies/limpam-com-fogo">a feature film about fires</a> in the favelas. Those that are more frequently destroyed by fire are closer to the centre of the city, where the land is more densely occupied, and worth more. These communities are frowned upon, both because residents fear that slums will result in more crime in the neighbourhood and bring down the values of their homes. It’s the very old-fashioned prejudice of rich folk everywhere against the poor. In S&atilde;o Paulo, it means the favelas do not evolve beyond dwellings made mostly of cardboard and wood.</p>
                     <p>Slums further away from the city centre become more urbanised over time, and are made of brick and cement and as such less susceptible to fire. This is the social mechanism at work in this correlation between land value and fire. What sparks the fire is not all that relevant – most are caused by accidents or electrical short circuits. The real question is why these people were allowed to live in homes made of flammable material for so long, with no action from the authorities to prevent fire. This is why the “government finds no link”, <a href="x-gu://item/mobile.guardianapis.com/uk/items/cities/2017/nov/27/revealed-fires-sao-paulo-favelas-higher-value-land">as you reported</a>. It’s the failure of the government that these communities remain in misery. <em>Conrado Ferrato</em></p>

--- a/test/spec/unit/modules/youtubeTest.js
+++ b/test/spec/unit/modules/youtubeTest.js
@@ -309,7 +309,6 @@ define([
                 window.YT.players[0].onReady('video1');
                 setPlayerState('PLAYING', window.YT.players[0]);
 
-                expect(Player.prototype.getCurrentTime).to.have.been.called;
                 expect(utilMock.signalDevice).to.have.been.calledOnce;
                 expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:start'}));
             });
@@ -333,7 +332,6 @@ define([
                 // Restart Video
                 setPlayerState('PLAYING', window.YT.players[0]);
 
-                expect(Player.prototype.getCurrentTime).to.have.been.called;
                 expect(utilMock.signalDevice).to.have.been.calledOnce;
                 expect(utilMock.signalDevice).to.have.been.calledWith('youtube/' + JSON.stringify({id:'video1', eventType:'video:content:start'}));
 
@@ -451,7 +449,6 @@ define([
 
                 setPlayerState('PLAYING', window.YT.players[0]);
 
-                expect(Player.prototype.getCurrentTime).not.to.have.been.called;
                 expect(window.GuardianJSInterface.trackAction).not.to.have.been.called;
             });
 
@@ -466,7 +463,6 @@ define([
                 window.YT.players[0].onReady('video1');
                 setPlayerState('PLAYING', window.YT.players[0]);
 
-                expect(Player.prototype.getCurrentTime).to.have.been.called;
                 expect(window.GuardianJSInterface.trackAction).to.have.been.calledOnce;
                 expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:start'}));
             });
@@ -489,7 +485,6 @@ define([
                 // Restart Video
                 setPlayerState('PLAYING', window.YT.players[0]);
 
-                expect(Player.prototype.getCurrentTime).to.have.been.called;
                 expect(window.GuardianJSInterface.trackAction).to.have.been.calledOnce;
                 expect(window.GuardianJSInterface.trackAction).to.have.been.calledWith('youtube', JSON.stringify({id:'video1', eventType:'video:content:start'}));
 


### PR DESCRIPTION
Non-youtube video embeds in articles are broken on iOS and Android. 

This is because they need to be wrapped in an `<a>` tag. All `<a>` in the body currently have a style applied to them from the `text-underline` mixin, this applies a nice underline effect on links, but it shouldn't be used on `video-url` links, so I've put a `not(.video-url)`  exception on this mixin, which fixes the issue.

Before...

![screenshot 6](https://user-images.githubusercontent.com/1590704/41347948-1676e450-6f03-11e8-85e7-a078f171962d.png)

After...

![screen shot 2018-06-13 at 12 07 47](https://user-images.githubusercontent.com/1590704/41347996-39590502-6f03-11e8-844c-5b9223081596.png)
