### PR TITLE
Allow single taps on twitter embeds

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/common.js
+++ b/ArticleTemplates/assets/js/bootstraps/common.js
@@ -26,7 +26,10 @@ define([
     var trackCommentContainerView = true;
         
     function init() {
-        fastClick.attach(document.body); // polyfill to remove click delays on browsers with touch
+        if (GU.opts.platform === 'android') {
+            // polyfill to remove click delays on browsers with touch
+            fastClick.attach(document.body);
+        }
         formatImages();
         figcaptionToggle();
         articleContentType();


### PR DESCRIPTION
Seems like the 300ms tap delay was removed in iOS 9.3 (we support iOS 10+ now). https://developers.google.com/web/updates/2013/12/300ms-tap-delay-gone-away

For some reason, fastClick is causing a bug in liveblogs where you need to tap twice on twitter embeds for it to be recognised.

We could probably remove fastClick altogether now...