### PR TITLE
alias curl to require

### DIFF
--- a/ArticleTemplates/interactiveTemplate.html
+++ b/ArticleTemplates/interactiveTemplate.html
@@ -11,6 +11,9 @@
     </script>
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/curl.js"></script>
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/boot.js"></script>
+    <script type="text/javascript">
+        window.require = curl || {};
+    </script>
 </head>
 
 <body class="__FONT_SIZE__ __PLATFORM__ __IS_OFFLINE__ __DISPLAY_HINT__" data-fullscreen-interactive data-content-type="interactive" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-page-id="__PAGE_ID__" data-template-directory="__TEMPLATES_DIRECTORY__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">


### PR DESCRIPTION
Some interactive templates (docs) still use the require keyword and rely on it being in window scope.
