### PR TITLE
avoid flash of alt comment on every article view

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-layout/_article.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_article.scss
@@ -4,6 +4,10 @@
     @include mq($from: col4) {
         background-color: color(brightness-93);
     }
+
+    img {
+        color: color(tone-sandy-light);
+    }
 }
 
 .article__header {


### PR DESCRIPTION
- Initially set alt attribute to be colour of background to avoid flash of content

# TODO
- Set colour back to original once img is loaded
- Show article caption by default if offline?
- Stop "Match Info" temporarily showing