### PR TITLE
Show top of gallery images

### DIFF
--- a/ArticleTemplates/assets/scss/modules/media/_gallery.scss
+++ b/ArticleTemplates/assets/scss/modules/media/_gallery.scss
@@ -65,6 +65,7 @@ $galleryGutter: 4px;
                 width: 100%;
                 height: 100%;
                 object-fit: cover;
+                object-position: 50% 0%;
             }
         }
     }


### PR DESCRIPTION
| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/11618797/53240224-08ac1380-3696-11e9-9938-bf12ee702678.png" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/53240223-08ac1380-3696-11e9-9c94-c3c5269f1ec8.png" width="300px" />|
|<img src="https://user-images.githubusercontent.com/11618797/53240316-5163cc80-3696-11e9-81c5-5c40f2daf30c.png" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/53240329-5aed3480-3696-11e9-985b-ad838dbe66c8.png" width="300px" />|
|<img src="https://user-images.githubusercontent.com/11618797/53240483-b7e8ea80-3696-11e9-9ba3-faf3252fc5fc.png" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/53240494-bcad9e80-3696-11e9-836a-5e3eeca825ce.png" width="300px" />|
|<img src="https://user-images.githubusercontent.com/11618797/53240532-d3ec8c00-3696-11e9-81f7-63ebceea5024.png" width="300px" />| <img src="https://user-images.githubusercontent.com/11618797/53240512-c931f700-3696-11e9-9216-b3230729e588.png" width="300px" /> |


This change works for tall portrait images (like those seen on the red carpet), but there's a chance that we won't show the important parts of other images, as we're not always fitting to the centre.

This change doesn't seem to change square images (as shown below)

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/11618797/53240607-0d24fc00-3697-11e9-8007-0ee3895d4d5f.png" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/53240603-0bf3cf00-3697-11e9-97ef-85f0f07e51b9.png" width="300px" />|
| <img src="https://user-images.githubusercontent.com/11618797/53241040-4dd14500-3698-11e9-8ba3-8097168fdf23.png" width="300px"/> | <img src="https://user-images.githubusercontent.com/11618797/53241051-588bda00-3698-11e9-8747-2cb181a33c69.png" width="300px"/> |