### PR TITLE
Use GuardianTextEgyptian on Android (AA-561)

### DIFF
--- a/ArticleTemplates/assets/scss/base/_typography.scss
+++ b/ArticleTemplates/assets/scss/base/_typography.scss
@@ -7,7 +7,7 @@ $fontMap: (
         ios-src: 'url("../fonts/icons.otf")'
     ),
 
-    // Agaate
+    // Guardian Headline
     GHGuardianHeadlineLight: (
         family: 'Guardian Headline',
         weight: 200,
@@ -91,26 +91,26 @@ $fontMap: (
     // Text Egyptian
     GuardianTextEgyptianWeb: (
         family: 'Guardian Text Egyptian Web',
-        android-src: 'url("../fonts/egyptiantext-regular.otf")',
+        android-src: 'url("../fonts/GuardianTextEgyptian-Regular.ttf"), url("../fonts/egyptiantext-regular.otf")',
         ios-src: 'url("../fonts/egyptiantext-regular.otf")'
     ),
     GuardianTextEgyptianWebBold: (
         family: 'Guardian Text Egyptian Web',
         weight: 'bold',
-        android-src: 'url("../fonts/egyptiantext-medium.otf")',
+        android-src: 'url("../fonts/GuardianTextEgyptian-Medium.ttf"), url("../fonts/egyptiantext-medium.otf")',
         ios-src: 'url("../fonts/egyptiantext-medium.otf")'
     ),
     GuardianTextEgyptianWebItalic: (
         family: 'Guardian Text Egyptian Web',
         style: 'italic',
-        android-src: 'url("../fonts/egyptiantext-regularitalic.otf")',
+        android-src: 'url("../fonts/GuardianTextEgyptian-RegularItalic.ttf"), url("../fonts/egyptiantext-regularitalic.otf")',
         ios-src: 'url("../fonts/egyptiantext-regularitalic.otf")'
     ),
     GuardianTextEgyptianWebBoldItalic: (
         family: 'Guardian Text Egyptian Web',
         style: 'italic',
         weight: 'bold',
-        android-src: 'url("../fonts/egyptiantext-mediumitalic.otf")',
+        android-src: 'url("../fonts/GuardianTextEgyptian-MediumItalic.ttf"), url("../fonts/egyptiantext-mediumitalic.otf")',
         ios-src: 'url("../fonts/egyptiantext-mediumitalic.otf")'
     ),
 


### PR DESCRIPTION
This PR works in conjunction with this PR against the [Android repo](https://github.com/guardian/android-news-app/pull/4714) to replace the old EgyptianText fonts with the new GuardianTextEgyptian ones.

The Android app will provide these fonts from its codebase for now, rather than importing them from templates repo, so that iOS don't have to include unused fonts in their app bundle. But I have prepared a second PR for the templates repo (#843) to resolve this, which we can merge later when iOS are happy with the change.

This and first templates PR above combined fix the issue raised by Kath's brother that Zach emailed us about. You can see some screenshots on [the Android PR](https://github.com/guardian/android-news-app/pull/4714).