### PR TITLE
AA-80 - Add aria tag to image in article

### DIFF
--- a/ArticleTemplates/articleTemplateImage.html
+++ b/ArticleTemplates/articleTemplateImage.html
@@ -1,7 +1,7 @@
 <figure class="element element-image figure-wide">
     <div class="element__inner" style="padding-bottom: __IMAGE_RATIO_PERCENTAGE__;">
         <a href="x-gu://gallery/__IMAGE_URL__">
-            <img src="__IMAGE_URL__" alt="__IMAGE_ALT__"/>
+            <img src="__IMAGE_URL__" aria-label="Image of __IMAGE_ALT__" alt="__IMAGE_ALT__"/>
         </a>
     </div>
     <figcaption class="main-media__caption">


### PR DESCRIPTION
This adds a small change to how a screen reader interacts with the templates in webview and is linked to this ticket here:

https://theguardian.atlassian.net/browse/AA-80

It simple adds the words "Image of" to the front of any alt text as the Accessibility Survey highlighted that it's unclear exactly what is is selected on the screen when using talkback.