### PR TITLE
Add podcast links to the audio page

### DIFF
--- a/ArticleTemplates/assets/scss/modules/media/_audio-player.scss
+++ b/ArticleTemplates/assets/scss/modules/media/_audio-player.scss
@@ -151,10 +151,11 @@
 
 .podcast-meta {
     background: color(neutral-1);
-    margin: 0 10px;
     color: color(brightness-100);
-    padding: 10px 10px 0;
+    font-family: $agate-sans;
     font-size: 12px;
+    margin: 0 10px;
+    padding: 10px 10px 0;
 }
 
 .podcast-meta ul > .podcast-meta__item::before {

--- a/ArticleTemplates/assets/scss/modules/media/_audio-player.scss
+++ b/ArticleTemplates/assets/scss/modules/media/_audio-player.scss
@@ -148,3 +148,21 @@
     width: 16px;
     position: absolute;
 }
+
+.podcast-meta {
+    background: color(neutral-1);
+    margin: 0 10px;
+    color: color(brightness-100);
+    padding: 10px 10px 0;
+    font-size: 12px;
+}
+
+.podcast-meta ul > .podcast-meta__item::before {
+    content: none;
+}
+
+.podcast-meta__link {
+    color: color(brightness-86);
+    display: block;
+    line-height: 2.5;
+}

--- a/ArticleTemplates/audioTemplate.html
+++ b/ArticleTemplates/audioTemplate.html
@@ -51,6 +51,11 @@
                         </div>
                     </div>
                 </div>
+                <div class="podcast-meta">
+                    <div class="podcast-meta__title">Subscribe for free:</div>
+                    __PODCAST_LINKS__
+                </div>
+    
                 <div class="meta keyline-4">
                     <div class="meta__misc">
                         <div class="meta__published__comments">__COMMENT_CTA__</div>

--- a/test/fixtures/audio-news.html
+++ b/test/fixtures/audio-news.html
@@ -50,6 +50,20 @@
                         </div>
                     </div>
                 </div>
+                <div class="podcast-meta">
+                    <div class="podcast-meta__title">Subscribe for free:</div>
+                    <ul>
+                        <li class="podcast-meta__item podcast-meta__item--itunes">
+                            <a class="podcast-meta__link" href="#" data-link-name="podcast:subscribe:iTunes:Sarah Waters, John Boyne and the 2018 Man Booker prize shortlist – books podcast">Apple Podcasts</a>
+                        </li>
+                        <li class="podcast-meta__item podcast-meta__item--googlePodcasts">
+                            <a class="podcast-meta__link" href="#" data-link-name="podcast:subscribe:googlePodcasts:Sarah Waters, John Boyne and the 2018 Man Booker prize shortlist – books podcast">Google Podcasts</a>
+                        </li>
+                        <li class="podcast-meta__item podcast-meta__item--spotify">
+                            <a class="podcast-meta__link" href="#" data-link-name="podcast:subscribe:spotify:Sarah Waters, John Boyne and the 2018 Man Booker prize shortlist – books podcast">Spotify</a>
+                        </li>
+                    </ul>
+                </div>div>
                 <div class="meta keyline-4">
                     <div class="meta__misc">
                         <div class="meta__published__comments">

--- a/test/fixtures/audio-news.html
+++ b/test/fixtures/audio-news.html
@@ -63,7 +63,7 @@
                             <a class="podcast-meta__link" href="#" data-link-name="podcast:subscribe:spotify:Sarah Waters, John Boyne and the 2018 Man Booker prize shortlist – books podcast">Spotify</a>
                         </li>
                     </ul>
-                </div>div>
+                </div>
                 <div class="meta keyline-4">
                     <div class="meta__misc">
                         <div class="meta__published__comments">


### PR DESCRIPTION
This requires apps to be updated in order to fill a new placeholder, `__PODCAST_LINKS__` with something that looks like that:
```html
<ul>
  <li class="podcast-meta__item podcast-meta__item--itunes">
    <a class="podcast-meta__link" href="..." data-link-name="podcast:subscribe:iTunes:Sarah Waters, John Boyne and the 2018 Man Booker prize shortlist – books podcast">Apple Podcasts</a>
  </li>
  <li class="podcast-meta__item podcast-meta__item--googlePodcasts">
    <a class="podcast-meta__link" href="..." data-link-name="podcast:subscribe:googlePodcasts:Sarah Waters, John Boyne and the 2018 Man Booker prize shortlist – books podcast">Google Podcasts</a>
  </li>
  <li class="podcast-meta__item podcast-meta__item--spotify">
    <a class="podcast-meta__link" href="..." data-link-name="podcast:subscribe:spotify:Sarah Waters, John Boyne and the 2018 Man Booker prize shortlist – books podcast">Spotify</a>
  </li>
</ul>
```

All three fields URLs will soon be [available in MAPI](https://github.com/guardian/mobile-apps-api/pull/1222).

![screen shot 2018-09-25 at 13 30 04](https://user-images.githubusercontent.com/629976/46014698-0e420500-c0c8-11e8-8394-e766e1b7d2c7.png)
