### PR TITLE
Add loading state once audio requested

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/audio.js
+++ b/ArticleTemplates/assets/js/bootstraps/audio.js
@@ -78,6 +78,9 @@ define([
         }
 
         slider1.setValue(current);
+        if (current > 0) {
+            audioPlaying();
+        }
     }
 
     function audioSlider() {
@@ -115,9 +118,22 @@ define([
 
     function audioPlay() {
         var button = document.getElementsByClassName('audio-player__button')[0];
+        var loading = document.getElementsByClassName('audio-player__button--loading')[0];
 
-        if (button) {
+        if (button && loading) {
+            loading.style.display = "block";
+            button.style.display = "none";
+        }
+    }
+
+    function audioPlaying() {
+        var button = document.getElementsByClassName('audio-player__button')[0];
+        var loading = document.getElementsByClassName('audio-player__button--loading')[0];
+
+        if (button && loading) {
             button.classList.add('pause');
+            loading.style.display = "none";
+            button.style.display = "block";
         }
     }
 

--- a/ArticleTemplates/assets/js/bootstraps/audio.js
+++ b/ArticleTemplates/assets/js/bootstraps/audio.js
@@ -15,7 +15,7 @@ define([
 
     function getColor() {
         var isAudio = !document.body.classList.contains('tone--podcast') && document.body.classList.contains('article--audio');
-        
+
         return GU.opts.isAdvertising ? 'rgba(105, 209, 202, 0.15)' : (isAudio ? 'rgba(255, 187, 0, 0.05)' : 'rgba(167, 216, 242, 0.10)');
     }
 
@@ -57,7 +57,7 @@ define([
 
     function changeSlider(duration, percentage) {
         var audioPlayerSliderPlayed = document.getElementsByClassName('audio-player__slider__played')[0],
-            audioPlayerSliderRemaining = document.getElementsByClassName('audio-player__slider__remaining')[0];            
+            audioPlayerSliderRemaining = document.getElementsByClassName('audio-player__slider__remaining')[0];
 
         audioCurrent = percentage;
 
@@ -121,24 +121,21 @@ define([
     }
 
     function audioPlay() {
-        var button = document.getElementsByClassName('audio-player__button')[0];
-        var loading = document.getElementsByClassName('audio-player__button--loading')[0];
+        var audioPlayer = document.getElementsByClassName('audio-player')[0];
 
-        if (button && loading) {
-            loading.style.display = "block";
-            button.style.display = "none";
+        if (audioPlayer) {
+            audioPlayer.classList.add('loading');
         }
     }
 
     function audioPlaying() {
         var button = document.getElementsByClassName('audio-player__button')[0];
-        var loading = document.getElementsByClassName('audio-player__button--loading')[0];
+        var audioPlayer = document.getElementsByClassName('audio-player')[0];
         var screenReadable = document.getElementsByClassName('audio-player-readable')[0];
 
-        if (button && loading && screenReadable) {
+        if (button && audioPlayer && screenReadable) {
             button.classList.add('pause');
-            loading.style.display = "none";
-            button.style.display = "block";
+            audioPlayer.classList.remove('loading');
             screenReadable.innerHTML = "Pause";
         }
     }
@@ -154,19 +151,13 @@ define([
     }
 
     function audioLoad() {
-        var button = document.getElementsByClassName('audio-player__button')[0],
-            loadingButton = document.getElementsByClassName('audio-player__button--loading')[0];
-
-        button.style.display = 'none';
-        loadingButton.style.display = 'block';
+        var audioPlayer = document.getElementsByClassName('audio-player')[0];
+        audioPlayer.classList.add('loading');
     }
 
     function audioFinishLoad() {
-        var button = document.getElementsByClassName('audio-player__button')[0],
-            loadingButton = document.getElementsByClassName('audio-player__button--loading')[0];
-
-        button.style.display = 'block';
-        loadingButton.style.display = 'none';
+        var audioPlayer = document.getElementsByClassName('audio-player')[0];
+        audioPlayer.classList.remove('loading');
     }
 
     function audioBackground(duration) {

--- a/ArticleTemplates/assets/js/bootstraps/audio.js
+++ b/ArticleTemplates/assets/js/bootstraps/audio.js
@@ -79,12 +79,12 @@ define([
         }
 
         slider1.setValue(current);
-        if (current > previous) {
+        if (current - previous === 1) {
             audioPlaying();
-            previous = current;
         } else if (current === previous) {
             audioStop();
         }
+        previous = current;
     }
 
     function audioSlider() {

--- a/ArticleTemplates/assets/scss/modules/media/_audio-player.scss
+++ b/ArticleTemplates/assets/scss/modules/media/_audio-player.scss
@@ -86,15 +86,11 @@
     position: absolute;
     top: base-px(1);
     left: base-px(1);
-    width: 44px;
-    height: 44px;
-    background-color: rgba(255, 255, 255, 1);
-    border-top-right-radius: 30px;
-    border-top-left-radius: 30px;
-    border-bottom-left-radius: 29px;
-    border-bottom-right-radius: 29px;
-    border: 2px solid color(brightness-100);
-    display: none;
+
+    .loading::before {
+        color: #ffe500;
+        margin: 6px 0 0 -3px;
+    }
 }
 
 .audio-player__slider {

--- a/ArticleTemplates/assets/scss/modules/media/_audio-player.scss
+++ b/ArticleTemplates/assets/scss/modules/media/_audio-player.scss
@@ -86,10 +86,41 @@
     position: absolute;
     top: base-px(1);
     left: base-px(1);
-
-    .loading::before {
-        color: #ffe500;
-        margin: 6px 0 0 -3px;
+    width: 48px;
+    height: 48px;
+    .pulse {
+        transform: scale(.5);
+        &,
+        &:before,
+        &:after {
+            content: '';
+            display: block;
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border-radius: 100%;
+            background-color: color(tone-highlight);
+            transition: transform 500ms linear;
+        }
+        &:before,
+        &:after {
+            animation: pulseOut 2s ease-out infinite;
+        }
+        &:before {
+            animation-delay: 1s;
+        }
+    }
+    @keyframes pulseOut {
+        0% {
+            transform: scale(0);
+            opacity: 1;
+        }
+        100% {
+            transform: scale(2.6);
+            opacity: 0;
+        }
     }
 }
 

--- a/ArticleTemplates/assets/scss/modules/media/_audio-player.scss
+++ b/ArticleTemplates/assets/scss/modules/media/_audio-player.scss
@@ -58,6 +58,15 @@
     top: base-px(1);
     left: base-px(1);
 
+    transform: scale(1);
+    transition: all 300ms;
+    z-index: 10;
+    .loading & {
+        transform: scale(0.5);
+        transition: all 1ms;
+        z-index: -1;
+    }
+
     &.touchpoint--primary .touchpoint__button {
         color: color(brightness-7);
         background-color: color(tone-media);
@@ -86,30 +95,37 @@
     position: absolute;
     top: base-px(1);
     left: base-px(1);
-    width: 48px;
-    height: 48px;
+    width: 44px;
+    height: 44px;
+    visibility: hidden;
     .pulse {
-        transform: scale(.5);
-        &,
-        &:before,
-        &:after {
-            content: '';
-            display: block;
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            border-radius: 100%;
-            background-color: color(tone-highlight);
-            transition: transform 500ms linear;
-        }
-        &:before,
-        &:after {
-            animation: pulseOut 2s ease-out infinite;
-        }
-        &:before {
-            animation-delay: 1s;
+        transform: scale(1);
+        transition: transform 300ms ease-in-out;
+        .loading & {
+            visibility: visible;
+            transform: scale(0.5);
+            &:before,
+            &:after,
+            & {
+                content: '';
+                display: block;
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                border-radius: 100%;
+                background-color: color(tone-highlight);
+            }
+            &:before,
+            &:after {
+                opacity: 0;
+                transform: scale(0);
+                animation: pulseOut 2s ease-out infinite;
+            }
+            &:after {
+                animation-delay: 1s;
+            }
         }
     }
     @keyframes pulseOut {

--- a/ArticleTemplates/assets/scss/modules/media/_audio-player.scss
+++ b/ArticleTemplates/assets/scss/modules/media/_audio-player.scss
@@ -36,6 +36,17 @@
     z-index: 2;
 }
 
+@keyframes pulseOut {
+    0% {
+        transform: scale(0);
+        opacity: 1;
+    }
+    100% {
+        transform: scale(2.6);
+        opacity: 0;
+    }
+}
+
 @include mq($from: col4) {
     .audio-player__container {
         background-color: darken(color(brightness-20), 5%);
@@ -101,41 +112,34 @@
     .pulse {
         transform: scale(1);
         transition: transform 300ms ease-in-out;
+        &:before,
+        &:after,
+        & {
+            content: '';
+            display: block;
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border-radius: 100%;
+            background-color: color(tone-highlight);
+        }
+        &:before,
+        &:after {
+            opacity: 0;
+            transform: scale(0);
+        }
         .loading & {
             visibility: visible;
             transform: scale(0.5);
             &:before,
-            &:after,
-            & {
-                content: '';
-                display: block;
-                position: absolute;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
-                border-radius: 100%;
-                background-color: color(tone-highlight);
-            }
-            &:before,
             &:after {
-                opacity: 0;
-                transform: scale(0);
                 animation: pulseOut 2s ease-out infinite;
             }
             &:after {
                 animation-delay: 1s;
             }
-        }
-    }
-    @keyframes pulseOut {
-        0% {
-            transform: scale(0);
-            opacity: 1;
-        }
-        100% {
-            transform: scale(2.6);
-            opacity: 0;
         }
     }
 }

--- a/ArticleTemplates/audioTemplate.html
+++ b/ArticleTemplates/audioTemplate.html
@@ -37,10 +37,13 @@
                 <div class="audio-player__container">
                     <div class="audio-player__wrapper">
                         <div class="audio-player">
+                            <div class="audio-player__button--loading ">
+                                <div class="loading" data-icon="&#xe00C;"></div>
+                            </div>
                             <a class="audio-player__button touchpoint touchpoint--primary" id="audio-play-button" href="x-gu://playaudio/__AUDIO_URI__">
-                            <span class="touchpoint__button play" data-icon="&#xe04b;" aria-hidden="true"></span>
-                            <span class="touchpoint__button pause" data-icon="&#xe04D;" aria-hidden="true"></span>
-                            <span class="touchpoint__label screen-readable">Play</span>
+                                <span class="touchpoint__button play" data-icon="&#xe04b;" aria-hidden="true"></span>
+                                <span class="touchpoint__button pause" data-icon="&#xe04D;" aria-hidden="true"></span>
+                                <span class="touchpoint__label screen-readable">Play</span>
                             </a>
                             <div class="audio-player__slider">
                                 <input type="text" class="audio-player__slider__played" id="audio-scrubber" disabled/>

--- a/ArticleTemplates/audioTemplate.html
+++ b/ArticleTemplates/audioTemplate.html
@@ -38,7 +38,7 @@
                     <div class="audio-player__wrapper">
                         <div class="audio-player">
                             <div class="audio-player__button--loading ">
-                                <div class="loading" data-icon="&#xe00C;"></div>
+                                <div class='pulse touchpoint__button'></div>
                             </div>
                             <a class="audio-player__button touchpoint touchpoint--primary" id="audio-play-button" href="x-gu://playaudio/__AUDIO_URI__">
                                 <span class="touchpoint__button play" data-icon="&#xe04b;" aria-hidden="true"></span>

--- a/test/fixtures/audio-news-loading.html
+++ b/test/fixtures/audio-news-loading.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+    <title>Article</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
+    <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="../../ArticleTemplates/assets/css/fonts-ios.css" />
+    <link rel="stylesheet" type="text/css" media="all" href="../../ArticleTemplates/assets/css/style-sync.css" />
+    <style>/* <-- */
+        /* --> */
+    </style>
+    <script type="text/javascript">
+        window.GU = window.GU || {};
+    </script>
+    <script type="text/javascript" src="../../ArticleTemplates/assets/build/polyfills/promise.js"></script>
+    <script type="text/javascript" src="../../ArticleTemplates/assets/build/polyfills/requestAnimationFrame.js"></script>
+    <script type="text/javascript" src="../../ArticleTemplates/assets/build/bootstrap.js"></script>
+</head>
+    <body class="garnett--type-media garnett--pillar-news tone--podcast font-size-4  ios  advert-config--mobile  " data-content-type="audio" data-ads-enabled="" data-ads-enable-hiding="true" data-ads-config="mobile" style="margin-top: 0px;" data-font-size="4"  data-template-directory="../../ArticleTemplates/"  data-page-id="news/audio/2018/dec/11/labours-brexit-dilemma" data-mpu-after-paragraphs="3" data-use-ads-ready="true">
+        <div class="article article--audio">
+            <div class="article__header cutout">
+                <div class="cutout__container" >
+                    <div class="section section__container hide-garnett" id="section">
+                        <div class="content__container">
+                            <div class="content__labels__container">
+                                <div class="content__labels">Labour</div>
+                                <div class="content__series-label content__labels"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/news/series/todayinfocus">Today in Focus</a></div>
+                            </div>
+
+                        </div>
+                    </div>
+                    <div class="article-kicker">
+                        <div class='article-kicker__section'>Labour</div>
+                        <div class='article-kicker__series'>
+                            <span class='article-kicker__highlight'><a href="x-gu://list/mobile.guardianapis.com/lists/tag/news/series/todayinfocus">Today in Focus</a></span>
+                        </div>
+                    </div>
+                    <h1 class="headline selectable card__title--audio"><span class="card__titletext" id="headline">Labour's Brexit dilemma</span></h1>
+                </div>
+                <div class="audio-player__container">
+                    <div class="audio-player__wrapper">
+                        <div class="audio-player">
+                            <div class="audio-player__button--loading " style='display: block;'>
+                                <div class='pulse touchpoint__button'></div>
+                            </div>
+                            <a role="button" aria-role="button" class="audio-player__button touchpoint touchpoint--primary" id="audio-play-button" href="x-gu://playaudio/audio.guim.co.uk/2018/12/10-82526-20181210TIF_labour01.mp3" style='display: none;'>
+                                <span class="touchpoint__button play" data-icon="&#xe04b;" aria-hidden="true"></span>
+                                <span class="touchpoint__button pause" data-icon="&#xe04D;" aria-hidden="true"></span>
+                                <span class="touchpoint__label screen-readable audio-player-readable">Play</span>
+                            </a>
+                            <div class="audio-player__slider">
+                                <input type="text" class="audio-player__slider__played" id="audio-scrubber" disabled/>
+                                <input type="text" class="audio-player__slider__remaining" id="audio-scrubber-left" disabled/>
+                                <div class="audio-player__slider__track"></div>
+                                <div class="audio-player__slider__knob" role="slider" id="audio-slider-knob"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="meta keyline-4">
+                    <div class="meta__misc">
+                        <div class="meta__published__comments"></div>
+                        <div class="meta__byline">
+                            <span class="byline">Presented by <span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/anushkaasthana">Anushka Asthana</a></span> with <span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/jonathanfreedland">Jonathan Freedland</a></span>   produced by <span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/joshua-kelly">Joshua Kelly</a></span> and<span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/rachel-humphreys">Rachel Humphreys</a></span>; executive producers <span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/philmaynard">Phil Maynard</a></span> and <span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/nicolejackson">Nicole Jackson</a></span></span>
+                        </div>
+                        <p class="meta__pubdate hide-garnett"><span class="screen-readable">Published: </span><span id="published-date">03:00 GMT Tuesday, 11 December 2018</span></p>
+                        <div class='meta__published'>
+                            <div class="meta__published__date"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">03:00 GMT Tuesday, 11 December 2018</span></div>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+            <div class="standfirst selectable">
+                <div class="standfirst__inner" id="standfirst">
+                    <p>Theresa May has postponed her crucial Brexit vote amid huge divisions in her party. But there is a dilemma, too, for Labour MPs whose constituencies voted overwhelmingly in favour of leaving the EU. How do they square their voters’ wishes with that of their party and their own conscience? Plus: Jonathan Freedland on why Labour should be backing a second referendum</p>
+                </div>
+            </div>
+            <div class="article__body">
+                <div class="from-content-api prose resizable resizable-line-height selectable" id="audio-body-blocks">
+                    <p>Theresa May has finally admitted <a href="x-gu://item/mobile.guardianapis.com/us/items/politics/2018/dec/10/theresa-may-postpones-brexit-deal-meaningful-vote-eu">parliament will not back her Brexit deal,</a> but the prime minister is not ready to give up. In a desperate plea to MPs, she asked: “Does this house still want to deliver Brexit?”</p>
+<p>These appeals were aimed not just at the Tory MPs behind her but at Labour MPs opposite – and especially those whose constituencies voted heavily to leave the EU. One is <strong>Gloria De Piero,</strong> who holds a slim majority in the Nottinghamshire seat of Ashfield. The Guardian’s political editor <strong>Heather Stewart </strong>joined Gloria for a <a href="x-gu://item/mobile.guardianapis.com/us/items/politics/2018/dec/09/deeply-divided-brexit-ashfield-residents-voice-their-differences">tour of her constituency</a> and found voters mostly fed up with discussing Brexit and wishing that the situation would be resolved quickly.</p>
+<p>Plus, the Guardian’s<strong> Jonathan Freedland </strong>argues that although it would be highly divisive for the country, the least worst option left on Brexit is a second referendum – and that Labour should now get behind it. </p>
+                </div>
+            </div>
+            <div class="tags" id="tags">
+                <span class="screen-readable">Tags:</span>
+                <ul class="inline-list tags__inline-list" id="tag-list"></ul>
+            </div>
+        </div>
+        <div class="related-content"></div>
+
+        <script type="text/javascript">
+            (function () {
+                var atoms = {};
+                function readAtoms() {
+
+                }
+                readAtoms.call(atoms);
+                GU.bootstrap.init({
+                    asyncStylesFilename: "style-async",
+                    sectionTone: "news",
+                    isAdvertising: "" ? true : false,
+                    fontSize: "font-size-4",
+                    platform: "ios",
+                    isOffline: "" ? true : false,
+                    contentType: "article",
+                    adsEnabled: "mpu",
+                    adsEnableHiding: "true" === "true",
+                    adsConfig: "mobile",
+                    actionBarHeight: "0",
+                    fontSizeInt: "4",
+                    templatesDirectory: "../../ArticleTemplates/",
+                    pageId: "cities/2017/dec/02/its-not-just-extra-rich-and-extra-poor-paulistanos-respond-to-sao-paulo-live",
+                    mpuAfterParagraphs: "3",
+                    useAdsReady: "true" === "true",
+                    section: "cities",
+                    tests: '{}',
+                    nativeYoutubeEnabled: "" === "true" ? true : false,
+                    disableEnhancedTweets: "" === "true" ? true : false,
+                    atoms: atoms,
+                    hasEpic: "true" === "true"
+                });
+            }());
+        </script>
+    </body>
+</html>

--- a/test/fixtures/audio-news-loading.html
+++ b/test/fixtures/audio-news-loading.html
@@ -39,11 +39,11 @@
                 </div>
                 <div class="audio-player__container">
                     <div class="audio-player__wrapper">
-                        <div class="audio-player">
-                            <div class="audio-player__button--loading " style='display: block;'>
+                        <div class="audio-player" onclick="this.classList.toggle('loading')">
+                            <div class="audio-player__button--loading">
                                 <div class='pulse touchpoint__button'></div>
                             </div>
-                            <a role="button" aria-role="button" class="audio-player__button touchpoint touchpoint--primary" id="audio-play-button" href="x-gu://playaudio/audio.guim.co.uk/2018/12/10-82526-20181210TIF_labour01.mp3" style='display: none;'>
+                            <a role="button" aria-role="button" class="audio-player__button touchpoint touchpoint--primary" id="audio-play-button" href="x-gu://playaudio/audio.guim.co.uk/2018/12/10-82526-20181210TIF_labour01.mp3">
                                 <span class="touchpoint__button play" data-icon="&#xe04b;" aria-hidden="true"></span>
                                 <span class="touchpoint__button pause" data-icon="&#xe04D;" aria-hidden="true"></span>
                                 <span class="touchpoint__label screen-readable audio-player-readable">Play</span>

--- a/test/fixtures/audio-news.html
+++ b/test/fixtures/audio-news.html
@@ -1,42 +1,46 @@
 <!DOCTYPE html>
 <html lang="en-US">
-    <head>
-        <title>Audio</title>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
-        <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="../../ArticleTemplates/assets/css/fonts-ios.css" />
-        <link rel="stylesheet" type="text/css" media="all" href="../../ArticleTemplates/assets/css/style-sync.css" />
-        <script type="text/javascript">
-            window.GU = window.GU || {};
-        </script>
-        <script type="text/javascript" src="../../ArticleTemplates/assets/build/polyfills/promise.js"></script>
-        <script type="text/javascript" src="../../ArticleTemplates/assets/build/polyfills/requestAnimationFrame.js"></script>
-        <script type="text/javascript" src="../../ArticleTemplates/assets/build/bootstrap.js"></script>
-    </head>
-    <body class="garnett--pillar-news garnett--type-media tone--podcast font-size-4 ios  advert-config--mobile  " data-content-type="audio" data-ads-enabled="mpu" data-ads-enable-hiding="true" data-ads-config="mobile" style="margin-top: 0px;" data-font-size="4"  data-template-directory="../../ArticleTemplates/"  data-page-id="news/audio/2017/oct/27/why-cant-we-cure-the-common-cold-podcast" data-mpu-after-paragraphs="3" data-use-ads-ready="true">
+<head>
+    <title>Article</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
+    <link rel="stylesheet" type="text/css" media="all" id="fontStyles" href="../../ArticleTemplates/assets/css/fonts-ios.css" />
+    <link rel="stylesheet" type="text/css" media="all" href="../../ArticleTemplates/assets/css/style-sync.css" />
+    <style>/* <-- */
+        /* --> */
+    </style>
+    <script type="text/javascript">
+        window.GU = window.GU || {};
+    </script>
+    <script type="text/javascript" src="../../ArticleTemplates/assets/build/polyfills/promise.js"></script>
+    <script type="text/javascript" src="../../ArticleTemplates/assets/build/polyfills/requestAnimationFrame.js"></script>
+    <script type="text/javascript" src="../../ArticleTemplates/assets/build/bootstrap.js"></script>
+</head>
+    <body class="garnett--type-media garnett--pillar-news tone--podcast font-size-4  ios  advert-config--mobile  " data-content-type="audio" data-ads-enabled="" data-ads-enable-hiding="true" data-ads-config="mobile" style="margin-top: 0px;" data-font-size="4"  data-template-directory="../../ArticleTemplates/"  data-page-id="news/audio/2018/dec/11/labours-brexit-dilemma" data-mpu-after-paragraphs="3" data-use-ads-ready="true">
         <div class="article article--audio">
             <div class="article__header cutout">
                 <div class="cutout__container" >
                     <div class="section section__container hide-garnett" id="section">
                         <div class="content__container">
                             <div class="content__labels__container">
-                                <div class="content__labels">News</div>
-                                <div class="content__series-label content__labels"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/news/series/the-audio-long-read">The Guardian's Audio Long Reads</a></div>
+                                <div class="content__labels">Labour</div>
+                                <div class="content__series-label content__labels"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/news/series/todayinfocus">Today in Focus</a></div>
                             </div>
+
                         </div>
                     </div>
                     <div class="article-kicker">
-                        <div class='article-kicker__section'>News</div>
+                        <div class='article-kicker__section'>Labour</div>
                         <div class='article-kicker__series'>
-                            <span class='article-kicker__highlight'><a href="x-gu://list/mobile.guardianapis.com/lists/tag/news/series/the-audio-long-read">The Guardian's Audio Long Reads</a></span>
+                            <span class='article-kicker__highlight'><a href="x-gu://list/mobile.guardianapis.com/lists/tag/news/series/todayinfocus">Today in Focus</a></span>
                         </div>
                     </div>
-                    <h1 class="headline selectable card__title--audio"><span class="card__titletext" id="headline">Why can’t we cure the common cold? – podcast</span></h1>
+                    <h1 class="headline selectable card__title--audio"><span class="card__titletext" id="headline">Labour's Brexit dilemma</span></h1>
                 </div>
                 <div class="audio-player__container">
                     <div class="audio-player__wrapper">
                         <div class="audio-player">
-                            <a class="audio-player__button touchpoint touchpoint--primary" id="audio-play-button" href="x-gu://playaudio/audio.guim.co.uk/2017/10/26-54191-gdn.lr.171026.sb.common-cold-scientists-breakthrough-in-sight.mp3">
+                            <a class="audio-player__button touchpoint touchpoint--primary" id="audio-play-button" href="x-gu://playaudio/audio.guim.co.uk/2018/12/10-82526-20181210TIF_labour01.mp3">
                             <span class="touchpoint__button play" data-icon="&#xe04b;" aria-hidden="true"></span>
                             <span class="touchpoint__button pause" data-icon="&#xe04D;" aria-hidden="true"></span>
                             <span class="touchpoint__label screen-readable">Play</span>
@@ -52,34 +56,28 @@
                 </div>
                 <div class="meta keyline-4">
                     <div class="meta__misc">
-                        <div class="meta__published__comments">
-                            <div class="comment-count">
-                                <a href="x-gu://showcomments">
-                                <span data-icon="&#xe03c;" aria-hidden="true"></span><span id="comment-count">1 </span>
-                                <span class="screen-readable">Comments</span>
-                                </a>
-                            </div>
-                        </div>
+                        <div class="meta__published__comments"></div>
                         <div class="meta__byline">
-                            <span class="byline">Written by <span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/nicola-davison">Nicola Davison</a></span>, read by Lucy Scott and produced by <span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/simon-barnard">Simon Barnard</a></span>, Source: theguardian.com</span>
+                            <span class="byline">Presented by <span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/anushkaasthana">Anushka Asthana</a></span> with <span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/jonathanfreedland">Jonathan Freedland</a></span>   produced by <span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/joshua-kelly">Joshua Kelly</a></span> and<span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/rachel-humphreys">Rachel Humphreys</a></span>; executive producers <span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/philmaynard">Phil Maynard</a></span> and <span class="byline__author"><a href="x-gu://list/mobile.guardianapis.com/lists/tag/profile/nicolejackson">Nicole Jackson</a></span></span>
                         </div>
-                        <p class="meta__pubdate hide-garnett"><span class="screen-readable">Published: </span><span id="published-date">12:00 BST Friday, 27 October 2017</span></p>
+                        <p class="meta__pubdate hide-garnett"><span class="screen-readable">Published: </span><span id="published-date">03:00 GMT Tuesday, 11 December 2018</span></p>
                         <div class='meta__published'>
-                            <div class="meta__published__date"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">12:00 BST Friday, 27 October 2017</span></div>
-                            <div class="meta__published__comments"></div>
+                            <div class="meta__published__date"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">03:00 GMT Tuesday, 11 December 2018</span></div>
                         </div>
                     </div>
+                </div>
+
+            </div>
+            <div class="standfirst selectable">
+                <div class="standfirst__inner" id="standfirst">
+                    <p>Theresa May has postponed her crucial Brexit vote amid huge divisions in her party. But there is a dilemma, too, for Labour MPs whose constituencies voted overwhelmingly in favour of leaving the EU. How do they square their voters’ wishes with that of their party and their own conscience? Plus: Jonathan Freedland on why Labour should be backing a second referendum</p>
                 </div>
             </div>
             <div class="article__body">
-                <div class="standfirst selectable">
-                    <div class="standfirst__inner" id="standfirst">
-                        <p>After thousands of years of failure, some scientists believe a breakthrough might finally be in sight</p>
-                        <p><span class="bullet">•</span> <a href="x-gu://item/mobile.guardianapis.com/uk/items/news/2017/oct/06/why-cant-we-cure-the-common-cold">Read the text version here</a></p>
-                    </div>
-                </div>
-                <div class="from-content-api prose resizable selectable" id="audio-body-blocks">
-                    <p><strong>Subscribe via <a href="https://audioboom.com/channel/guardian-long-reads">Audioboom</a>, <a href="https://itunes.apple.com/gb/podcast/the-guardian-long-read/id587347784?mt=2">Apple Podcasts</a>, <a href="https://soundcloud.com/theguardianlongread">Soundcloud</a>, <a href="https://www.mixcloud.com/GuardianAudiolongreads/">Mixcloud</a>, <a href="https://www.acast.com/longread">Acast</a> &amp; <a href="http://www.stitcher.com/podcast/guardianuk/guardian-audio-edition">Sticher</a> </strong><strong>and join the discussion on <a href="https://www.facebook.com/GuardianPodcasts/">Facebook</a> and <a href="https://twitter.com/guardianaudio">Twitter</a></strong></p>
+                <div class="from-content-api prose resizable resizable-line-height selectable" id="audio-body-blocks">
+                    <p>Theresa May has finally admitted <a href="x-gu://item/mobile.guardianapis.com/us/items/politics/2018/dec/10/theresa-may-postpones-brexit-deal-meaningful-vote-eu">parliament will not back her Brexit deal,</a> but the prime minister is not ready to give up. In a desperate plea to MPs, she asked: “Does this house still want to deliver Brexit?”</p>
+<p>These appeals were aimed not just at the Tory MPs behind her but at Labour MPs opposite – and especially those whose constituencies voted heavily to leave the EU. One is <strong>Gloria De Piero,</strong> who holds a slim majority in the Nottinghamshire seat of Ashfield. The Guardian’s political editor <strong>Heather Stewart </strong>joined Gloria for a <a href="x-gu://item/mobile.guardianapis.com/us/items/politics/2018/dec/09/deeply-divided-brexit-ashfield-residents-voice-their-differences">tour of her constituency</a> and found voters mostly fed up with discussing Brexit and wishing that the situation would be resolved quickly.</p>
+<p>Plus, the Guardian’s<strong> Jonathan Freedland </strong>argues that although it would be highly divisive for the country, the least worst option left on Brexit is a second referendum – and that Labour should now get behind it. </p>
                 </div>
             </div>
             <div class="tags" id="tags">
@@ -87,45 +85,40 @@
                 <ul class="inline-list tags__inline-list" id="tag-list"></ul>
             </div>
         </div>
-        <section class="related-content">
-            <div class="related-content__wrapper">
-                <h2 class="related-content__header">
-                    Related Stories
-                </h2>
-                <div class="loading loading--related" data-icon="&#xe00C;">
+        <div class="related-content"></div>
 
-                </div>
-                <div class="block block--failed" id="related-module-failed-block">
-                    <div class="block__body">
-                        <p>Related stories are currently unavailable. Please try again later.</p>
-                    </div>
-                </div>
-            </div>
-        </section>
         <script type="text/javascript">
-            GU.bootstrap.init({
-                asyncStylesFilename: "style-async",
-                sectionTone: "podcast",
-                fontSize: "font-size-4",
-                platform: "ios",
-                isOffline: "" ? true : false,
-                isAdvertising: "" ? true : false,
-                contentType: "audio",
-                adsEnabled: "mpu",
-                adsEnableHiding: "true" === "true",
-                adsConfig: "mobile",
-                actionBarHeight: "0",
-                fontSizeInt: "4",
-                templatesDirectory: "../../ArticleTemplates/",
-                pageId: "news/audio/2017/oct/27/why-cant-we-cure-the-common-cold-podcast",
-                mpuAfterParagraphs: "3",
-                useAdsReady: "true" === "true",
-                section: "News",
-                tests: '{}',
-                nativeYoutubeEnabled: "" === "true",
-                disableEnhancedTweets: "" === "true",
-                hasEpic: "" === "true"
-            });
+            (function () {
+                var atoms = {};
+                function readAtoms() {
+
+                }
+                readAtoms.call(atoms);
+                GU.bootstrap.init({
+                    asyncStylesFilename: "style-async",
+                    sectionTone: "news",
+                    isAdvertising: "" ? true : false,
+                    fontSize: "font-size-4",
+                    platform: "ios",
+                    isOffline: "" ? true : false,
+                    contentType: "article",
+                    adsEnabled: "mpu",
+                    adsEnableHiding: "true" === "true",
+                    adsConfig: "mobile",
+                    actionBarHeight: "0",
+                    fontSizeInt: "4",
+                    templatesDirectory: "../../ArticleTemplates/",
+                    pageId: "cities/2017/dec/02/its-not-just-extra-rich-and-extra-poor-paulistanos-respond-to-sao-paulo-live",
+                    mpuAfterParagraphs: "3",
+                    useAdsReady: "true" === "true",
+                    section: "cities",
+                    tests: '{}',
+                    nativeYoutubeEnabled: "" === "true" ? true : false,
+                    disableEnhancedTweets: "" === "true" ? true : false,
+                    atoms: atoms,
+                    hasEpic: "true" === "true"
+                });
+            }());
         </script>
     </body>
 </html>

--- a/test/fixtures/audio-news.html
+++ b/test/fixtures/audio-news.html
@@ -40,10 +40,13 @@
                 <div class="audio-player__container">
                     <div class="audio-player__wrapper">
                         <div class="audio-player">
-                            <a class="audio-player__button touchpoint touchpoint--primary" id="audio-play-button" href="x-gu://playaudio/audio.guim.co.uk/2018/12/10-82526-20181210TIF_labour01.mp3">
-                            <span class="touchpoint__button play" data-icon="&#xe04b;" aria-hidden="true"></span>
-                            <span class="touchpoint__button pause" data-icon="&#xe04D;" aria-hidden="true"></span>
-                            <span class="touchpoint__label screen-readable">Play</span>
+                            <div class="audio-player__button--loading ">
+                                <div class="loading" data-icon="&#xe00C;"></div>
+                            </div>
+                            <a role="button" aria-role="button" class="audio-player__button touchpoint touchpoint--primary" id="audio-play-button" href="x-gu://playaudio/audio.guim.co.uk/2018/12/10-82526-20181210TIF_labour01.mp3">
+                                <span class="touchpoint__button play" data-icon="&#xe04b;" aria-hidden="true"></span>
+                                <span class="touchpoint__button pause" data-icon="&#xe04D;" aria-hidden="true"></span>
+                                <span class="touchpoint__label screen-readable audio-player-readable">Play</span>
                             </a>
                             <div class="audio-player__slider">
                                 <input type="text" class="audio-player__slider__played" id="audio-scrubber" disabled/>


### PR DESCRIPTION
Using the existing loading state to show content is loading (this can be quite long, especially on slow 3g/4g connections).

The logic to add a loading state is there so we can update the design to anything else.

Could also animate the play/pause icons to make it less jumpy.

| Current | Suggested |
| --- | --- |
| ![current](https://user-images.githubusercontent.com/11618797/48941892-3ce82a80-ef15-11e8-8480-0eba8f292e6c.gif) | ![after](https://user-images.githubusercontent.com/11618797/48941917-52f5eb00-ef15-11e8-8a99-1c8357146954.gif) |

