### PR TITLE
Correctly display rich links above tweets and embeds

### DIFF
--- a/ArticleTemplates/assets/js/modules/rich-links.js
+++ b/ArticleTemplates/assets/js/modules/rich-links.js
@@ -11,9 +11,15 @@ define(function() {
         for (var i = 0; i < richLinks.length; i++) {
             var currentLink = richLinks[i];
             var sibling = currentLink.nextElementSibling;
-            if (sibling && hasClass(sibling, 'element-atom')) {
-                currentLink.style.width = "100%";
-                sibling.style.clear = "both";
+            if (sibling) {
+                if (
+                    hasClass(sibling, 'element-atom') ||
+                    hasClass(sibling, 'element-embed') ||
+                    hasClass(sibling, 'element-tweet')
+                ) {
+                    currentLink.style.width = '100%';
+                    sibling.style.clear = 'both';
+                }
             }
         }
     }


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/48765167-859bab80-eca9-11e8-96e2-ecc44fb662af.png" width="300px"/> | <img src="https://user-images.githubusercontent.com/11618797/48765197-91876d80-eca9-11e8-8c16-f3b4158b1988.png" width="300px"/> |