### PR TITLE
New inline creative type

### DIFF
--- a/ArticleTemplates/assets/js/modules/creativeInjector.js
+++ b/ArticleTemplates/assets/js/modules/creativeInjector.js
@@ -68,13 +68,36 @@ function (
         creativeContainer.classList.add(type + '-creative-container');
         creativeContainer.innerHTML = html;
 
-        if (type === 'inline-article') {
+        if (type === 'inline' && id === 'in-article-signup-test') {
+            injectInlineCreativeWithoutEpic(creativeContainer);
+        } else if (type === 'inline-article') {
             injectInlineCreative(creativeContainer);
         } else {
             injectEpicCreative(creativeContainer);
         }
 
         addEventListenerScroll(creativeContainer, id);
+    }
+
+    function injectInlineCreativeWithoutEpic(creativeContainer) {
+        var i,
+            prose = document.querySelector('.article__body > div.prose'),
+            paragraphs = prose.querySelectorAll('p:nth-child(n+6)');
+
+        // Don't show creative if less than 10 paragraphs
+        if (document.querySelectorAll('.article__body > div.prose > p').length < 10) {
+            return;
+        }
+
+        // loop through paragraphs from 4th paragraph
+        // insert creativeContainer if paragraph is followed by a p or h1 elem
+        for (i = 0; i < paragraphs.length; i++) {
+            if (paragraphs[i].nextElementSibling &&
+                (paragraphs[i].nextElementSibling.tagName === 'P' || paragraphs[i].nextElementSibling.tagName === 'H1')) {
+                paragraphs[i].nextElementSibling.parentNode.insertBefore(creativeContainer, paragraphs[i].nextElementSibling);
+                break;
+            }
+        }
     }
 
     function injectInlineCreative(creativeContainer) {

--- a/ArticleTemplates/assets/js/modules/creativeInjector.js
+++ b/ArticleTemplates/assets/js/modules/creativeInjector.js
@@ -69,7 +69,7 @@ function (
         creativeContainer.innerHTML = html;
 
         if (type === 'inline' && id === 'in-article-signup-test') {
-            injectInlineCreativeWithoutEpic(creativeContainer);
+            injectInlineCreativeIfLength(creativeContainer, 10);
         } else if (type === 'inline-article') {
             injectInlineCreative(creativeContainer);
         } else {
@@ -79,13 +79,13 @@ function (
         addEventListenerScroll(creativeContainer, id);
     }
 
-    function injectInlineCreativeWithoutEpic(creativeContainer) {
+    function injectInlineCreativeIfLength(creativeContainer, minParagraphs) {
         var i,
             prose = document.querySelector('.article__body > div.prose'),
             paragraphs = prose.querySelectorAll('p:nth-child(n+6)');
 
         // Don't show creative if less than 10 paragraphs
-        if (document.querySelectorAll('.article__body > div.prose > p').length < 10) {
+        if (document.querySelectorAll('.article__body > div.prose > p').length < minParagraphs) {
             return;
         }
 

--- a/ArticleTemplates/assets/js/modules/creativeInjector.js
+++ b/ArticleTemplates/assets/js/modules/creativeInjector.js
@@ -68,7 +68,7 @@ function (
         creativeContainer.classList.add(type + '-creative-container');
         creativeContainer.innerHTML = html;
 
-        if (type === 'inline' && id === 'in-article-signup-test') {
+        if (type === 'inline' && id === 'midarticle') {
             injectInlineCreativeIfLength(creativeContainer, 10);
         } else if (type === 'inline-article') {
             injectInlineCreative(creativeContainer);


### PR DESCRIPTION
Currently set up on CODE as ``` in-article-signup-test ```. This will need migrating to PROD Olgil and the parameters set up.

https://olgil-admin.code.dev-gutools.co.uk/admin/creatives

<img src="https://user-images.githubusercontent.com/11618797/50347390-4fae4900-052d-11e9-9ed3-46b738102faa.png" width="300px"/> <img src="https://user-images.githubusercontent.com/11618797/50347435-77051600-052d-11e9-86a2-c5abab45eb03.png" width="300px" />