### PR TITLE
Call ads-ready on short articles with only one ad

### DIFF
--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -35,7 +35,7 @@ function insertAdPlaceholders(mpuAfterParagraphs, amountOfMpu) {
     
         if (!(mpuSibling && mpuSibling.parentNode)) {
             // Not enough paragraphs on page to add advert
-            return;
+            break;
         }
     
         mpuSibling.parentNode.insertBefore(mpu, mpuSibling);


### PR DESCRIPTION
On short articles (<9 paragraphs), there is only space for one ad slot. While this was being correctly added, `adsReady` was not being set to true, which meant that the native code never filled the slot.

This change breaks out of the loop but not the function, ensuring that `adsReady` will always be set. I have tested this locally, and can see that the slot is now correctly filled.

You can test this on any short article - I have a Charles response saved if you can't find one.