### PR TITLE
liveblog.js: let native layers pass block id as-is

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -17,7 +17,7 @@ function updateBlocksOnScroll() {
 }
 
 function scrollToBlock(id) {
-    const block = document.querySelector(`#block-${id}`);
+    const block = document.querySelector(`#${id}`);
     if (block) {
         scrollToElement(block)
         return true;


### PR DESCRIPTION
The newly-introduced (and not yet used on iOS) function `scrollToBlock` accepts a block id, but it's requiring the native layer to remove the `block-` prefix from the id... because the function itself prepends it to the supplied id!

That is, as far as I know, the only place where we're doing such a thing, hence this PR :)

[Agreed with @jordanterry that we can change the behaviour of the Android app to match]