### PR TITLE
Charts and iframes fixes

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/atoms.js
+++ b/ArticleTemplates/assets/js/bootstraps/atoms.js
@@ -7,14 +7,14 @@ function init() {
     const atomTypes = GU.opts.atoms;
     Object.keys(atomTypes).forEach(t => {
         const f = atomTypes[t];
-        if (typeof f.default !== 'function' || f.default.length !== 1) {
+        if (t === 'chart' || typeof f.default !== 'function' || f.default.length !== 1) {
             return;
         }
         bootAtomType(t, atomTypes[t]);
-        if (t === 'chart') {
-            initCharts();
-        }
     });
+    if ('chart' in atomTypes) {
+        initCharts();
+    }
 }
 
 function initCharts() {

--- a/ArticleTemplates/assets/scss/base/_reset.scss
+++ b/ArticleTemplates/assets/scss/base/_reset.scss
@@ -77,3 +77,8 @@ button, input, optgroup, select, textarea {
     margin: 0;
     -webkit-font-smoothing: antialiased;
 }
+
+iframe {
+    display: block;
+    width: 100%;
+}


### PR DESCRIPTION
There was some issue bootstrapping charts because of the weird need for iframes, so I factored them out of the normal atom bootstrap. Then this fix highlighted issues with how iframes are rendered in the app.

| Before | After |
| --- | --- |
|![53641456-e894cb00-3c26-11e9-8cf3-00b19473f934](https://user-images.githubusercontent.com/629976/54121379-2e554e80-43f2-11e9-838e-9e1342fde53e.png)|![Screen Shot 2019-03-11 at 11 37 11](https://user-images.githubusercontent.com/629976/54121319-11208000-43f2-11e9-975f-901a5a537eef.png)|
