### PR TITLE
GLA-1101: fix smart inversion

### DIFF
--- a/ArticleTemplates/assets/scss/base/_inverted.scss
+++ b/ArticleTemplates/assets/scss/base/_inverted.scss
@@ -1,0 +1,5 @@
+@mixin inverted-colors {
+    @media (inverted-colors: inverted) {
+        filter: invert(100%);
+    }
+}

--- a/ArticleTemplates/assets/scss/layout/_article--shared.scss
+++ b/ArticleTemplates/assets/scss/layout/_article--shared.scss
@@ -36,6 +36,10 @@
                 margin-right: 0;
                 width: 100%;
             }
+
+            @media (inverted-colors: inverted) {
+                filter: invert(100%);
+            }
         }
 
         // Interactives within article body

--- a/ArticleTemplates/assets/scss/layout/_article--shared.scss
+++ b/ArticleTemplates/assets/scss/layout/_article--shared.scss
@@ -45,6 +45,10 @@
         // Interactives within article body
         .element-interactive {
             width: auto;
+
+            @media (inverted-colors: inverted) {
+                filter: invert(100%);
+            }
         }
 
         .element--thumbnail.element-interactive {

--- a/ArticleTemplates/assets/scss/layout/_article--shared.scss
+++ b/ArticleTemplates/assets/scss/layout/_article--shared.scss
@@ -37,18 +37,14 @@
                 width: 100%;
             }
 
-            @media (inverted-colors: inverted) {
-                filter: invert(100%);
-            }
+            @include inverted-colors
         }
 
         // Interactives within article body
         .element-interactive {
             width: auto;
 
-            @media (inverted-colors: inverted) {
-                filter: invert(100%);
-            }
+            @include inverted-colors
         }
 
         .element--thumbnail.element-interactive {

--- a/ArticleTemplates/assets/scss/modules/_cutout.scss
+++ b/ArticleTemplates/assets/scss/modules/_cutout.scss
@@ -52,9 +52,7 @@
         top: 0;
         z-index: 35;
 
-        @media (inverted-colors: inverted) {
-            filter: invert(100%);
-        }
+        @include inverted-colors;
 
         @include mq($from: col2) {
             background-size: auto 200px;

--- a/ArticleTemplates/assets/scss/modules/_cutout.scss
+++ b/ArticleTemplates/assets/scss/modules/_cutout.scss
@@ -52,6 +52,10 @@
         top: 0;
         z-index: 35;
 
+        @media (inverted-colors: inverted) {
+            filter: invert(100%);
+        }
+
         @include mq($from: col2) {
             background-size: auto 200px;
         }

--- a/ArticleTemplates/assets/scss/modules/_tags.scss
+++ b/ArticleTemplates/assets/scss/modules/_tags.scss
@@ -64,6 +64,7 @@
 
 .tags__list-item {
     margin: 1rem 0;
+    @include inverted-colors;
 
     a {
         white-space: nowrap;
@@ -81,12 +82,6 @@
     }
 
     #more {
-        @media (inverted-colors: inverted) {
-            filter: invert(100%);
-        }
-    }
-
-    @media (inverted-colors: inverted) {
-        filter: invert(100%);
+        @include inverted-colors
     }
 }

--- a/ArticleTemplates/assets/scss/modules/_tags.scss
+++ b/ArticleTemplates/assets/scss/modules/_tags.scss
@@ -60,7 +60,6 @@
         margin-left: 232px; // 240 - 4 (item padding offset) - 4 (visually offset rounded items);
         width: 940px;
     }
-
 }
 
 .tags__list-item {

--- a/ArticleTemplates/assets/scss/modules/_tags.scss
+++ b/ArticleTemplates/assets/scss/modules/_tags.scss
@@ -81,6 +81,12 @@
         @include tag-more-button(color(brightness-7), darken(color(brightness-96), 10%));
     }
 
+    #more {
+        @media (inverted-colors: inverted) {
+            filter: invert(100%);
+        }
+    }
+
     @media (inverted-colors: inverted) {
         filter: invert(100%);
     }

--- a/ArticleTemplates/assets/scss/modules/_tags.scss
+++ b/ArticleTemplates/assets/scss/modules/_tags.scss
@@ -60,6 +60,7 @@
         margin-left: 232px; // 240 - 4 (item padding offset) - 4 (visually offset rounded items);
         width: 940px;
     }
+
 }
 
 .tags__list-item {
@@ -78,5 +79,9 @@
     &.more-button a {
         background-color: transparent !important;
         @include tag-more-button(color(brightness-7), darken(color(brightness-96), 10%));
+    }
+
+    @media (inverted-colors: inverted) {
+        filter: invert(100%);
     }
 }

--- a/ArticleTemplates/assets/scss/style-async.scss
+++ b/ArticleTemplates/assets/scss/style-async.scss
@@ -8,6 +8,7 @@
 // Base
 @import 'base/animation';
 @import 'base/colour';
+@import 'base/inverted';
 
 // Modules
 @import 'modules/aside';

--- a/ArticleTemplates/assets/scss/style-sync.scss
+++ b/ArticleTemplates/assets/scss/style-sync.scss
@@ -10,6 +10,7 @@
 @import 'base/global';
 @import 'base/reset';
 @import 'base/iconography';
+@import 'base/inverted';
 
 // Modules
 @import 'modules/advert-slot';


### PR DESCRIPTION
This is a fix to smart inversion on:

- article cutout images (https://www.theguardian.com/education/2019/mar/19/uk-government-runs-down-schools-laura-mcinerney)
- tags (any article with tags!)
- YouTube videos embedded within article body (https://www.theguardian.com/tv-and-radio/shortcuts/2019/mar/19/crushed-giant-cheese-10-greatest-celebrities-moments-midsomer-murders)
- interactives within article body (https://www.theguardian.com/culture/ng-interactive/2019/mar/17/simone-lia-banana-split)

Taking screenshots with Smart Invert on doesn't really work, so I've provided links to the relevant sections in case you want to see the changes yourself. 