### PR TITLE
MSS-1064: gallery lab fixes

### DIFF
--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -1,4 +1,4 @@
-import { signalDevice, getElementOffset, isAdvertising } from "modules/util";
+import { signalDevice, getElementOffset } from "modules/util";
 
 let adsReady = false;
 let numberOfMpus = 0;
@@ -43,7 +43,7 @@ function insertAdPlaceholders(mpuAfterParagraphs) {
     placeholder.classList.add('advert-slot');
     placeholder.classList.add('advert-slot--placeholder');
 
-    // To mimic the correct positioning on full width tablet view, we will need an 
+    // To mimic the correct positioning on full width tablet view, we will need an
     // empty div to pad out the text so we can position absolutely over it.
     if (placeholderSibling && placeholderSibling.parentNode) {
         placeholderSibling.parentNode.insertBefore(placeholder, placeholderSibling);
@@ -262,7 +262,7 @@ function init(config) {
     if (adsType === 'liveblog') {
         adsReady = true;
         updateLiveblogAdPlaceholders();
-    } else if (adsType === 'gallery' && !isAdvertising()) {
+    } else if (adsType === 'gallery') {
         numberOfMpus = 1;
         const mpuAfterImages = 4;
         insertAdPlaceholdersGallery(mpuAfterImages);
@@ -270,7 +270,7 @@ function init(config) {
         numberOfMpus = 1;
         insertAdPlaceholders(config.mpuAfterParagraphs);
     }
- 
+
     if (adsReady) {
         if (GU.opts.platform !== 'android') {
             initMpuPoller();

--- a/ArticleTemplates/assets/js/modules/util.js
+++ b/ArticleTemplates/assets/js/modules/util.js
@@ -83,7 +83,7 @@ function debounce(func, wait, immediate) {
     return function() {
         context = this;
         args = arguments;
-        
+
         later = () => {
             timeout = null;
             if (!immediate) {
@@ -92,7 +92,7 @@ function debounce(func, wait, immediate) {
         }
 
         callNow = immediate && !timeout;
-        
+
         clearTimeout(timeout);
 
         timeout = setTimeout(later, wait);
@@ -138,10 +138,6 @@ function scrollToElement(element) {
     scroll.animateScroll(element, { speed: 1500 });
 }
 
-function isAdvertising() {
-    return !!document.querySelector('body.is_advertising');
-}
-
 export {
     isElementPartiallyInViewport,
     getElementOffset,
@@ -156,6 +152,5 @@ export {
     append,
     insertAfter,
     getAndroidVersion,
-    scrollToElement,
-    isAdvertising
+    scrollToElement
 };

--- a/ArticleTemplates/assets/scss/base/_colour.scss
+++ b/ArticleTemplates/assets/scss/base/_colour.scss
@@ -169,7 +169,9 @@ $gu-colours: (
     quiz-correct-answer: #3db540,
     // Comments
     comment-highlighted: #ffbb50,
-    comment-highlighted-link: #9f1f02
+    comment-highlighted-link: #9f1f02,
+    //Gallery
+    tone-gallery-link: #5fa794
 );
 
 // Colour palette

--- a/ArticleTemplates/assets/scss/modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/modules/_advert-slot.scss
@@ -180,7 +180,8 @@
     }
 }
 
-.garnett--type-media[data-content-type='gallery'] {
+.garnett--type-media[data-content-type='gallery'],
+.is_advertising.garnett--type-guardianlabs[data-content-type='gallery'] {
     .advert-slot--mpu {
         margin: 0 0 32px 0;
 

--- a/ArticleTemplates/assets/scss/modules/_related-content.scss
+++ b/ArticleTemplates/assets/scss/modules/_related-content.scss
@@ -10,7 +10,3 @@
     }
  }
 
- .is_advertising.garnett--type-guardianlabs[data-content-type='gallery'] .related-content {
-    background: color(global-adv-bg);
-}
-

--- a/ArticleTemplates/assets/scss/modules/_related-content.scss
+++ b/ArticleTemplates/assets/scss/modules/_related-content.scss
@@ -9,4 +9,8 @@
         width: 1200px;
     }
  }
- 
+
+ .is_advertising.garnett--type-guardianlabs[data-content-type='gallery'] .related-content {
+    background: color(global-adv-bg);
+}
+

--- a/ArticleTemplates/assets/scss/style-async.scss
+++ b/ArticleTemplates/assets/scss/style-async.scss
@@ -15,7 +15,6 @@
 @import 'modules/inline-list';
 @import 'modules/interactive';
 @import 'modules/more';
-@import 'type/media-gallery';
 @import 'modules/outbrain';
 @import 'modules/tags';
 @import 'modules/related-content';

--- a/ArticleTemplates/assets/scss/style-async.scss
+++ b/ArticleTemplates/assets/scss/style-async.scss
@@ -15,6 +15,7 @@
 @import 'modules/inline-list';
 @import 'modules/interactive';
 @import 'modules/more';
+@import 'type/media-gallery';
 @import 'modules/outbrain';
 @import 'modules/tags';
 @import 'modules/related-content';

--- a/ArticleTemplates/assets/scss/type/_media-gallery.scss
+++ b/ArticleTemplates/assets/scss/type/_media-gallery.scss
@@ -2,6 +2,8 @@
 .is_advertising.garnett--type-guardianlabs[data-content-type='gallery'] .article {
     .advert-slot--mpu {
         margin: 0;
+        margin-bottom: base-px(1);
+        margin-top: -(base-px(1));
     }
 
     .article--visual {
@@ -226,6 +228,10 @@
     p a, em a {
         color: color(tone-gallery-link);
         border-bottom: 0.00625rem solid color(tone-gallery-link);
+        }
+
+    .sponsorship, .keyline:before {
+            background: color(global-adv-bg)
         }
 
     .meta__misc a  {

--- a/ArticleTemplates/assets/scss/type/_media-gallery.scss
+++ b/ArticleTemplates/assets/scss/type/_media-gallery.scss
@@ -220,10 +220,11 @@
 
 .is_advertising.garnett--type-guardianlabs[data-content-type='gallery'] .article {
     a {
-        border-bottom: 0.00625rem solid #999;
+        color: #5fa794;
+        border-bottom: 0.00625rem solid #5fa794;
         }
 
-    .sponsorship__inner a {
+    .sponsorship__inner a, .meta__misc a {
         border-bottom: none;
     }
 

--- a/ArticleTemplates/assets/scss/type/_media-gallery.scss
+++ b/ArticleTemplates/assets/scss/type/_media-gallery.scss
@@ -1,5 +1,9 @@
 .garnett--type-media[data-content-type='gallery'],
 .is_advertising.garnett--type-guardianlabs[data-content-type='gallery'] .article {
+    .advert-slot--mpu {
+        margin: 0;
+    }
+
     .article--visual {
         position: relative;
     }
@@ -219,13 +223,13 @@
 }
 
 .is_advertising.garnett--type-guardianlabs[data-content-type='gallery'] .article {
-    a {
+    p a, em a {
         color: #5fa794;
         border-bottom: 0.00625rem solid #5fa794;
         }
 
-    .sponsorship__inner a, .meta__misc a {
-        border-bottom: none;
+    .meta__misc a  {
+        color: #5fa794;
     }
 
     .article__header .headline {

--- a/ArticleTemplates/assets/scss/type/_media-gallery.scss
+++ b/ArticleTemplates/assets/scss/type/_media-gallery.scss
@@ -219,6 +219,14 @@
 }
 
 .is_advertising.garnett--type-guardianlabs[data-content-type='gallery'] .article {
+    a {
+        border-bottom: 0.00625rem solid #999;
+        }
+
+    .sponsorship__inner a {
+        border-bottom: none;
+    }
+
     .article__header .headline {
         padding-top: $gs-unit / 2;
     }

--- a/ArticleTemplates/assets/scss/type/_media-gallery.scss
+++ b/ArticleTemplates/assets/scss/type/_media-gallery.scss
@@ -1,11 +1,5 @@
 .garnett--type-media[data-content-type='gallery'],
 .is_advertising.garnett--type-guardianlabs[data-content-type='gallery'] .article {
-    .advert-slot--mpu {
-        margin: 0;
-        margin-bottom: base-px(1);
-        margin-top: -(base-px(1));
-    }
-
     .article--visual {
         position: relative;
     }

--- a/ArticleTemplates/assets/scss/type/_media-gallery.scss
+++ b/ArticleTemplates/assets/scss/type/_media-gallery.scss
@@ -224,12 +224,12 @@
 
 .is_advertising.garnett--type-guardianlabs[data-content-type='gallery'] .article {
     p a, em a {
-        color: #5fa794;
-        border-bottom: 0.00625rem solid #5fa794;
+        color: color(tone-gallery-link);
+        border-bottom: 0.00625rem solid color(tone-gallery-link);
         }
 
     .meta__misc a  {
-        color: #5fa794;
+        color: color(tone-gallery-link);
     }
 
     .article__header .headline {


### PR DESCRIPTION
1. Reinstated the ad slot, and fixed the margin
2. Made the related content container the same colour as the article body to make it more consistent
3. Add some color and underline to links (using this article as a guideline (App version not dotcom): https://www.theguardian.com/rdg-epic-rail-journeys/2019/aug/01/views-box-set-binges-and-reducing-co2-nine-reasons-to-love-train-travel) 

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/19835654/62882089-0d8a7f80-bd29-11e9-9dc5-07138922c3cc.PNG" width="300px" />|<img src="https://user-images.githubusercontent.com/19835654/62882131-23984000-bd29-11e9-8d11-540d785985c6.png" width="300px" />|

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/19835654/62882276-7671f780-bd29-11e9-9f00-6e8a21545e5e.PNG" width="300px" />|<img src="https://user-images.githubusercontent.com/19835654/62882322-8c7fb800-bd29-11e9-879e-e729433ccc9b.png" width="300px" />|

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/19835654/62882460-d799cb00-bd29-11e9-8e2d-1143b8319c17.PNG" width="300px" />|<img src="https://user-images.githubusercontent.com/19835654/62882491-e84a4100-bd29-11e9-8c26-71f55d866e25.png" width="300px" />|