### PR TITLE
Add childList mutations to the list of items to observe because it seems to be necessary

### DIFF
--- a/ArticleTemplates/assets/js/modules/cards.js
+++ b/ArticleTemplates/assets/js/modules/cards.js
@@ -19,7 +19,7 @@ function (
                     // The native layer defines bodyMutationNotification.
                     window.webkit.messageHandlers.bodyMutationNotification.postMessage({rect: newRelatedContentPosition });
                 }
-            }).observe(window.document.body, { attributes: true, subtree: true });
+            }).observe(window.document.body, { attributes: true, childList: true, subtree: true });
             setupGlobals();
         }
     }


### PR DESCRIPTION
The related content wasn't being positioned correctly on some articles - Live blogs and articles containing Tweets for example. Adding `childList` to the list of items to observe seems to solve this problem. There may be performance issues with this though I haven't observed any. 