### PR TITLE
Kick-off atoms and callouts in liveblogs

### DIFF
--- a/ArticleTemplates/assets/js/liveblog.js
+++ b/ArticleTemplates/assets/js/liveblog.js
@@ -1,9 +1,12 @@
 import { init as commonInit } from 'bootstraps/common';
 import { init as liveblogInit } from 'bootstraps/liveblog';
-
+import { init as atomsInit } from 'bootstraps/atoms';
+import { init as campaignInit } from 'bootstraps/campaign';
 const init = () => {
     commonInit(true);
     liveblogInit();
+    atomsInit();
+    campaignInit();
 };
 
 export { init };


### PR DESCRIPTION
It's been reported a few times that atoms embedded in liveblogs work on web but not on apps. This will address the issue, at the same time for campaign callouts as well.