### PR TITLE
Revert "Enable CORS"

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/campaign.js
+++ b/ArticleTemplates/assets/js/bootstraps/campaign.js
@@ -44,7 +44,6 @@ define([
       req.open('POST', endpoint);
       req.setRequestHeader('Content-Type', 'application/json');
       req.setRequestHeader('Accept', 'application/json');
-      req.withCredentials = true;
       req.onload = displayConfirmation.bind(null, campaign, form);
       req.onerror = displayError.bind(null, campaign, form);
       req.send(JSON.stringify(data));


### PR DESCRIPTION
Reverts guardian/mobile-apps-article-templates#811

Testing from @SLambrakis and the Android team suggests that this change has stopped submit working on the forms. 

If we want to use `req.withCredentials = true;` we need to set the `Access-Control-Allow-Origin` header to point to the app url. 
```
      req.setRequestHeader('Access-Control-Allow-Origin', 'https://guardian.co.uk');
      req.setRequestHeader('Vary', 'Origin');
```
We should return to the use of `withCredentials` before rolling this out to editorial 