### PR TITLE
Updated iOS Simulator Instructions - npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ $ npm install
     "@guardian/mobile-apps-article-templates": "file:../mobile-apps-article-templates"
 }
 ```
+* Run `npm install` in the root of the `ios-live` repo.
 
 ### Running on Android simulator
 * Checkout the branch you are developing against


### PR DESCRIPTION
## Why?

As far as I can tell, you need to run `npm install` to pick up the new (local) location of the templates.
