### PR TITLE
Related content and outbrain cleanup

### DIFF
--- a/ArticleTemplates/assets/scss/base/_reset.scss
+++ b/ArticleTemplates/assets/scss/base/_reset.scss
@@ -18,7 +18,7 @@ audio, video {
 
 body,
 html {
-    background-color: color(brightness-93);
+    background-color: color(brightness-96);
     color: color(brightness-7);
     width: 100%;
     max-width: 100%;

--- a/ArticleTemplates/assets/scss/layout/_article--audio.scss
+++ b/ArticleTemplates/assets/scss/layout/_article--audio.scss
@@ -35,6 +35,6 @@
     }
 
     .standfirst {
-        padding: base-px(2, 1, 0.25, 1);
+        padding: base-px(2, 1, .25, 1);
     }
 }

--- a/ArticleTemplates/assets/scss/layout/_article--liveblog.scss
+++ b/ArticleTemplates/assets/scss/layout/_article--liveblog.scss
@@ -83,6 +83,17 @@ body[data-content-type='liveblog'] {
         }
     }
 
+    .tags__inline-list:not(:empty) {
+        @include mq($from: col3) {
+            margin-left: cols($base-4, 5, 1);
+        }
+
+        @include mq($from: col4) {
+            margin-left: 232px; // 240 - 4 (item padding offset) - 4 (visually offset rounded items);
+            width: 940px;
+        }
+    }
+
     .tags {
         border-top: 0;
 

--- a/ArticleTemplates/assets/scss/layout/_article--liveblog.scss
+++ b/ArticleTemplates/assets/scss/layout/_article--liveblog.scss
@@ -83,17 +83,6 @@ body[data-content-type='liveblog'] {
         }
     }
 
-    .tags__inline-list:not(:empty) {
-        @include mq($from: col3) {
-            margin-left: cols($base-4, 5, 1);
-        }
-
-        @include mq($from: col4) {
-            margin-left: 232px; // 240 - 4 (item padding offset) - 4 (visually offset rounded items);
-            width: 940px;
-        }
-    }
-
     .tags {
         border-top: 0;
 

--- a/ArticleTemplates/assets/scss/layout/_article.scss
+++ b/ArticleTemplates/assets/scss/layout/_article.scss
@@ -2,7 +2,7 @@
     overflow: hidden;
 
     @include mq($from: col4) {
-        background-color: color(brightness-93);
+        background-color: color(brightness-96);
     }
 
     img {

--- a/ArticleTemplates/assets/scss/layout/_base-tone.scss
+++ b/ArticleTemplates/assets/scss/layout/_base-tone.scss
@@ -8,7 +8,7 @@ body {
             background-color: color(brightness-100);
 
             @include mq($from: col4) {
-                background-color: color(brightness-93);
+                background-color: color(brightness-96);
 
                 .section,
                 .article-kicker,

--- a/ArticleTemplates/assets/scss/modules/_comments.scss
+++ b/ArticleTemplates/assets/scss/modules/_comments.scss
@@ -85,7 +85,7 @@
 
     &__header {
         position: relative;
-        margin: base-px(1);
+        margin: base-px(1, 1, 3, 1);
 
         @include mq($from: col2) {
             margin: base-px(1, 1, 1.5, 1);
@@ -136,7 +136,11 @@
     }
 
     &__title {
-        @include body-font(1.5, $egyptian-display, 600);
+        font-family: 'Guardian Headline', 'Guardian Egyptian Web', Georgia, serif;
+        font-weight: 600;
+        font-size: 2rem;
+        line-height: 2.3rem;
+        padding-bottom: 0;
 
         @include mq($from: col2) {
             line-height: 1;
@@ -277,9 +281,9 @@
 
     .block {
         margin: base-px(1);
-        border: solid 1px #dcdad5;
-        border-top: 1px solid #999999;
-        border-bottom: 2px solid #dcdad5;
+        border: solid 1px color(tone-sandy-light);
+        border-top: 1px solid color(brightness-60);
+        border-bottom: 2px solid color(tone-sandy-light);
 
         @include mq($from: col4) {
             margin: base-px(1, 0);

--- a/ArticleTemplates/assets/scss/modules/_comments.scss
+++ b/ArticleTemplates/assets/scss/modules/_comments.scss
@@ -62,9 +62,10 @@
     margin: 0;
     padding: base-px(0, 0, 2, 0);
     overflow: hidden;
+    background: color(brightness-96);
 
     &--module {
-        border-top: 2px solid color(brightness-20);
+        border-top: 1px solid color(brightness-46);
     }
 
     &__wrapper {
@@ -85,10 +86,10 @@
     &__header {
         position: relative;
         margin: base-px(1);
-        min-height: 44px;
 
         @include mq($from: col2) {
             margin: base-px(1, 1, 1.5, 1);
+            min-height: 44px;
         }
 
         .android & {
@@ -142,9 +143,7 @@
         }
 
         @include mq($from: col4) {
-            font-size: 2.3rem;
-            line-height: 2.3rem;
-            margin-bottom: 15px;
+            margin-bottom: 6px;
         }
     }
 
@@ -152,6 +151,8 @@
     &__link:active,
     .comments__link {
         color: color(brightness-7);
+        font-size: 2.0rem;
+        line-height: 2.3rem;
     }
 
     &__count {
@@ -253,6 +254,10 @@
 
         // If comment count is 0 then show the --empty block
         &--empty {
+            @include mq($from: col2, $to: col4) {
+                margin-left: 12px;
+            }
+
             .comments-0:not(.comments--closed) & {
                 display: block;
             }
@@ -272,6 +277,9 @@
 
     .block {
         margin: base-px(1);
+        border: solid 1px #dcdad5;
+        border-top: 1px solid #999999;
+        border-bottom: 2px solid #dcdad5;
 
         @include mq($from: col4) {
             margin: base-px(1, 0);

--- a/ArticleTemplates/assets/scss/modules/_container.scss
+++ b/ArticleTemplates/assets/scss/modules/_container.scss
@@ -39,7 +39,7 @@
 
 .container {
     margin: base-px(0, 0, 2, 0);
-    border-top: 2px solid color(brightness-20);
+    border-top: 1px solid color(brightness-46);
 }
 
 .container__header,
@@ -198,6 +198,9 @@
 .container__outbrain {
     overflow: hidden;
     display: none;
+    background-color: color(brightness-96);
+    margin: 0;
+    padding-bottom: 17px;
 }
 
 /* Android Tweaks - Displays Leave a comment icon by default */

--- a/ArticleTemplates/assets/scss/modules/_related-content.scss
+++ b/ArticleTemplates/assets/scss/modules/_related-content.scss
@@ -1,4 +1,5 @@
 .related-content {
+    background-color: color(brightness-96);
     @include mq($from: col4) {
         margin: 0 auto;
         padding: {

--- a/ArticleTemplates/assets/scss/modules/_tags.scss
+++ b/ArticleTemplates/assets/scss/modules/_tags.scss
@@ -56,6 +56,10 @@
     display: block;
     padding: base-px(.4, 1, 1.7, .7);
 
+    @include mq($from: col2) {
+        padding: base-px(0, 1, 1.7, 0);
+    }
+
     @include mq($from: col4) {
         margin-left: 232px; // 240 - 4 (item padding offset) - 4 (visually offset rounded items);
         width: 940px;

--- a/ArticleTemplates/assets/scss/outbrain.scss
+++ b/ArticleTemplates/assets/scss/outbrain.scss
@@ -47,7 +47,7 @@
     @for $i from 15 through 35 {
         .AR_#{$i}.ob-strip-layout {
             .ob-widget-header, .ob-widget-header div {
-                color: #121212;
+                color: color(brightness-7);
                 font-family: "Guardian Headline","Guardian Egyptian Web",Georgia,serif;
                 font-weight: 600;
                 font-size: 2.0rem;
@@ -95,7 +95,7 @@
 
             .ob-widget-header {
                 margin: 12px 0 !important;
-                color: #121212;
+                color: color(brightness-7);
                 font-family: "Guardian Headline","Guardian Egyptian Web",Georgia,serif;
                 font-weight: 600;
                 @include mq($to: col4) {

--- a/ArticleTemplates/assets/scss/outbrain.scss
+++ b/ArticleTemplates/assets/scss/outbrain.scss
@@ -44,7 +44,7 @@
         }
     }
 
-    @for $i from 10 through 35 {
+    @for $i from 15 through 35 {
         .AR_#{$i}.ob-strip-layout {
             .ob-widget-header, .ob-widget-header div {
                 color: #121212;
@@ -53,9 +53,10 @@
                 font-size: 2.0rem;
                 line-height: 2.3rem;
                 padding-bottom: 0;
-
-                &::first-letter {
-                    text-transform: capitalize;
+                @include mq($to: col4) {
+                    &::first-letter {
+                        text-transform: capitalize;
+                    }
                 }
             }
         }
@@ -97,9 +98,10 @@
                 color: #121212;
                 font-family: "Guardian Headline","Guardian Egyptian Web",Georgia,serif;
                 font-weight: 600;
-
-                &::first-letter {
-                    text-transform: capitalize;
+                @include mq($to: col4) {
+                    &::first-letter {
+                        text-transform: capitalize;
+                    }
                 }
 
                 span {

--- a/ArticleTemplates/assets/scss/outbrain.scss
+++ b/ArticleTemplates/assets/scss/outbrain.scss
@@ -48,7 +48,7 @@
         .AR_#{$i}.ob-strip-layout {
             .ob-widget-header, .ob-widget-header div {
                 color: color(brightness-7);
-                font-family: "Guardian Headline","Guardian Egyptian Web",Georgia,serif;
+                font-family: "Guardian Sans","Guardian Egyptian Web",Georgia,serif;
                 font-weight: 600;
                 font-size: 2.0rem;
                 line-height: 2.3rem;
@@ -80,6 +80,7 @@
                 margin: 12px 0;
                 span {
                     font-size: 14px;
+                    font-family: "Guardian Agate Sans 1 Web", "Guardian Egyptian Web", Georgia, serif;
                 }
             }
         }
@@ -96,7 +97,7 @@
             .ob-widget-header {
                 margin: 12px 0 !important;
                 color: color(brightness-7);
-                font-family: "Guardian Headline","Guardian Egyptian Web",Georgia,serif;
+                font-family: "Guardian Sans", "Guardian Egyptian Web", Georgia, serif;
                 font-weight: 600;
                 @include mq($to: col4) {
                     &::first-letter {
@@ -106,6 +107,7 @@
 
                 span {
                     margin-left: 12px !important;
+                    font-family: "Guardian Agate Sans 1 Web", "Guardian Egyptian Web", Georgia, serif;
                 }
             }
 

--- a/ArticleTemplates/assets/scss/outbrain.scss
+++ b/ArticleTemplates/assets/scss/outbrain.scss
@@ -8,11 +8,14 @@
 // This whole stylesheet is horrible, but needs to be imported last and have importants to overide the outbrain css
 
 // Avoid hover state within apps
-
-.AR_30.ob-widget, .AR_31.ob-widget {
-    .ob-dynamic-rec-link:hover .ob-unit.ob-rec-text {
+@for $i from 15 through 35 {
+    .AR_#{$i}.ob-widget .ob-dynamic-rec-link:hover .ob-unit.ob-rec-text {
         color: #005689;
         text-decoration: none;
+    }
+
+    .AR_#{$i}.ob-widget:hover .ob_logo {
+        background-position: unset;
     }
 }
 
@@ -26,11 +29,35 @@
 
 
 .OUTBRAIN {
+    .ob-unit.ob-rec-text {
+        @include mq($from: col2) {
+            font-size: 1.3rem !important;
+            line-height: 1.6rem !important;
+        }
+    }
+
     .ob-dynamic-rec-link {
         .ob-rec-source {
             white-space: nowrap;
             text-overflow: ellipsis;
             overflow: hidden;
+        }
+    }
+
+    @for $i from 10 through 35 {
+        .AR_#{$i}.ob-strip-layout {
+            .ob-widget-header, .ob-widget-header div {
+                color: #121212;
+                font-family: "Guardian Headline","Guardian Egyptian Web",Georgia,serif;
+                font-weight: 600;
+                font-size: 2.0rem;
+                line-height: 2.3rem;
+                padding-bottom: 0;
+
+                &::first-letter {
+                    text-transform: capitalize;
+                }
+            }
         }
     }
 
@@ -67,6 +94,13 @@
 
             .ob-widget-header {
                 margin: 12px 0 !important;
+                color: #121212;
+                font-family: "Guardian Headline","Guardian Egyptian Web",Georgia,serif;
+                font-weight: 600;
+
+                &::first-letter {
+                    text-transform: capitalize;
+                }
 
                 span {
                     margin-left: 12px !important;
@@ -138,12 +172,12 @@
 
             .ob-dynamic-rec-container {
                 margin-right: 16px !important;
-                max-width: 210px !important;
-                width: 210px !important;
+                max-width: 230px !important;
+                width: 230px !important;
             }
         }
 
-        .AR_31.ob-strip-layout .ob-rec-text {
+        .AR_31.ob-strip-layout .ob-rec-text, .AR_20.ob-strip-layout .ob-rec-text {
             margin-top: -25px !important;
             padding: 6px .3125rem .5em !important;
         }
@@ -153,11 +187,12 @@
         margin: 0 auto !important;
         max-width: 1200px !important;
 
-        .ob-widget.AR_30 {
+        .ob-widget.AR_30, .ob-widget.AR_18 {
             .ob-widget-items-container {
-                margin-top: -135px !important;
+                margin-top: -106px !important;
             }
         }
+
         .ob-widget {
             .ob-widget-items-container {
                 margin-left: 240px !important;


### PR DESCRIPTION
- Update background of related content + outbrain to match native iOS colour
- Update related content + outbrain borders to match fronts
- Use the same font and size for both titles
- Remove more hover states in outbrain container
- Fix alignment of guardian labs outbrain on iPad pro


| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/48707266-c4245e00-ebf6-11e8-8a41-241c1fc74e42.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/48707280-d1d9e380-ebf6-11e8-80b0-886f35ac46fc.png" width="300px" /> |
| <img src="https://user-images.githubusercontent.com/11618797/48707302-eb7b2b00-ebf6-11e8-8c72-94bebae56e8d.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/11618797/48707313-f7ff8380-ebf6-11e8-827b-d3fb6cb9d884.png" width="300px" /> |