### PR TITLE
make links readable in preview

### DIFF
--- a/ArticleTemplates/assets/scss/modules/blocks/_comment.scss
+++ b/ArticleTemplates/assets/scss/modules/blocks/_comment.scss
@@ -439,6 +439,10 @@
         .prose blockquote {
             color: color(brightness-100);
         }
+
+        a {
+            color: color(brightness-100);
+        }
     }
 
     .comment__recommend {


### PR DESCRIPTION
Missed a case where links were hard to read in the preview:
![img_0061](https://user-images.githubusercontent.com/11618797/44099722-2418043c-9fdb-11e8-9f6e-cae93ab6291b.PNG)

After:
![screen shot 2018-08-14 at 15 58 23](https://user-images.githubusercontent.com/11618797/44099751-379ec054-9fdb-11e8-86fd-e765ddcc896f.png)
