### PR TITLE
Define and expose function for allowing Live Blog block to be scrolled to smoothly.

### DIFF
--- a/ArticleTemplates/assets/js/bootstrap.js
+++ b/ArticleTemplates/assets/js/bootstrap.js
@@ -34,7 +34,8 @@
             'getArticleHeight',
             'injectInlineArticleMembershipCreative',
             'getRelatedContentPosition',
-            'setRelatedContentHeight'
+            'setRelatedContentHeight',
+            'scrollToBlock'
         ],
         loadCss = function() {
             var url = 'assets/css/' + opts.asyncStylesFilename + '.css',

--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -6,7 +6,8 @@ define([
     'bootstraps/common',
     'modules/util',
     'modules/creativeInjector',
-    'modules/cards'
+    'modules/cards',
+    'smoothScroll'
 ], function (
     relativeDates,
     twitter,
@@ -15,7 +16,8 @@ define([
     common,
     util,
     creativeInjector,
-    cards
+    cards,
+    SmoothScroll
 ) {
     'use strict';
 
@@ -26,6 +28,14 @@ define([
     function updateBlocksOnScroll() {
         if (liveblogStartPos.top > window.scrollY) {
             liveblogNewBlockDump();
+        }
+    }
+
+    function scrollToBlock(id) {  
+        var smoothScroll = new SmoothScroll();
+        var element = document.querySelector('#block-' + id);
+        if (element) {
+            smoothScroll.animateScroll(element);
         }
     }
 
@@ -222,11 +232,13 @@ define([
         window.showLiveMore = showLiveMore;
         window.liveblogNewBlock = liveblogNewBlock;
         window.liveblogNewKeyEvent = liveblogNewKeyEvent;
+        window.scrollToBlock = scrollToBlock;
 
         window.applyNativeFunctionCall('liveblogNewBlock');
         window.applyNativeFunctionCall('liveblogDeleteBlock');
         window.applyNativeFunctionCall('liveblogUpdateBlock');
         window.applyNativeFunctionCall('liveblogNewKeyEvent');
+        window.applyNativeFunctionCall('scrollToBlock');
     }
 
     function keyEvents() {


### PR DESCRIPTION
This PR adds a function that will be called by the native layer passing the id of a Live Blog block in order to scroll that block into view. The [SmoothScroll](https://github.com/cferdinandi/smooth-scroll) library needed to be used here because [Safari on iOS doesn't yet support smooth scrolling](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) when using `window.scrollIntoView()`

