### PR TITLE
Revert "stop hiding captions"

### DIFF
--- a/ArticleTemplates/assets/scss/layout/_article--photo-essay.scss
+++ b/ArticleTemplates/assets/scss/layout/_article--photo-essay.scss
@@ -48,6 +48,9 @@
 
 .display-hint--photoEssay .prose,
 .display-hint--articleImmersive .prose {
+    figure.element-image figcaption {
+        display: none;
+    }
 
     figure.element-image + ul {
         clear: both;


### PR DESCRIPTION
Reverts guardian/mobile-apps-article-templates#820

Found a case that displays two captions: https://www.theguardian.com/cities/2018/aug/13/halfway-boiling-city-50c