### PR TITLE
GuardianLabs style improvements

### DIFF
--- a/ArticleTemplates/assets/scss/layout/_article--sponsorship.scss
+++ b/ArticleTemplates/assets/scss/layout/_article--sponsorship.scss
@@ -38,6 +38,10 @@
 .is_advertising {
     background-color: color(global-adv-bg);
 
+    .article-kicker {
+        background-color: color(global-adv-bg);
+    }
+
     @include mq($from: col4) {
         background-color: color(brightness-86);
     }
@@ -146,6 +150,7 @@
                         border-top: 0;
                     }
 
+                    .prose .element-pullquote blockquote,
                     .prose .element-pullquote blockquote cite,
                     .prose .element-pullquote blockquote::before,
                     .prose .element-pullquote blockquote::after {

--- a/ArticleTemplates/assets/scss/pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/pillar/_colour.scss
@@ -286,7 +286,7 @@
 // depending on context
 @mixin pillar-reversible($kicker, $feature, $soft, $inverted) {
 
-    &:not(.garnett--type-live) {
+    &:not(.garnett--type-live):not(.garnett--type-guardianlabs) {
         // Section and series labels above headline
         .article-kicker {
             color: $kicker;
@@ -312,5 +312,4 @@
         }
 
     }
-
 }

--- a/ArticleTemplates/assets/scss/style-sync.scss
+++ b/ArticleTemplates/assets/scss/style-sync.scss
@@ -66,6 +66,7 @@
 @import 'type/media-all';
 @import 'type/media-audio';
 @import 'type/media-video';
+@import 'type/guardianlabs';
 @import 'type/guardianview';
 @import 'type/matchreport';
 @import 'type/collection';

--- a/ArticleTemplates/assets/scss/type/_guardianlabs.scss
+++ b/ArticleTemplates/assets/scss/type/_guardianlabs.scss
@@ -1,0 +1,11 @@
+.garnett--type-guardianlabs {
+    &.display-hint--immersive {
+        .article__header {
+            display: none;
+        }
+
+        .article--standard .article__body {
+            padding: 0;
+        }
+    }
+}


### PR DESCRIPTION
| Before | After
|---|---|
| ![screen shot 2018-09-03 at 14 37 15](https://user-images.githubusercontent.com/11618797/45000470-0c02f400-afbd-11e8-8446-03044ce7cabb.png) | <img width="434" alt="screen shot 2018-09-03 at 21 03 06" src="https://user-images.githubusercontent.com/11618797/45000473-10c7a800-afbd-11e8-8601-f932df1e3855.png"> |
| ![screen shot 2018-09-03 at 14 35 08](https://user-images.githubusercontent.com/11618797/45000475-145b2f00-afbd-11e8-9352-5619d25902c7.png) | <img width="394" alt="screen shot 2018-09-03 at 21 03 50" src="https://user-images.githubusercontent.com/11618797/45000476-17561f80-afbd-11e8-95d5-f784f1b6cfc8.png"> |
| ![screen shot 2018-09-03 at 11 01 29](https://user-images.githubusercontent.com/11618797/45000479-1ae9a680-afbd-11e8-8411-0ce951f35acf.png) | <img width="435" alt="screen shot 2018-09-03 at 21 00 54" src="https://user-images.githubusercontent.com/11618797/45000481-1d4c0080-afbd-11e8-9cc0-a07286ed9cfa.png"> |
| ![screen shot 2018-09-04 at 11 20 24](https://user-images.githubusercontent.com/11618797/45026075-1cef4c00-b035-11e8-8f49-08a7ebee940e.png) | ![screen shot 2018-09-04 at 10 54 02](https://user-images.githubusercontent.com/11618797/45026088-25478700-b035-11e8-8e13-cd1b03e95cb5.png) |


