### PR TITLE
Callout campaigns: Add waiting message to callout form

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/campaign.js
+++ b/ArticleTemplates/assets/js/bootstraps/campaign.js
@@ -40,6 +40,7 @@ define([
     }
 
     function submit(data, campaign, form) {
+      displayWaiting(form);
       var req = new XMLHttpRequest();
       req.open('POST', endpoint);
       req.setRequestHeader('Content-Type', 'application/json');
@@ -71,6 +72,12 @@ define([
       enableButton(form);
     }
 
+    function displayWaiting(form) {
+      var button = form.querySelector('.form_submit button');
+      button.textContent = 'Sending...';
+      disableButton(form);
+    }
+
     function disableButton(form) {
       var button = form.querySelector('button');
       button.disabled = true;
@@ -79,6 +86,7 @@ define([
     function enableButton(form) {
       var button = form.querySelector('button');
       button.disabled = false;
+      button.textContent = 'Share with the Guardian';
     }
 
     return {

--- a/ArticleTemplates/assets/scss/modules/_campaign.scss
+++ b/ArticleTemplates/assets/scss/modules/_campaign.scss
@@ -31,17 +31,22 @@
             font-family: $agate-sans;
         }
     }
-            
+
 }
 
 .campaign__error {
     padding: 0px 0px 10px 23px;
-    color: color(news-feature-headline);
     margin-top: -35px;
     margin-bottom: 20px;
+    color: color(news-feature-headline);
     p {
         font-family: $agate-sans;
     }
+}
+
+p.campaign__info {
+    color: color(global-adv-shade-1);
+    font-family: $agate-sans;
 }
 
 .campaign--snippet .form_submit button {
@@ -52,32 +57,32 @@
         &:hover, :active {
             background-color: darken(color(news-kicker), 5%);
         }
-    
+
         .garnett--pillar-news & {
             &:hover, &:active {
                 background-color: darken(color(news-kicker), 5%);
             }
         }
 
-    
+
         .garnett--pillar-sport & {
             &:hover, &:active {
                 background-color: darken(color(sport-feature-headline), 5%);
             }
         }
-    
+
         .garnett--pillar-opinion & {
             &:hover, &:active {
                 background-color: darken(color(opinion-feature-headline), 5%);
             }
         }
-    
+
         .garnett--pillar-arts & {
             &:hover, &:active {
                 background-color: darken(color(arts-feature-headline), 5%);
             }
         }
-    
+
         .garnett--pillar-lifestyle & {
             &:hover, &:active {
                 background-color: darken(color(lifestyle-kicker), 5%);
@@ -178,7 +183,7 @@
         &:hover, :active {
             color: color(brightness-100);
             background-color: color(arts-feature-headline);
-            
+
             .icon {
                 fill: color(brightness-100);
             }


### PR DESCRIPTION
Reader callout forms should show a "Waiting" message if the form is waiting to be submitted 

On poor connections this can be up to 12 seconds. 

Connected PR: https://github.com/guardian/mobile-apps-api/pull/1203