### PR TITLE
Fix audioPlay() test

### DIFF
--- a/test/spec/unit/bootstraps/audioTest.js
+++ b/test/spec/unit/bootstraps/audioTest.js
@@ -105,10 +105,13 @@ define([
         describe('window.audioPlay()', function () {
             it('updates touchPointButton', function () {
                 var playerButton = document.createElement('div');
+                var screenReaderLabel = document.createElement('span');
 
                 playerButton.classList.add('audio-player__button');
+                screenReaderLabel.classList.add('audio-player-readable');
 
                 container.appendChild(playerButton);
+                container.appendChild(screenReaderLabel);
 
                 audio.init();
 


### PR DESCRIPTION
@webb04 woops, forgot to run the tests.

The function now depends on finding the `audio-player-readable` span to work.
