### PR TITLE
Revert "apply missing padding to articles on android"

### DIFF
--- a/ArticleTemplates/assets/scss/garnett-layout/_article.scss
+++ b/ArticleTemplates/assets/scss/garnett-layout/_article.scss
@@ -1,7 +1,3 @@
-.android .article {
-    padding-top: 6px;
-}
-
 .article {
     overflow: hidden;
 


### PR DESCRIPTION
Reverts guardian/mobile-apps-article-templates#832