### PR TITLE
fix dev server bug caused by invalid scss

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
+++ b/ArticleTemplates/assets/scss/garnett-helpers/_mixins.scss
@@ -126,12 +126,12 @@ $meta-lead: 2.2rem;
             background-image: linear-gradient(rgba($color, .33) 0%, rgba($color, .33) 100%);
             background-position: 0 93%;
         }
+    }
 
-        a:active,
-        &:hover {
-            color: $color-accent;
-            background-image: linear-gradient(to bottom, darken($color-accent, 6%) 0%, darken($color-accent, 6%) 100%);
-        }
+    a:not(.video-URL) a:active,
+    a:not(.video-URL):hover {
+        color: $color-accent;
+        background-image: linear-gradient(to bottom, darken($color-accent, 6%) 0%, darken($color-accent, 6%) 100%);
     }
 }
 


### PR DESCRIPTION
`yarn develop` began falling over once this PR was merged https://github.com/guardian/mobile-apps-article-templates/pull/795 because of a clash between the `:not(.video-URL)` and the nested `&:hover`, 

I've pulled the pseudo selectors `a:not(.video-URL) a:active`, `a:not(.video-URL):hover` out into their own block.