### PR TITLE
Add ESTabBarController acknowledgement

### DIFF
--- a/ArticleTemplates/simpleBodyTemplatePrepopCredits.html
+++ b/ArticleTemplates/simpleBodyTemplatePrepopCredits.html
@@ -31,7 +31,7 @@
             <p>Copyright &copy; 2009-2010:<br/>
                 Luc Vandal, Edovia Inc., http://www.edovia.com<br/>
                 Ortwin Gentz, FutureTap GmbH, http://www.futuretap.com<br/>
-                All rights reserved.</p>
+            All rights reserved.</p>
             <p>It is appreciated but not required that you give credit to Luc Vandal and Ortwin Gentz, as the original authors of this code. You can give credit in a blog post, a tweet or on a info page of your app. Also, the original authors appreciate letting them know if you use this code.</p>
             <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
             <p>This code is licensed under the BSD license that is available at: http://www.opensource.org/licenses/bsd-license.php</p>
@@ -40,7 +40,7 @@
 
             <h2>ISO8601DateFormatter</h2></p>
             <p>Copyright &copy; 2006–2013 Peter Hosey<br/>
-                All rights reserved.</p>
+            All rights reserved.</p>
             <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
             <p>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</p>
             <p>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</p>
@@ -59,7 +59,7 @@
 
             <h2>KFData</h2></p>
             <p>Copyright &copy; 2012-2013, Kyle Fuller<br/>
-                All rights reserved.</p>
+            All rights reserved.</p>
             <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
             <ol>
                 <li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
@@ -97,7 +97,7 @@
 
             <h2>NSString+URLEncoding</h2></p>
             <p>Created by Jon Crosby on 10/19/07.<br/>
-                Copyright 2007 Kaboomerang LLC. All rights reserved.</p>
+            Copyright 2007 Kaboomerang LLC. All rights reserved.</p>
             <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
             <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
             <p>THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
@@ -190,7 +190,7 @@
             <hr />
 
             <h2>Bonzo</h2>
-            <p>Copyright 2012, Dustin Diaz (the "Original Author")<p>
+            <p>Copyright 2012, Dustin Diaz (the "Original Author")</p>
             <p>All rights reserved.</p>
             <p>MIT License</p>
             <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
@@ -268,6 +268,26 @@
             <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
             <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
             <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+
+            <hr />
+
+            <h2>ESTabBarController</h2>
+            <p>Copyright &copy; 2016 lihao</p>
+            <p>Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+            furnished to do so, subject to the following conditions:</p>
+            <p>The above copyright notice and this permission notice shall be included in all
+            copies or substantial portions of the Software.</p>
+            <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+            SOFTWARE.</p>
         </div>
     </div>
 </body>


### PR DESCRIPTION
I've added license information for ESTabBarController, which will be added in https://github.com/guardian/ios-live/pull/4447.