### PR TITLE
remove duplicate fontSize property

### DIFF
--- a/ArticleTemplates/articleTemplate.html
+++ b/ArticleTemplates/articleTemplate.html
@@ -39,7 +39,7 @@
             adsEnableHiding: "__ADS_ENABLE_HIDING__" === "true",
             adsConfig: "__ADS_CONFIG__",
             actionBarHeight: "__ACTIONBARHEIGHT__",
-            fontSize: "__FONT_SIZE_INT__",
+            fontSizeInt: "__FONT_SIZE_INT__",
             templatesDirectory: "__TEMPLATES_DIRECTORY__",
             pageId: "__PAGE_ID__",
             mpuAfterParagraphs: "__MPU_AFTER_PARAGRAPHS__",

--- a/ArticleTemplates/audioTemplate.html
+++ b/ArticleTemplates/audioTemplate.html
@@ -95,7 +95,7 @@
                 adsEnableHiding: "__ADS_ENABLE_HIDING__" === "true",
                 adsConfig: "__ADS_CONFIG__",
                 actionBarHeight: "__ACTIONBARHEIGHT__",
-                fontSize: "__FONT_SIZE_INT__",
+                fontSizeInt: "__FONT_SIZE_INT__",
                 templatesDirectory: "__TEMPLATES_DIRECTORY__",
                 pageId: "__PAGE_ID__",
                 mpuAfterParagraphs: "__MPU_AFTER_PARAGRAPHS__",

--- a/ArticleTemplates/collectionTemplate.html
+++ b/ArticleTemplates/collectionTemplate.html
@@ -35,7 +35,7 @@
             adsEnableHiding: "__ADS_ENABLE_HIDING__" === "true",
             adsConfig: "__ADS_CONFIG__",
             actionBarHeight: "__ACTIONBARHEIGHT__",
-            fontSize: "__FONT_SIZE_INT__",
+            fontSizeInt: "__FONT_SIZE_INT__",
             templatesDirectory: "__TEMPLATES_DIRECTORY__",
             pageId: "__PAGE_ID__",
             mpuAfterParagraphs: "__MPU_AFTER_PARAGRAPHS__",

--- a/ArticleTemplates/commentsTemplate.html
+++ b/ArticleTemplates/commentsTemplate.html
@@ -58,7 +58,7 @@
                 isOffline: "__IS_OFFLINE__" ? true : false,
                 contentType: "comments",
                 adsConfig: "__ADS_CONFIG__",
-                fontSize: "__FONT_SIZE_INT__",
+                fontSizeInt: "__FONT_SIZE_INT__",
                 templatesDirectory: "__TEMPLATES_DIRECTORY__",
                 pageId: "__PAGE_ID__",
                 skipStyle: true,

--- a/ArticleTemplates/cricketTemplate.html
+++ b/ArticleTemplates/cricketTemplate.html
@@ -94,7 +94,7 @@
             adsEnableHiding: "__ADS_ENABLE_HIDING__" === "true",
             adsConfig: "__ADS_CONFIG__",
             actionBarHeight: "__ACTIONBARHEIGHT__",
-            fontSize: "__FONT_SIZE_INT__",
+            fontSizeInt: "__FONT_SIZE_INT__",
             templatesDirectory: "__TEMPLATES_DIRECTORY__",
             pageId: "__PAGE_ID__",
             mpuAfterParagraphs: "__MPU_AFTER_PARAGRAPHS__",

--- a/ArticleTemplates/errorExpiredContent.html
+++ b/ArticleTemplates/errorExpiredContent.html
@@ -31,7 +31,7 @@
             platform: "__PLATFORM__",
             contentType: "error",
             actionBarHeight: "__ACTIONBARHEIGHT__",
-            fontSize: "__FONT_SIZE_INT__",
+            fontSizeInt: "__FONT_SIZE_INT__",
             templatesDirectory: "__TEMPLATES_DIRECTORY__",
             tests: '__TEST_SPEC__',
             nativeYoutubeEnabled: "__NATIVE_YOUTUBE_ENABLED__" === "true",

--- a/ArticleTemplates/footballTemplate.html
+++ b/ArticleTemplates/footballTemplate.html
@@ -54,7 +54,7 @@
             adsEnableHiding: "__ADS_ENABLE_HIDING__" === "true",
             adsConfig: "__ADS_CONFIG__",
             actionBarHeight: "__ACTIONBARHEIGHT__",
-            fontSize: "__FONT_SIZE_INT__",
+            fontSizeInt: "__FONT_SIZE_INT__",
             templatesDirectory: "__TEMPLATES_DIRECTORY__",
             pageId: "__PAGE_ID__",
             mpuAfterParagraphs: "__MPU_AFTER_PARAGRAPHS__",

--- a/ArticleTemplates/galleryTemplate.html
+++ b/ArticleTemplates/galleryTemplate.html
@@ -76,7 +76,7 @@
                 adsEnableHiding: "__ADS_ENABLE_HIDING__" === "true",
                 adsConfig: "__ADS_CONFIG__",
                 actionBarHeight: "__ACTIONBARHEIGHT__",
-                fontSize: "__FONT_SIZE_INT__",
+                fontSizeInt: "__FONT_SIZE_INT__",
                 templatesDirectory: "__TEMPLATES_DIRECTORY__",
                 pageId: "__PAGE_ID__",
                 mpuAfterParagraphs: "__MPU_AFTER_PARAGRAPHS__",

--- a/ArticleTemplates/interactiveTemplate.html
+++ b/ArticleTemplates/interactiveTemplate.html
@@ -29,7 +29,7 @@
             adsEnableHiding: "__ADS_ENABLE_HIDING__" === "true",
             adsConfig: "__ADS_CONFIG__",
             actionBarHeight: "__ACTIONBARHEIGHT__",
-            fontSize: "__FONT_SIZE_INT__",
+            fontSizeInt: "__FONT_SIZE_INT__",
             templatesDirectory: "__TEMPLATES_DIRECTORY__",
             pageId: "__PAGE_ID__",
             mpuAfterParagraphs: "__MPU_AFTER_PARAGRAPHS__",

--- a/ArticleTemplates/liveblogTemplate.html
+++ b/ArticleTemplates/liveblogTemplate.html
@@ -191,7 +191,7 @@
                 adsEnableHiding: "__ADS_ENABLE_HIDING__" === "true",
                 adsConfig: "__ADS_CONFIG__",
                 actionBarHeight: "__ACTIONBARHEIGHT__",
-                fontSize: "__FONT_SIZE_INT__",
+                fontSizeInt: "__FONT_SIZE_INT__",
                 templatesDirectory: "__TEMPLATES_DIRECTORY__",
                 pageId: "__PAGE_ID__",
                 mpuAfterParagraphs: "__MPU_AFTER_PARAGRAPHS__",

--- a/ArticleTemplates/videoTemplate.html
+++ b/ArticleTemplates/videoTemplate.html
@@ -82,7 +82,7 @@
             adsEnableHiding: "__ADS_ENABLE_HIDING__" === "true",
             adsConfig: "__ADS_CONFIG__",
             actionBarHeight: "__ACTIONBARHEIGHT__",
-            fontSize: "__FONT_SIZE_INT__",
+            fontSizeInt: "__FONT_SIZE_INT__",
             templatesDirectory: "__TEMPLATES_DIRECTORY__",
             pageId: "__PAGE_ID__",
             mpuAfterParagraphs: "__MPU_AFTER_PARAGRAPHS__",

--- a/test/fixtures/analysis-news-specialreport.html
+++ b/test/fixtures/analysis-news-specialreport.html
@@ -167,7 +167,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "politics/2016/apr/06/the-cameron-network-inherited-wealth-and-family-companies",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/analysis-news-video.html
+++ b/test/fixtures/analysis-news-video.html
@@ -150,7 +150,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "politics/2017/nov/19/philip-hammond-no-unemployed-gaffe-fuels-beliefs-tories",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/analysis-news.html
+++ b/test/fixtures/analysis-news.html
@@ -306,7 +306,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "world/2017/nov/17/zimbabwe-was-mugabes-fall-a-result-of-china-flexing-its-muscle",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/analysis-opinion.html
+++ b/test/fixtures/analysis-opinion.html
@@ -188,7 +188,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "commentisfree/2017/nov/26/egypt-iron-fist-response-terror-attacks-never-works",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/article-arts.html
+++ b/test/fixtures/article-arts.html
@@ -188,7 +188,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "music/2017/dec/04/jorja-smith-wins-2018-brits-critics-choice-award",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/article-lifestyle.html
+++ b/test/fixtures/article-lifestyle.html
@@ -177,7 +177,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "lifeandstyle/the-running-blog/2017/nov/30/only-amateurs-here-a-day-in-ethiopias-exercise-hub",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/article-news-specialreport.html
+++ b/test/fixtures/article-news-specialreport.html
@@ -158,7 +158,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "film/2016/may/17/pedro-almodovar-on-panama-papers-im-one-of-the-least-important-names-cited",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/article-news.html
+++ b/test/fixtures/article-news.html
@@ -278,7 +278,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "cities/2017/dec/02/its-not-just-extra-rich-and-extra-poor-paulistanos-respond-to-sao-paulo-live",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/article-sport-cricket-deadblog.html
+++ b/test/fixtures/article-sport-cricket-deadblog.html
@@ -1024,7 +1024,7 @@
              adsEnableHiding: "true" === "true",
              adsConfig: "mobile",
              actionBarHeight: "76",
-             fontSize: "4",
+             fontSizeInt: "4",
              templatesDirectory: "../../ArticleTemplates/",
              pageId: "sport/live/2018/jan/07/ashes-2017-18-australia-v-england-fifth-test-day-five-live",
              mpuAfterParagraphs: "3",

--- a/test/fixtures/article-sport-cricket-liveblog.html
+++ b/test/fixtures/article-sport-cricket-liveblog.html
@@ -1024,7 +1024,7 @@
              adsEnableHiding: "true" === "true",
              adsConfig: "mobile",
              actionBarHeight: "76",
-             fontSize: "4",
+             fontSizeInt: "4",
              templatesDirectory: "../../ArticleTemplates/",
              pageId: "sport/live/2018/jan/07/ashes-2017-18-australia-v-england-fifth-test-day-five-live",
              mpuAfterParagraphs: "3",

--- a/test/fixtures/article-sport-football-liveblog.html
+++ b/test/fixtures/article-sport-football-liveblog.html
@@ -248,7 +248,7 @@
              adsEnableHiding: "true" === "true",
              adsConfig: "mobile",
              actionBarHeight: "76",
-             fontSize: "4",
+             fontSizeInt: "4",
              templatesDirectory: "../../ArticleTemplates/",
              pageId: "football/live/2017/nov/26/valencia-v-barcelona-la-liga-live",
              mpuAfterParagraphs: "3",

--- a/test/fixtures/article-sport.html
+++ b/test/fixtures/article-sport.html
@@ -199,7 +199,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "sport/2017/oct/23/verstappen-says-rulemakers-killing-the-sport-after-stupid-penalty",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/audio-arts.html
+++ b/test/fixtures/audio-arts.html
@@ -159,7 +159,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "books/audio/2017/nov/28/max-tegmark-and-ken-macleod-on-artificial-intelligence-books-podcast",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/audio-news-specialreport.html
+++ b/test/fixtures/audio-news-specialreport.html
@@ -117,7 +117,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "news/audio/2016/apr/26/panama-papers-the-biggest-leak-in-history-guardian-live-event",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/audio-news-sponsored.html
+++ b/test/fixtures/audio-news-sponsored.html
@@ -120,7 +120,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "news/audio/2017/oct/27/why-cant-we-cure-the-common-cold-podcast",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/audio-news.html
+++ b/test/fixtures/audio-news.html
@@ -115,7 +115,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "news/audio/2017/oct/27/why-cant-we-cure-the-common-cold-podcast",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/audio-sport.html
+++ b/test/fixtures/audio-sport.html
@@ -172,7 +172,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "football/blog/audio/2017/dec/04/gunners-misfire-hull-upheaval-and-benevento-scenes-football-weekly",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/collection.html
+++ b/test/fixtures/collection.html
@@ -106,7 +106,7 @@
             adsEnableHiding: "true" === "true",
             adsConfig: "mobile",
             actionBarHeight: "0",
-            fontSize: "4",
+            fontSizeInt: "4",
             templatesDirectory: "../../ArticleTemplates/",
             pageId: "news/live/2018/apr/30/the-forgotten-story-",
             mpuAfterParagraphs: "3",

--- a/test/fixtures/comment-arts.html
+++ b/test/fixtures/comment-arts.html
@@ -222,7 +222,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "artanddesign/2017/dec/05/wynyard-stations-interloop-a-rare-win-for-public-art-in-a-city-that-can-leave-you-cold",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/comment-lifestyle.html
+++ b/test/fixtures/comment-lifestyle.html
@@ -160,7 +160,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "world/commentisfree/2017/dec/06/john-hockenberry-wnyc-investigation",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/comment-news.html
+++ b/test/fixtures/comment-news.html
@@ -188,7 +188,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "education/2017/dec/05/stop-treating-university-degrees-endured",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/comment-opinion-interactive.html
+++ b/test/fixtures/comment-opinion-interactive.html
@@ -169,7 +169,7 @@
                  adsEnableHiding: "true" === "true",
                  adsConfig: "tablet",
                  actionBarHeight: "0",
-                 fontSize: "4",
+                 fontSizeInt: "4",
                  templatesDirectory: "../../ArticleTemplates/",
                  pageId: "commentisfree/2018/jun/06/the-untold-story-of-the-death-of-the-nbn",
                  mpuAfterParagraphs: "3",

--- a/test/fixtures/comment-opinion-multipleauthors.html
+++ b/test/fixtures/comment-opinion-multipleauthors.html
@@ -233,7 +233,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "commentisfree/2017/nov/22/what-budget-november-2017-mean-conservatives-panel-philip-hammond",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/comment-opinion-nocutout.html
+++ b/test/fixtures/comment-opinion-nocutout.html
@@ -155,7 +155,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "commentisfree/2017/dec/07/beating-donald-trump-time-magazine-person-year-metoo-sexual-harassment",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/comment-opinion.html
+++ b/test/fixtures/comment-opinion.html
@@ -196,7 +196,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "commentisfree/2017/nov/16/working-four-day-week-hours-labour",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/comment-sport.html
+++ b/test/fixtures/comment-sport.html
@@ -194,7 +194,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "football/blog/2017/dec/06/chelsea-atletico-madrid-high-price-champions-league",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/comments.html
+++ b/test/fixtures/comments.html
@@ -57,7 +57,7 @@
 		    isOffline: "" ? true : false,
 		    contentType: "comments",
 		    adsConfig: "mobile",
-		    fontSize: "4",
+		    fontSizeInt: "4",
 		    templatesDirectory: "../../ArticleTemplates/",
 		    pageId: "world/live/2016/may/27/g7-summit-japan-obama-historic-visit-hiroshima-live",
 		    skipStyle: true,

--- a/test/fixtures/feature-arts-showcase.html
+++ b/test/fixtures/feature-arts-showcase.html
@@ -193,7 +193,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "tv-and-radio/2017/dec/06/the-50-best-tv-shows-of-2017-no-10-transparent",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/feature-arts.html
+++ b/test/fixtures/feature-arts.html
@@ -142,7 +142,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "tv-and-radio/2017/dec/05/how-the-return-of-house-of-cards-is-both-a-blessing-and-a-curse",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/feature-lifestyle-showcase.html
+++ b/test/fixtures/feature-lifestyle-showcase.html
@@ -189,7 +189,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "lifeandstyle/2017/dec/04/the-muslim-director-who-filmed-neo-nazis-i-thought-im-not-going-to-make-it-out",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/feature-lifestyle.html
+++ b/test/fixtures/feature-lifestyle.html
@@ -214,7 +214,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "us-news/2017/dec/06/these-are-my-hardest-moments-as-a-mother-what-are-yours",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/feature-news-showcase.html
+++ b/test/fixtures/feature-news-showcase.html
@@ -235,7 +235,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "society/2017/dec/06/i-want-to-study-and-play-sport-a-young-asylum-seeker-in-in-britain-one-year-on",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/feature-news.html
+++ b/test/fixtures/feature-news.html
@@ -188,7 +188,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "world/2017/dec/03/terrawatch-iceland-volcano-oraefajokull-agung",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/feature-sport-showcase.html
+++ b/test/fixtures/feature-sport-showcase.html
@@ -218,7 +218,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "global-development/2017/dec/05/boxing-the-good-fight-documentary-rio-de-janeiro-favelas-gun-violence",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/feature-sport.html
+++ b/test/fixtures/feature-sport.html
@@ -200,7 +200,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "football/these-football-times/2017/dec/06/ellie-brazil-england-serie-a-fiorentina-birmingham-city",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/gallery-arts.html
+++ b/test/fixtures/gallery-arts.html
@@ -106,7 +106,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "artanddesign/gallery/2017/nov/30/street-photography-lensculture-awards-in-pictures",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/gallery-lifestyle.html
+++ b/test/fixtures/gallery-lifestyle.html
@@ -103,7 +103,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "artanddesign/gallery/2017/nov/05/the-dalton-highway-americas-loneliest-road-in-pictures",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/gallery-news-sponsored.html
+++ b/test/fixtures/gallery-news-sponsored.html
@@ -120,7 +120,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "artanddesign/gallery/2017/oct/10/catalonia-independence-row-two-weeks-in-barcelona-in-pictures",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/gallery-news.html
+++ b/test/fixtures/gallery-news.html
@@ -115,7 +115,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "artanddesign/gallery/2017/oct/10/catalonia-independence-row-two-weeks-in-barcelona-in-pictures",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/gallery-sport.html
+++ b/test/fixtures/gallery-sport.html
@@ -105,7 +105,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "football/gallery/2017/dec/03/the-dozen-the-weekends-best-premier-league-photos",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/guardianview-opinion.html
+++ b/test/fixtures/guardianview-opinion.html
@@ -253,7 +253,7 @@
                  adsEnableHiding: "true" === "true",
                  adsConfig: "mobile",
                  actionBarHeight: "76",
-                 fontSize: "4",
+                 fontSizeInt: "4",
                  templatesDirectory: "../../ArticleTemplates/",
                  pageId: "commentisfree/2018/jan/02/the-guardian-view-on-renewing-europe",
                  mpuAfterParagraphs: "3",

--- a/test/fixtures/immersive-arts.html
+++ b/test/fixtures/immersive-arts.html
@@ -149,7 +149,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "world/2017/nov/18/taylor-wessing-prize-who-is-the-man-in-the-photograph",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/immersive-lifestyle.html
+++ b/test/fixtures/immersive-lifestyle.html
@@ -208,7 +208,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "news/2017/oct/06/why-cant-we-cure-the-common-cold",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/immersive-news-special.html
+++ b/test/fixtures/immersive-news-special.html
@@ -394,7 +394,7 @@
             adsEnableHiding: "true" === "true",
             adsConfig: "mobile",
             actionBarHeight: "0",
-            fontSize: "4",
+            fontSizeInt: "4",
             templatesDirectory: "../../ArticleTemplates/",
             pageId: "news/2018/mar/17/data-war-whistleblower-christopher-wylie-faceook-nix-bannon-trump",
             mpuAfterParagraphs: "3",

--- a/test/fixtures/immersive-news-video.html
+++ b/test/fixtures/immersive-news-video.html
@@ -211,7 +211,7 @@
             adsEnableHiding: "true" === "true",
             adsConfig: "mobile",
             actionBarHeight: "0",
-            fontSize: "4",
+            fontSizeInt: "4",
             templatesDirectory: "file:///var/mobile/Containers/Data/Application/37E6E44F-0BF5-4C80-8F08-753F35ABE31D/Library/Caches/article_templates/",
             pageId: "environment/2018/may/24/pig-farm-agriculture-its-wrong-to-stink-up-other-peoples-lives-fighting-the-manure-lagoons-of-north-carolina",
             mpuAfterParagraphs: "3",

--- a/test/fixtures/immersive-news.html
+++ b/test/fixtures/immersive-news.html
@@ -199,7 +199,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "news/2017/oct/31/coders-of-the-world-unite-can-silicon-valley-workers-curb-the-power-of-big-tech",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/immersive-sport.html
+++ b/test/fixtures/immersive-sport.html
@@ -250,7 +250,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "football/2016/apr/06/the-fall-how-diving-became-football-worst-crime",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/live-arts-dead.html
+++ b/test/fixtures/live-arts-dead.html
@@ -378,7 +378,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "tv-and-radio/live/2017/may/13/eurovision-song-contest-2017-live",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/live-news.html
+++ b/test/fixtures/live-news.html
@@ -540,7 +540,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "business/live/2017/dec/07/pound-sterling-ftse-brexit-bitcoin-economics-business-live",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/live-sport-dead.html
+++ b/test/fixtures/live-sport-dead.html
@@ -180,7 +180,7 @@
              adsEnableHiding: "true" === "true",
              adsConfig: "mobile",
              actionBarHeight: "0",
-             fontSize: "4",
+             fontSizeInt: "4",
              templatesDirectory: "../../ArticleTemplates/",
              pageId: "football/live/2017/dec/06/shakhtar-donetsk-v-manchester-city-champions-league-live",
              mpuAfterParagraphs: "3",

--- a/test/fixtures/matchreport-sport.html
+++ b/test/fixtures/matchreport-sport.html
@@ -164,7 +164,7 @@
              adsEnableHiding: "true" === "true",
              adsConfig: "mobile",
              actionBarHeight: "76",
-             fontSize: "4",
+             fontSizeInt: "4",
              templatesDirectory: "../../ArticleTemplates/",
              pageId: "football/2018/jan/01/stoke-city-newcastle-united-match-report",
              mpuAfterParagraphs: "3",

--- a/test/fixtures/recipe-lifestyle-showcase.html
+++ b/test/fixtures/recipe-lifestyle-showcase.html
@@ -221,7 +221,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "lifeandstyle/2017/nov/11/great-australian-cookbook-beetroot-medley-vegetarian-croquettes-and-palm-heart-salad",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/recipe-lifestyle.html
+++ b/test/fixtures/recipe-lifestyle.html
@@ -196,7 +196,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "lifeandstyle/2017/oct/14/mushroom-bao-recipe-chinese-bun-meera-sodha-vegan",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/review-arts-showcase.html
+++ b/test/fixtures/review-arts-showcase.html
@@ -208,7 +208,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "stage/2017/sep/28/after-the-rehearsal-persona-review-barbican-ivo-van-hove-ingmar-bergman",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/review-arts.html
+++ b/test/fixtures/review-arts.html
@@ -189,7 +189,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "music/2017/nov/30/nabihah-iqbal-weighing-of-the-heart-review-nostalgic-sweet-pop-and-pristine-beats",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/review-news.html
+++ b/test/fixtures/review-news.html
@@ -217,7 +217,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "technology/2017/dec/04/google-pixel-buds-review-bluetooth-earbuds-headphone-apple-airpods-translation",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/review-opinion.html
+++ b/test/fixtures/review-opinion.html
@@ -213,7 +213,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "technology/2012/feb/22/pinterest-not-just-for-girls",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/review-sport.html
+++ b/test/fixtures/review-sport.html
@@ -189,7 +189,7 @@
                     adsEnableHiding: "true" === "true",
                     adsConfig: "mobile",
                     actionBarHeight: "0",
-                    fontSize: "4",
+                    fontSizeInt: "4",
                     templatesDirectory: "../../ArticleTemplates/",
                     pageId: "books/2017/may/26/knowing-the-score-david-papineau-review",
                     mpuAfterParagraphs: "3",

--- a/test/fixtures/video-arts.html
+++ b/test/fixtures/video-arts.html
@@ -108,7 +108,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "music/video/2017/nov/20/barack-and-michelle-obama-pay-tribute-to-diana-ross-at-2017-american-music-awards-video",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/video-lifestyle.html
+++ b/test/fixtures/video-lifestyle.html
@@ -106,7 +106,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "lifeandstyle/video/2017/oct/31/swipe-my-race-tinder-happn-bame",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/video-news-specialreport.html
+++ b/test/fixtures/video-news-specialreport.html
@@ -103,7 +103,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "news/video/2016/apr/06/iceland-protests-reykjavik-sigmundur-davio-gunnlaugsson-panama-papers-video",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/video-news-sponsored.html
+++ b/test/fixtures/video-news-sponsored.html
@@ -110,7 +110,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "us-news/video/2017/dec/04/donald-trump-says-he-feels-very-badly-for-michael-flynn-video",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/video-news.html
+++ b/test/fixtures/video-news.html
@@ -105,7 +105,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "us-news/video/2017/dec/04/donald-trump-says-he-feels-very-badly-for-michael-flynn-video",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/video-opinion.html
+++ b/test/fixtures/video-opinion.html
@@ -100,7 +100,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "commentisfree/video/2017/jun/21/one-tragedy-after-another-whats-this-summer-doing-to-us",
                 mpuAfterParagraphs: "3",

--- a/test/fixtures/video-sport.html
+++ b/test/fixtures/video-sport.html
@@ -108,7 +108,7 @@
                 adsEnableHiding: "true" === "true",
                 adsConfig: "mobile",
                 actionBarHeight: "0",
-                fontSize: "4",
+                fontSizeInt: "4",
                 templatesDirectory: "../../ArticleTemplates/",
                 pageId: "football/video/2017/nov/30/270-miles-from-anfield-but-no-less-liverpool-video",
                 mpuAfterParagraphs: "3",


### PR DESCRIPTION
There's currently a duplicate property `fontSize` being passed in the options object passed to `GU.bootstrap.init`. I've renamed the duplicate to `fontSizeInt`. This is a simple search/replace job and will have no potential impact as `fontSize` is not being used anywhere in the JavaScript right now anyway!

Tidying up this Object and removing unused properties is something that needs to be done at a later date.