### PR TITLE
Update article geometry with callouts and snippets

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/atoms.js
+++ b/ArticleTemplates/assets/js/bootstraps/atoms.js
@@ -1,7 +1,9 @@
 define([
-  'modules/atoms/services'
+  'modules/atoms/services',
+  'modules/cards'
 ], function (
-  services
+  services,
+  cards
 ) {
     'use strict';
 
@@ -24,9 +26,16 @@ define([
         if (typeof atom === 'string') {
           console.log('Failed to initialise atom [' + atomType + '/' + atoms[i].getAttribute('data-atom-id') + ']: ' + atom);
         } else {
+          initExpandables(atoms[i]);
           atom.start();
         }
       }
+    }
+
+    function initExpandables(atom) {
+      Array.from(atom.getElementsByTagName('details')).forEach(function (d) {
+        d.addEventListener('toggle', cards.initPositionPoller);
+      });
     }
 
     return {

--- a/ArticleTemplates/assets/js/bootstraps/campaign.js
+++ b/ArticleTemplates/assets/js/bootstraps/campaign.js
@@ -2,7 +2,6 @@ define([], function () {
     'use strict';
 
     const endpoint = GU.opts.campaignsUrl;
-console.log(endpoint);
 
     function init() {
       const campaign = document.querySelector('.campaign--snippet');

--- a/ArticleTemplates/assets/js/bootstraps/campaign.js
+++ b/ArticleTemplates/assets/js/bootstraps/campaign.js
@@ -1,4 +1,6 @@
-define([], function () {
+define([
+  'modules/cards'
+], function (cards) {
     'use strict';
 
     const endpoint = GU.opts.campaignsUrl;
@@ -15,6 +17,7 @@ define([], function () {
         displayOfflineMessage(campaign);
       }
 
+      campaign.addEventListener('toggle', cards.initPositionPoller);
       window.addEventListener('online', hideOfflineMessage.bind(null, campaign));
       window.addEventListener('offline', displayOfflineMessage.bind(null, campaign));
 


### PR DESCRIPTION
The components at the bottom of articles belong in the native layer. As a result, when the geometry of the article changes, a process must update the position of these components so that they don't overlay the content (or a huge whitespace appears). There is a polling process in place that regularly checks and updates the geometry if necessary, but it has a back-off polling time. As a result, when opening a callout (for instance), there is a lag between the moment the article height changes and the components at the bottom are repositioned: this creates an ugly/broken visual effect, especially if the callout is at the bottom of the article.

This solution remedies the problem by explicitly requiring a geometry update every time an expandable atom/callout is either opened or closed.