### PR TITLE
Return a value so that we can track the success of the scroll

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -36,7 +36,9 @@ define([
         var element = document.querySelector('#block-' + id);
         if (element) {
             smoothScroll.animateScroll(element);
+            return true;
         }
+        return false;
     }
 
     function addNewBlockToBlog(insertAfterElem, block) {


### PR DESCRIPTION
To allow us to tracking how often users are attempting to link to blocks that are not within the first 10.