### PR TITLE
increase width for large tablet screens

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-modules/cricket/_match-summary.scss
+++ b/ArticleTemplates/assets/scss/garnett-modules/cricket/_match-summary.scss
@@ -282,7 +282,7 @@
         width: cols($base-3, 4, 1);
     }
 
-    @include mq($from: col3) {
+    @include mq(col3, col4) {
         width: cols($base-4, 5, 1);
     }
 
@@ -380,6 +380,12 @@
 
     @include mq($to: col2) {
         display: none;
+    }
+
+    @include mq($from: col4) {
+        .cricket-scorecard-title {
+            border-bottom: none;
+        }
     }
 
     .cricket-inning-result &,


### PR DESCRIPTION
iPad pro landscape screen width not currently handled:

# Before
![screen shot 2018-08-30 at 15 07 55](https://user-images.githubusercontent.com/11618797/44857526-e47ff480-ac67-11e8-8bd3-9e5fd9b32c76.png)

# After
![screen shot 2018-08-30 at 15 06 04](https://user-images.githubusercontent.com/11618797/44857511-dfbb4080-ac67-11e8-9f33-8bcf6ac21e11.png)
