### PR TITLE
Pinch and Zoom cartoons

### DIFF
--- a/ArticleTemplates/assets/js/article.js
+++ b/ArticleTemplates/assets/js/article.js
@@ -1,5 +1,5 @@
 import { init as commonInit } from 'bootstraps/common';
-import { init as articleInit } from 'bootstraps/article';
+import { init as articleInit, cartoonView } from 'bootstraps/article';
 import { init as atomsInit } from 'bootstraps/atoms';
 import { init as campaignInit } from 'bootstraps/campaign';
 
@@ -8,6 +8,9 @@ const init = () => {
     articleInit();
     atomsInit();
     campaignInit();
+    setTimeout(() => {
+        cartoonView();
+    }, 2000);
 };
 
 export { init };

--- a/ArticleTemplates/assets/js/bootstraps/article.js
+++ b/ArticleTemplates/assets/js/bootstraps/article.js
@@ -5,6 +5,7 @@ import { init as immersiveInit } from 'modules/immersive';
 import { init as creativeInjectorInit } from 'modules/creativeInjector';
 import { init as messengerInit } from 'modules/messenger';
 import resizeInit from 'modules/messenger/resize';
+import Hammer from 'hammerjs';
 
 function richLinkTracking() {
     let i;
@@ -29,6 +30,126 @@ function richLinkTracking() {
     }
 }
 
+function getUrlParameter(url, name) {
+    name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+    var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+    var results = regex.exec(url);
+    return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+}
+
+function wrap(el, wrapper) {
+    el.parentNode.insertBefore(wrapper, el);
+    wrapper.appendChild(el);
+}
+
+function cartoonView() {
+    const iframes = Array.from(document.querySelectorAll('.element-interactive.interactive iframe'))
+    if (iframes.length == 1) {
+        const src = iframes[0].src;
+        const imageSrcs = getUrlParameter(src, 'srcs-mobile');
+        const desktopSrc = getUrlParameter(src, 'srcs-desktop');
+        let comicStrips;
+        if (imageSrcs) {
+            comicStrips = imageSrcs.split(' ');
+        }
+
+        const hammerSettings = (GU.opts.platform === 'ios' ? { touchAction: 'auto' } : {})
+
+        iframes[0].parentNode.style.overflow = 'hidden';
+        comicStrips.forEach(strip => {
+            const img = document.createElement('img');
+            img.src = strip;
+            img.style.width = "100%";
+            iframes[0].parentNode.append(img);
+            const mc = new Hammer.Manager(img, hammerSettings);
+            const pinch = new Hammer.Pinch();
+            const pan = new Hammer.Pan();
+
+            mc.add(pinch);
+            mc.add(pan);
+
+            mc.on('pinch', ev => {
+                if (GU.opts.platform === 'ios') {
+                    ev.preventDefault();
+                }
+
+                const desiredScale = ev.scale;
+                const pinchCentre = getPinchCentre(img);
+
+                img.style.transformOrigin = `${pinchCentre.x}% ${pinchCentre.y}%`;
+                img.style.transform = `scale(${desiredScale})`;
+            });
+
+            mc.on('pinchstart', ev => {
+                lockArticleSwipe(true);
+                savePinchCentre(img, ev);
+            });
+
+            mc.on('pinchend', () => {
+                lockArticleSwipe(false);
+                bounceToInitialPosition(img);
+            });
+
+            mc.on("panleft panright", function(e) {
+                lockArticleSwipe(true);
+                console.log(e.type)
+                console.log(e.deltaX);
+                console.log(e.deltaY);
+            });
+        })
+        iframes[0].parentNode.removeChild(iframes[0]);
+    }
+}
+
+function lockArticleSwipe(toggle) {
+    if (GU.opts.platform === 'android') {
+        window.GuardianJSInterface.registerRelatedCardsTouch(toggle);
+    }
+}
+
+function getPinchCentre({dataset}) {
+    const pinchX = dataset.pinchCentreX;
+    const pinchY = dataset.pinchCentreY;
+    return {x: pinchX, y: pinchY};
+}
+
+function savePinchCentre(el, {center}) {
+    const elBounds = el.getBoundingClientRect();
+    const pinchCentreX = calcPinchCentre(elBounds, center, 'x', 'width');
+    const pinchCentreY = calcPinchCentre(elBounds, center, 'y', 'height');
+
+    el.dataset.pinchCentreX = pinchCentreX;
+    el.dataset.pinchCentreY = pinchCentreY;
+}
+
+function calcPinchCentre(elBounds, pinchCentre, axis, dimension) {
+    const elStart = elBounds[axis];
+    const elEnd = elBounds[dimension];
+    const pinch = pinchCentre[axis];
+
+    const pinchRel = (pinch-elStart)/(elEnd);
+    if (pinchRel > 0.75) {
+        return 100
+    } else if (pinchRel < 0.25) {
+        return 0
+    } else {
+        return Math.round(pinchRel*100);
+    }
+}
+
+function bounceToInitialPosition(el) {
+    const currentScale = (el.getBoundingClientRect().width/el.offsetWidth);
+    const newScale = currentScale + (1-currentScale)/5;
+    if (newScale >= 1) {
+        lockArticleSwipe(false);
+        return;
+    } else {
+        requestAnimationFrame(() => {
+            bounceToInitialPosition(el);
+        });
+    }
+}
+
 function init() {
     youtubeInit();
     twitterInit();
@@ -39,4 +160,4 @@ function init() {
     richLinkTracking();
 }
 
-export { init };
+export { init, cartoonView };


### PR DESCRIPTION
This pr replaces the cartoon iframe with the individual comic strip images.

I tried launching the iOS/Android image viewers using `x-gu://openimage/` but they only work when the displayImages are set in mapi. This could be possible but would require mapi or iOS and Android work.

Currently you can pinch and zoom individual comic strips, and we may want to add panleft and panright swiping.

We also have access to the desktop image, which might be nicer to pinch one image rather than multiple separate images. 

Now we have them as images in the html there's a lot we can do (pinching, buttons, new image viewer), I guess we should discuss what would be the best user functionality. @alfavata @glockett @zeek01 

Can test on:
https://www.theguardian.com/football/series/david-squires-on
https://www.theguardian.com/profile/first-dog-on-the-moon