### PR TITLE
Alias require to curl on pages that could rely on having require

### DIFF
--- a/ArticleTemplates/articleTemplate.html
+++ b/ArticleTemplates/articleTemplate.html
@@ -14,6 +14,9 @@
     </script>
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/curl.js"></script>
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/boot.js"></script>
+    <script type="text/javascript">
+        window.require = curl || {};
+    </script>
 </head>
 <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="article" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__" data-content-section="__SECTION__">
 

--- a/ArticleTemplates/collectionTemplate.html
+++ b/ArticleTemplates/collectionTemplate.html
@@ -11,6 +11,9 @@
     </script>
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/curl.js"></script>
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/boot.js"></script>
+    <script type="text/javascript">
+        window.require = curl || {};
+    </script>
 </head>
 
 <body class="garnett--type-collection garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="article" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__" data-content-section="__SECTION__">

--- a/ArticleTemplates/commentsTemplate.html
+++ b/ArticleTemplates/commentsTemplate.html
@@ -12,6 +12,9 @@
         </script>
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/curl.js"></script>
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/boot.js"></script>
+        <script type="text/javascript">
+            window.require = curl || {};
+        </script>
     </head>
     <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__">
         <section class="comments comments--page comments-__COMMENTS_COUNT__">

--- a/ArticleTemplates/commentsTemplateHighlighted.html
+++ b/ArticleTemplates/commentsTemplateHighlighted.html
@@ -12,6 +12,9 @@
         </script>
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/curl.js"></script>
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/boot.js"></script>
+        <script type="text/javascript">
+            window.require = curl || {};
+        </script>
     </head>
     <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__">
         <section class="comments comments--page comments-__COMMENTS_COUNT__">

--- a/ArticleTemplates/cricketTemplate.html
+++ b/ArticleTemplates/cricketTemplate.html
@@ -14,6 +14,9 @@
     </script>
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/curl.js"></script>
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/boot.js"></script>
+    <script type="text/javascript">
+        window.require = curl || {};
+    </script>
 </head>
 
 <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __DISPLAY_HINT__" data-content-type="cricket" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" style="margin-top: __ACTIONBARHEIGHT__px;" data-ads-config="__ADS_CONFIG__" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">

--- a/ArticleTemplates/errorExpiredContent.html
+++ b/ArticleTemplates/errorExpiredContent.html
@@ -10,6 +10,9 @@
     </script>
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/curl.js"></script>
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/boot.js"></script>
+    <script type="text/javascript">
+        window.require = curl || {};
+    </script>
 </head>
 
 <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--news __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__" data-content-type="error" data-ads-enabled="false" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__">

--- a/ArticleTemplates/footballTemplate.html
+++ b/ArticleTemplates/footballTemplate.html
@@ -14,6 +14,9 @@
     </script>
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/curl.js"></script>
     <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/boot.js"></script>
+    <script type="text/javascript">
+        window.require = curl || {};
+    </script>
 </head>
 
 <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __DISPLAY_HINT__" data-content-type="football" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" style="margin-top: __ACTIONBARHEIGHT__px;" data-ads-config="__ADS_CONFIG__" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">

--- a/ArticleTemplates/galleryTemplate.html
+++ b/ArticleTemplates/galleryTemplate.html
@@ -11,6 +11,9 @@
         </script>
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/curl.js"></script>
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/boot.js"></script>
+        <script type="text/javascript">
+            window.require = curl || {};
+        </script>
     </head>
     <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_ADVERTISING__ __DISPLAY_HINT__" data-content-type="gallery" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__" data-template-directory="__TEMPLATES_DIRECTORY__"  data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
         <div class="article article--visual">

--- a/ArticleTemplates/liveblogTemplate.html
+++ b/ArticleTemplates/liveblogTemplate.html
@@ -14,6 +14,9 @@
         </script>
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/curl.js"></script>
         <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/boot.js"></script>
+        <script type="text/javascript">
+            window.require = curl || {};
+        </script>
     </head>
     <body class="garnett--type-__GARNETT_TYPE__ garnett--pillar-__GARNETT_PILLAR__ tone--__SECTION_TONE__ __FONT_SIZE__ __LINE_HEIGHT__ __PLATFORM__ __IS_OFFLINE__ advert-config--__ADS_CONFIG__ __IS_LIVE__ __IS_ADVERTISING__ __THE_MINUTE__ new-templates __DISPLAY_HINT__" data-content-type="liveblog" data-ads-enabled="__ADS_ENABLED__" data-ads-enable-hiding="__ADS_ENABLE_HIDING__" data-ads-config="__ADS_CONFIG__" style="margin-top: __ACTIONBARHEIGHT__px;" data-font-size="__FONT_SIZE_INT__"  data-template-directory="__TEMPLATES_DIRECTORY__" data-page-id="__PAGE_ID__" data-mpu-after-paragraphs="__MPU_AFTER_PARAGRAPHS__" data-use-ads-ready="__ADS_FAST_CALLBACK__">
         <div class="article article--liveblog">


### PR DESCRIPTION
Some interactive templates still rely on having the require variable in the window scope.

We should alias it to curl just in case.