### PR TITLE
Remove underline from advert 'hide' button

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/_advert-slot.scss
@@ -37,13 +37,11 @@
     .advert-slot__label {
         overflow: auto;
         position: relative;
-        a {
-            background-image: none;
-        }
     }
 
     .advert-slot__action {
         color: color(brightness-46) !important;
+        background-image: none !important;
         display: none;
         padding-right: 2.5rem;
         position: absolute;

--- a/ArticleTemplates/assets/scss/garnett-modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/_advert-slot.scss
@@ -37,6 +37,9 @@
     .advert-slot__label {
         overflow: auto;
         position: relative;
+        a {
+            background-image: none;
+        }
     }
 
     .advert-slot__action {


### PR DESCRIPTION
The text-underline mixin was adding pillar-coloured underlines to the adverts' "Hide" button, and this removes them.

**After**
<img width=375 src=https://user-images.githubusercontent.com/4561/41419232-72100d96-6fe9-11e8-96fd-0aaeae925d30.png>

CC @jorgeazevedo 
