### PR TITLE
Add bootstrap for charts

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/atoms.js
+++ b/ArticleTemplates/assets/js/bootstraps/atoms.js
@@ -11,6 +11,47 @@ function init() {
             return;
         }
         bootAtomType(t, atomTypes[t]);
+        if (t === 'chart') {
+            initCharts();
+        }
+    });
+}
+
+function initCharts() {
+    var iframes = Array.prototype.slice.call(document.querySelectorAll('.atom--chart > .atom__iframe'));
+    window.addEventListener('message', function (event) {
+        var message;
+        var iframe = iframes.reduce(function (winner, candidate) {
+            if (winner) {
+                return winner;
+            }
+
+            try {
+                return candidate.name === event.source.name ? candidate : null;
+            } catch (e) {
+                return null;
+            }
+        }, null);
+        if (iframe) {
+            try {
+                message = JSON.parse(event.data);
+                switch (message.type) {
+                case 'set-height':
+                    iframe.height = message.value;
+                    break;
+                default:
+                }
+                // eslint-disable-next-line no-empty
+            } catch (e) {}
+        }
+    });
+
+    iframes.forEach(function (iframe) {
+        const src = (iframe.getAttribute('srcdoc') || '')
+            .replace(/<gu-script>/g, '<script>')
+            // eslint-disable-next-line no-useless-concat
+            .replace(/<\/gu-script>/g, '<' + '/script>');
+        iframe.setAttribute('srcdoc', src);
     });
 }
 


### PR DESCRIPTION
This is a temporary hack required for launching chart atoms in the UI. They currently are added in the form of an iframe with local source:
```html
<iframe srcdoc="@atomHtml"></iframe>
```
and inside that code is some JavaScript that is sending messages to the parent document. This must be controlled in such a way that we have a listener able to handle those messages before they are sent. Hence the local complexity.

- [x] Tested with Android Studio
- [ ] Tested on iOS (cc @webb04 can you help with this?)