### PR TITLE
AA-73 - Implement Line Height in Templates

### DIFF
--- a/ArticleTemplates/articleTemplate.html
+++ b/ArticleTemplates/articleTemplate.html
@@ -32,7 +32,6 @@
             sectionTone: "__SECTION_TONE__",
             isAdvertising: "__IS_ADVERTISING__" ? true : false,
             fontSize: "__FONT_SIZE__",
-            lineHeight: "__LINE_HEIGHT__",
             platform: "__PLATFORM__",
             isOffline: "__IS_OFFLINE__" ? true : false,
             contentType: "article",

--- a/ArticleTemplates/articleTemplate.html
+++ b/ArticleTemplates/articleTemplate.html
@@ -16,7 +16,7 @@
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/polyfills/requestAnimationFrame.js"></script>
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/bootstrap.js"></script>
 </head>
-<body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="article" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__" data-content-section="__SECTION__">
+<body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="article" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__" data-content-section="__SECTION__">
 
     __ARTICLE_CONTAINER__
 
@@ -32,6 +32,7 @@
             sectionTone: "__SECTION_TONE__",
             isAdvertising: "__IS_ADVERTISING__" ? true : false,
             fontSize: "__FONT_SIZE__",
+            lineHeight: "__LINE_HEIGHT__",
             platform: "__PLATFORM__",
             isOffline: "__IS_OFFLINE__" ? true : false,
             contentType: "article",

--- a/ArticleTemplates/articleTemplateContainer.html
+++ b/ArticleTemplates/articleTemplateContainer.html
@@ -48,7 +48,7 @@
         </div>
 
         <div class="article__body" id="article-body">
-            <div class="from-content-api prose resizable selectable" id="article-body-blocks">
+            <div class="from-content-api prose resizable resizable_line_height selectable" id="article-body-blocks">
                 __BODY__
             </div>
         </div>

--- a/ArticleTemplates/articleTemplateContainer.html
+++ b/ArticleTemplates/articleTemplateContainer.html
@@ -48,7 +48,7 @@
         </div>
 
         <div class="article__body" id="article-body">
-            <div class="from-content-api prose resizable resizable_line_height selectable" id="article-body-blocks">
+            <div class="from-content-api prose resizable resizable-line-height selectable" id="article-body-blocks">
                 __BODY__
             </div>
         </div>

--- a/ArticleTemplates/articleTemplateContainerComment.html
+++ b/ArticleTemplates/articleTemplateContainerComment.html
@@ -48,7 +48,7 @@
         </div>
 
         <div class="article__body" id="comment-body">
-            <div class="from-content-api prose resizable selectable" id="comment-body-blocks">
+            <div class="from-content-api prose resizable resizable_line_height selectable" id="comment-body-blocks">
                 __BODY__
             </div>
         </div>

--- a/ArticleTemplates/articleTemplateContainerComment.html
+++ b/ArticleTemplates/articleTemplateContainerComment.html
@@ -48,7 +48,7 @@
         </div>
 
         <div class="article__body" id="comment-body">
-            <div class="from-content-api prose resizable resizable_line_height selectable" id="comment-body-blocks">
+            <div class="from-content-api prose resizable resizable-line-height selectable" id="comment-body-blocks">
                 __BODY__
             </div>
         </div>

--- a/ArticleTemplates/articleTemplateContainerFeatures.html
+++ b/ArticleTemplates/articleTemplateContainerFeatures.html
@@ -44,7 +44,7 @@
         __SPONSORSHIP__
 
         <div class="article__body" id="feature-body">
-            <div class="from-content-api prose resizable selectable" id="feature-body-blocks">
+            <div class="from-content-api prose resizable resizable_line_height selectable" id="feature-body-blocks">
                 __BODY__
             </div>
             __TELL_ME_WHEN__

--- a/ArticleTemplates/articleTemplateContainerFeatures.html
+++ b/ArticleTemplates/articleTemplateContainerFeatures.html
@@ -44,7 +44,7 @@
         __SPONSORSHIP__
 
         <div class="article__body" id="feature-body">
-            <div class="from-content-api prose resizable resizable_line_height selectable" id="feature-body-blocks">
+            <div class="from-content-api prose resizable resizable-line-height selectable" id="feature-body-blocks">
                 __BODY__
             </div>
             __TELL_ME_WHEN__

--- a/ArticleTemplates/articleTemplateContainerImmersive.html
+++ b/ArticleTemplates/articleTemplateContainerImmersive.html
@@ -33,7 +33,7 @@
     </div>
 
     <div class="article__body" id="article-body">
-        <div class="from-content-api prose resizable selectable">
+        <div class="from-content-api prose resizable resizable_line_height selectable">
             <h2 class="section__rule"></h2>
             __BODY__
         </div>

--- a/ArticleTemplates/articleTemplateContainerImmersive.html
+++ b/ArticleTemplates/articleTemplateContainerImmersive.html
@@ -33,7 +33,7 @@
     </div>
 
     <div class="article__body" id="article-body">
-        <div class="from-content-api prose resizable resizable_line_height selectable">
+        <div class="from-content-api prose resizable resizable-line-height selectable">
             <h2 class="section__rule"></h2>
             __BODY__
         </div>

--- a/ArticleTemplates/assets/js/bootstraps/common.js
+++ b/ArticleTemplates/assets/js/bootstraps/common.js
@@ -429,7 +429,6 @@ define([
 
         document.body.classList.remove(current);
         document.body.classList.add(replacement);  
-        document.body.dataset.lineHeight = replacementInt[2];
     }
 
     function setupGetArticleHeight() {

--- a/ArticleTemplates/assets/js/bootstraps/common.js
+++ b/ArticleTemplates/assets/js/bootstraps/common.js
@@ -37,6 +37,7 @@ define([
         setupOfflineSwitch();
         setupAlertSwitch();
         setupFontSizing();
+        setupLineHeightSizing();
         setupGetArticleHeight();
         showTabs();
         setGlobalObject(window);
@@ -408,6 +409,11 @@ define([
         window.fontResize = fontResize;
     }
 
+    function setupLineHeightSizing() {
+        // Called by native code
+        window.lineHeightResize = lineHeightResize;
+    }
+
     function fontResize(current, replacement) {
         var replacementStr = replacement,
             replacementInt = replacementStr.split('-');
@@ -415,6 +421,15 @@ define([
         document.body.classList.remove(current);
         document.body.classList.add(replacement);  
         document.body.dataset.fontSize = replacementInt[2];
+    }
+
+    function lineHeightResize(current, replacement) {
+        var replacementStr = replacement,
+            replacementInt = replacementStr.split('-');
+
+        document.body.classList.remove(current);
+        document.body.classList.add(replacement);  
+        document.body.dataset.lineHeight = replacementInt[2];
     }
 
     function setupGetArticleHeight() {

--- a/ArticleTemplates/assets/scss/modules/_resizable.scss
+++ b/ArticleTemplates/assets/scss/modules/_resizable.scss
@@ -19,3 +19,11 @@
         }
     }
 }
+
+.resizable_line_height {
+    @for $i from 0 through 10 {
+        .line-height-#{$i} & {
+            line-height: 1.5 + ($i * 0.1);
+        }
+    }
+}

--- a/ArticleTemplates/assets/scss/modules/_resizable.scss
+++ b/ArticleTemplates/assets/scss/modules/_resizable.scss
@@ -20,7 +20,7 @@
     }
 }
 
-.resizable_line_height {
+.resizable-line-height {
     @for $i from 0 through 10 {
         .line-height-#{$i} & {
             line-height: 1.5 + ($i * 0.1);

--- a/ArticleTemplates/audioTemplate.html
+++ b/ArticleTemplates/audioTemplate.html
@@ -71,7 +71,7 @@
                         __STANDFIRST__
                     </div>
                 </div>
-                <div class="from-content-api prose resizable resizable_line_height selectable" id="audio-body-blocks">
+                <div class="from-content-api prose resizable resizable-line-height selectable" id="audio-body-blocks">
                     __BODY__
                 </div>
             </div>

--- a/ArticleTemplates/audioTemplate.html
+++ b/ArticleTemplates/audioTemplate.html
@@ -87,7 +87,6 @@
                 asyncStylesFilename: "__ASYNC_STYLES__",
                 sectionTone: "__SECTION_TONE__",
                 fontSize: "__FONT_SIZE__",
-                lineHeight: "__LINE_HEIGHT__",
                 platform: "__PLATFORM__",
                 isOffline: "__IS_OFFLINE__" ? true : false,
                 isAdvertising: "__IS_ADVERTISING__" ? true : false,

--- a/ArticleTemplates/audioTemplate.html
+++ b/ArticleTemplates/audioTemplate.html
@@ -13,7 +13,7 @@
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/polyfills/requestAnimationFrame.js"></script>
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/bootstrap.js"></script>
     </head>
-    <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="audio" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__"  data-template-directory="__TEMPLATES_DIRECTORY__"  data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
+    <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="audio" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__"  data-template-directory="__TEMPLATES_DIRECTORY__"  data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
         <div class="article article--audio">
             <div class="article__header cutout">
                 <div class="cutout__container" __CUTOUT__>
@@ -71,7 +71,7 @@
                         __STANDFIRST__
                     </div>
                 </div>
-                <div class="from-content-api prose resizable selectable" id="audio-body-blocks">
+                <div class="from-content-api prose resizable resizable_line_height selectable" id="audio-body-blocks">
                     __BODY__
                 </div>
             </div>
@@ -87,6 +87,7 @@
                 asyncStylesFilename: "__ASYNC_STYLES__",
                 sectionTone: "__SECTION_TONE__",
                 fontSize: "__FONT_SIZE__",
+                lineHeight: "__LINE_HEIGHT__",
                 platform: "__PLATFORM__",
                 isOffline: "__IS_OFFLINE__" ? true : false,
                 isAdvertising: "__IS_ADVERTISING__" ? true : false,

--- a/ArticleTemplates/collectionTemplate.html
+++ b/ArticleTemplates/collectionTemplate.html
@@ -18,7 +18,7 @@
 
     <div class="article article--standard" id="standard-article-container">
         <div class="article__body" id="article-body">
-            <div class="from-content-api prose resizable resizable_line_height selectable collection-blocks" id="article-body-blocks">
+            <div class="from-content-api prose resizable resizable-line-height selectable collection-blocks" id="article-body-blocks">
 	        __BODY__
 	    </div>
         </div>

--- a/ArticleTemplates/collectionTemplate.html
+++ b/ArticleTemplates/collectionTemplate.html
@@ -14,11 +14,11 @@
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/bootstrap.js"></script>
 </head>
 
-<body class="garnett--type-collection garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="article" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__" data-content-section="__SECTION__">
+<body class="garnett--type-collection garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="article" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__" data-content-section="__SECTION__">
 
     <div class="article article--standard" id="standard-article-container">
         <div class="article__body" id="article-body">
-            <div class="from-content-api prose resizable selectable collection-blocks" id="article-body-blocks">
+            <div class="from-content-api prose resizable resizable_line_height selectable collection-blocks" id="article-body-blocks">
 	        __BODY__
 	    </div>
         </div>
@@ -28,6 +28,7 @@
         GU.bootstrap.init({             
             asyncStylesFilename: "__ASYNC_STYLES__",
             fontSize: "__FONT_SIZE__",
+            lineHeight: "__LINE_HEIGHT__",
             platform: "__PLATFORM__",
             isOffline: "__IS_OFFLINE__" ? true : false,
             contentType: "collection",

--- a/ArticleTemplates/collectionTemplate.html
+++ b/ArticleTemplates/collectionTemplate.html
@@ -28,7 +28,6 @@
         GU.bootstrap.init({             
             asyncStylesFilename: "__ASYNC_STYLES__",
             fontSize: "__FONT_SIZE__",
-            lineHeight: "__LINE_HEIGHT__",
             platform: "__PLATFORM__",
             isOffline: "__IS_OFFLINE__" ? true : false,
             contentType: "collection",

--- a/ArticleTemplates/commentsTemplate.html
+++ b/ArticleTemplates/commentsTemplate.html
@@ -54,7 +54,6 @@
                 asyncStylesFilename: "__ASYNC_STYLES__",
                 sectionTone: "__SECTION_TONE__",
                 fontSize: "__FONT_SIZE__",
-                lineHeight: "__LINE_HEIGHT__",
                 platform: "__PLATFORM__",
                 isOffline: "__IS_OFFLINE__" ? true : false,
                 contentType: "comments",

--- a/ArticleTemplates/commentsTemplate.html
+++ b/ArticleTemplates/commentsTemplate.html
@@ -14,7 +14,7 @@
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/polyfills/requestAnimationFrame.js"></script>
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/bootstrap.js"></script>
     </head>
-    <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__">
+    <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__">
         <section class="comments comments--page comments-__COMMENTS_COUNT__">
             <div class="comments__wrapper">
                 <div class="comments__header">
@@ -54,6 +54,7 @@
                 asyncStylesFilename: "__ASYNC_STYLES__",
                 sectionTone: "__SECTION_TONE__",
                 fontSize: "__FONT_SIZE__",
+                lineHeight: "__LINE_HEIGHT__",
                 platform: "__PLATFORM__",
                 isOffline: "__IS_OFFLINE__" ? true : false,
                 contentType: "comments",

--- a/ArticleTemplates/commentsTemplateBlock.html
+++ b/ArticleTemplates/commentsTemplateBlock.html
@@ -15,7 +15,7 @@
         </div>
 
         <div class="comment__body">
-            <div class="prose resizable resizable_line_height selectable">
+            <div class="prose resizable resizable-line-height selectable">
                 __COMMENTS_BODY__
             </div>
         </div>

--- a/ArticleTemplates/commentsTemplateBlock.html
+++ b/ArticleTemplates/commentsTemplateBlock.html
@@ -15,7 +15,7 @@
         </div>
 
         <div class="comment__body">
-            <div class="prose resizable selectable">
+            <div class="prose resizable resizable_line_height selectable">
                 __COMMENTS_BODY__
             </div>
         </div>

--- a/ArticleTemplates/cricketTemplate.html
+++ b/ArticleTemplates/cricketTemplate.html
@@ -17,7 +17,7 @@
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/bootstrap.js"></script>
 </head>
 
-<body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __DISPLAY_HINT__" data-content-type="cricket" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" style="margin-top: __ACTIONBARHEIGHT__px;" data-ads-config="__ADS_CONFIG__" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
+<body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __DISPLAY_HINT__" data-content-type="cricket" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" style="margin-top: __ACTIONBARHEIGHT__px;" data-ads-config="__ADS_CONFIG__" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
     <div class="cricket cricket--__CRICKET_STATUS__">
         <div id="cricket-header">
             __CRICKET_HEADER__
@@ -86,6 +86,7 @@
             asyncStylesFilename: "__ASYNC_STYLES__",
             sectionTone: "__SECTION_TONE__",
             fontSize: "__FONT_SIZE__",
+            lineHeight: "__LINE_HEIGHT__",
             isLive: "__IS_LIVE__" ? true : false,
             platform: "__PLATFORM__",
             isOffline: "__IS_OFFLINE__" ? true : false,

--- a/ArticleTemplates/cricketTemplate.html
+++ b/ArticleTemplates/cricketTemplate.html
@@ -86,7 +86,6 @@
             asyncStylesFilename: "__ASYNC_STYLES__",
             sectionTone: "__SECTION_TONE__",
             fontSize: "__FONT_SIZE__",
-            lineHeight: "__LINE_HEIGHT__",
             isLive: "__IS_LIVE__" ? true : false,
             platform: "__PLATFORM__",
             isOffline: "__IS_OFFLINE__" ? true : false,

--- a/ArticleTemplates/errorExpiredContent.html
+++ b/ArticleTemplates/errorExpiredContent.html
@@ -13,7 +13,7 @@
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/bootstrap.js"></script>
 </head>
 
-<body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--news __FONT_SIZE__ __PLATFORM__" data-content-type="error" data-ads-enabled="false" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__">
+<body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--news __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__" data-content-type="error" data-ads-enabled="false" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__">
     
     <div class="error-message error-message--expired-content">
         <h1 class="headline error-message__title">Sorry – the page you are looking for has been removed.</h1>
@@ -28,6 +28,7 @@
         GU.bootstrap.init({             
             asyncStylesFilename: "__ASYNC_STYLES__",
             fontSize: "__FONT_SIZE__",
+            lineHeight: "__LINE_HEIGHT__",
             platform: "__PLATFORM__",
             contentType: "error",
             actionBarHeight: "__ACTIONBARHEIGHT__",

--- a/ArticleTemplates/errorExpiredContent.html
+++ b/ArticleTemplates/errorExpiredContent.html
@@ -28,7 +28,6 @@
         GU.bootstrap.init({             
             asyncStylesFilename: "__ASYNC_STYLES__",
             fontSize: "__FONT_SIZE__",
-            lineHeight: "__LINE_HEIGHT__",
             platform: "__PLATFORM__",
             contentType: "error",
             actionBarHeight: "__ACTIONBARHEIGHT__",

--- a/ArticleTemplates/footballTemplate.html
+++ b/ArticleTemplates/footballTemplate.html
@@ -46,7 +46,6 @@
             asyncStylesFilename: "__ASYNC_STYLES__",
             sectionTone: "__SECTION_TONE__",
             fontSize: "__FONT_SIZE__",
-            lineHeight: "__LINE_HEIGHT__",
             isLive: "__IS_LIVE__" ? true : false,
             platform: "__PLATFORM__",
             isOffline: "__IS_OFFLINE__" ? true : false,

--- a/ArticleTemplates/footballTemplate.html
+++ b/ArticleTemplates/footballTemplate.html
@@ -17,7 +17,7 @@
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/bootstrap.js"></script>
 </head>
 
-<body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __DISPLAY_HINT__" data-content-type="football" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" style="margin-top: __ACTIONBARHEIGHT__px;" data-ads-config="__ADS_CONFIG__" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
+<body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __DISPLAY_HINT__" data-content-type="football" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" style="margin-top: __ACTIONBARHEIGHT__px;" data-ads-config="__ADS_CONFIG__" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
     <div class="football">
 
         __MATCH_SUMMARY__
@@ -46,6 +46,7 @@
             asyncStylesFilename: "__ASYNC_STYLES__",
             sectionTone: "__SECTION_TONE__",
             fontSize: "__FONT_SIZE__",
+            lineHeight: "__LINE_HEIGHT__",
             isLive: "__IS_LIVE__" ? true : false,
             platform: "__PLATFORM__",
             isOffline: "__IS_OFFLINE__" ? true : false,

--- a/ArticleTemplates/galleryTemplate.html
+++ b/ArticleTemplates/galleryTemplate.html
@@ -13,7 +13,7 @@
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/polyfills/requestAnimationFrame.js"></script>
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/bootstrap.js"></script>
     </head>
-    <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="gallery" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__"  data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
+    <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="gallery" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__"  data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
         <div class="article article--visual">
             <div class="article__header">
                 <div class="section section__container hide-garnett" id="section">
@@ -69,6 +69,7 @@
                 sectionTone: "__SECTION_TONE__",
                 isAdvertising: "__IS_ADVERTISING__" ? true : false,
                 fontSize: "__FONT_SIZE__",
+                lineHeight: "__LINE_HEIGHT__",
                 platform: "__PLATFORM__",
                 isOffline: "__IS_OFFLINE__" ? true : false,
                 contentType: "gallery",

--- a/ArticleTemplates/galleryTemplate.html
+++ b/ArticleTemplates/galleryTemplate.html
@@ -69,7 +69,6 @@
                 sectionTone: "__SECTION_TONE__",
                 isAdvertising: "__IS_ADVERTISING__" ? true : false,
                 fontSize: "__FONT_SIZE__",
-                lineHeight: "__LINE_HEIGHT__",
                 platform: "__PLATFORM__",
                 isOffline: "__IS_OFFLINE__" ? true : false,
                 contentType: "gallery",

--- a/ArticleTemplates/interactiveTemplate.html
+++ b/ArticleTemplates/interactiveTemplate.html
@@ -22,7 +22,6 @@
         GU.bootstrap.init({             
             asyncStylesFilename: "__ASYNC_STYLES__",
             fontSize: "__FONT_SIZE__",
-            lineHeight: "__LINE_HEIGHT__",
             platform: "__PLATFORM__",
             isOffline: "__IS_OFFLINE__" ? true : false,
             contentType: "interactive",

--- a/ArticleTemplates/interactiveTemplate.html
+++ b/ArticleTemplates/interactiveTemplate.html
@@ -22,6 +22,7 @@
         GU.bootstrap.init({             
             asyncStylesFilename: "__ASYNC_STYLES__",
             fontSize: "__FONT_SIZE__",
+            lineHeight: "__LINE_HEIGHT__",
             platform: "__PLATFORM__",
             isOffline: "__IS_OFFLINE__" ? true : false,
             contentType: "interactive",

--- a/ArticleTemplates/liveblogTemplate.html
+++ b/ArticleTemplates/liveblogTemplate.html
@@ -184,7 +184,6 @@
                 isMinute: "__THE_MINUTE__" ? true : false,
                 isAdvertising: "__IS_ADVERTISING__" ? true : false,
                 fontSize: "__FONT_SIZE__",
-                lineHeight: "__LINE_HEIGHT__",
                 platform: "__PLATFORM__",
                 isOffline: "__IS_OFFLINE__" ? true : false,
                 contentType: "liveblog",

--- a/ArticleTemplates/liveblogTemplate.html
+++ b/ArticleTemplates/liveblogTemplate.html
@@ -16,7 +16,7 @@
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/polyfills/requestAnimationFrame.js"></script>
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/bootstrap.js"></script>
     </head>
-    <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_LIVE__ __IS_ADVERTISING__ __THE_MINUTE__ new-templates __DISPLAY_HINT__" data-content-type="liveblog" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__"  data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
+    <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_LIVE__ __IS_ADVERTISING__ __THE_MINUTE__ new-templates __DISPLAY_HINT__" data-content-type="liveblog" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__"  data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
         <div class="article article--liveblog">
             <div class="article__header">
                 <div class="section section__container hide-garnett" id="section">
@@ -184,6 +184,7 @@
                 isMinute: "__THE_MINUTE__" ? true : false,
                 isAdvertising: "__IS_ADVERTISING__" ? true : false,
                 fontSize: "__FONT_SIZE__",
+                lineHeight: "__LINE_HEIGHT__",
                 platform: "__PLATFORM__",
                 isOffline: "__IS_OFFLINE__" ? true : false,
                 contentType: "liveblog",

--- a/ArticleTemplates/liveblogTemplateBlock.html
+++ b/ArticleTemplates/liveblogTemplateBlock.html
@@ -2,7 +2,7 @@
     <p class="block__time" title="__BLOCK_TIME__">__BLOCK_TIME_RELATIVE__</p>
     __BLOCK_BYLINE__
     <div class="block__body">
-        <div class="from-content-api prose resizable selectable">
+        <div class="from-content-api prose resizable resizable_line_height selectable">
             __BLOCK_TITLE__
             __BLOCK_CONTENT__
         </div>

--- a/ArticleTemplates/liveblogTemplateBlock.html
+++ b/ArticleTemplates/liveblogTemplateBlock.html
@@ -2,7 +2,7 @@
     <p class="block__time" title="__BLOCK_TIME__">__BLOCK_TIME_RELATIVE__</p>
     __BLOCK_BYLINE__
     <div class="block__body">
-        <div class="from-content-api prose resizable resizable_line_height selectable">
+        <div class="from-content-api prose resizable resizable-line-height selectable">
             __BLOCK_TITLE__
             __BLOCK_CONTENT__
         </div>

--- a/ArticleTemplates/videoTemplate.html
+++ b/ArticleTemplates/videoTemplate.html
@@ -14,7 +14,7 @@
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/bootstrap.js"></script>
 </head>
 
-<body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="video" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
+<body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="video" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
     <div class="article article--visual" id="video-article-container">
         <div class="article__header" id="video-header">
             <div class="section section__container hide-garnett" id="section">
@@ -75,6 +75,7 @@
             sectionTone: "__SECTION_TONE__",
             isAdvertising: "__IS_ADVERTISING__" ? true : false,
             fontSize: "__FONT_SIZE__",
+            lineHeight: "__LINE_HEIGHT__",
             platform: "__PLATFORM__",
             isOffline: "__IS_OFFLINE__" ? true : false,
             contentType: "video",

--- a/ArticleTemplates/videoTemplate.html
+++ b/ArticleTemplates/videoTemplate.html
@@ -75,7 +75,6 @@
             sectionTone: "__SECTION_TONE__",
             isAdvertising: "__IS_ADVERTISING__" ? true : false,
             fontSize: "__FONT_SIZE__",
-            lineHeight: "__LINE_HEIGHT__",
             platform: "__PLATFORM__",
             isOffline: "__IS_OFFLINE__" ? true : false,
             contentType: "video",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3293,9 +3293,9 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
-"smooth-scroll@git://github.com/cferdinandi/smooth-scroll":
-  version "11.0.2"
-  resolved "git://github.com/cferdinandi/smooth-scroll#80e63e5306cd50d174c3907bfecb9c2b2b223950"
+smooth-scroll@^14.2.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/smooth-scroll/-/smooth-scroll-14.2.0.tgz#87a224fc32c8956995e5bb014a5e1a07b8361e21"
 
 sntp@1.x.x:
   version "1.0.9"


### PR DESCRIPTION
This work is related to this ticket in the Android board:

https://theguardian.atlassian.net/browse/AA-73

This adds the ability to call `lineHeightResize()` from native iOS or Android code which allows the line spacing for the body text in articles to be changes at runtime. 

This is my first foray into the templates in any substantial way so let me know if there's any gotchas that I might have fallen in to, however from my testing everything seems to be working correctly.

Screenshots: https://photos.app.goo.gl/AHv7PfYZNqZp5dez8
1. Shows the new dialog with the slider
2. Shows the default line spacing (the same as previously)
3. Shows the maximum line spacing