### PR TITLE
Temporary GE2019 Badge

### DIFF
--- a/ArticleTemplates/articleTemplateBadge.html
+++ b/ArticleTemplates/articleTemplateBadge.html
@@ -1,0 +1,1 @@
+<img class="article-badge" src="__BADGE_URL__" alt="__BADGE_NAME__">

--- a/ArticleTemplates/articleTemplateContainer.html
+++ b/ArticleTemplates/articleTemplateContainer.html
@@ -15,9 +15,12 @@
         </div>
 
         <div class="article-kicker">
-            <div class='article-kicker__section'>__SECTION__</div>
-            <div class='article-kicker__series'>
-                <span class='article-kicker__highlight'>__SERIES__</span>
+            __BADGE__
+            <div class="article-kicker__copy">
+                <div class='article-kicker__section'>__SECTION__</div>
+                <div class='article-kicker__series'>
+                    <span class='article-kicker__highlight'>__SERIES__</span>
+                </div>
             </div>
         </div>
 

--- a/ArticleTemplates/articleTemplateContainerComment.html
+++ b/ArticleTemplates/articleTemplateContainerComment.html
@@ -13,9 +13,12 @@
             __CUTOUT__
 
             <div class="article-kicker">
-                <div class='article-kicker__section'>__SECTION__</div>
-                <div class='article-kicker__series'>
-                    <span class='article-kicker__highlight'>__SERIES__</span>
+                __BADGE__
+                <div class="article-kicker__copy">
+                    <div class='article-kicker__section'>__SECTION__</div>
+                    <div class='article-kicker__series'>
+                        <span class='article-kicker__highlight'>__SERIES__</span>
+                    </div>
                 </div>
             </div>
 

--- a/ArticleTemplates/articleTemplateContainerFeatures.html
+++ b/ArticleTemplates/articleTemplateContainerFeatures.html
@@ -14,9 +14,12 @@
         </div>
 
         <div class="article-kicker">
-            <div class='article-kicker__section'>__SECTION__</div>
-            <div class='article-kicker__series'>
-                <span class='article-kicker__highlight'>__SERIES__</span>
+            __BADGE__
+            <div class="article-kicker__copy">
+                <div class='article-kicker__section'>__SECTION__</div>
+                <div class='article-kicker__series'>
+                    <span class='article-kicker__highlight'>__SERIES__</span>
+                </div>
             </div>
         </div>
 

--- a/ArticleTemplates/assets/scss/modules/content/_article-kicker.scss
+++ b/ArticleTemplates/assets/scss/modules/content/_article-kicker.scss
@@ -1,6 +1,8 @@
 .article-kicker {
     padding: base-px(.5, 1, 0, 1);
     min-height: 0;
+    display: flex;
+    align-items: flex-start;
     position: relative;
 
     &__live,
@@ -46,7 +48,9 @@
     }
     .article-badge {
         width: 55px;
-        margin-right: base-px(0.5);
+        margin-right: 8px;
+        padding-top: base-px(0.5);
+        padding-bottom: 8px;
 
         @include mq($from: col2) {
             width: 70px;
@@ -61,6 +65,8 @@
             }
 
             .article-kicker__series {
+                display: block;
+                margin-bottom: 14px;
                 font-weight: 400;
                 margin-left: 0;
             }

--- a/ArticleTemplates/assets/scss/modules/content/_article-kicker.scss
+++ b/ArticleTemplates/assets/scss/modules/content/_article-kicker.scss
@@ -38,4 +38,32 @@
             color: inherit;
         }
     }
+    &__copy {
+        vertical-align: top;
+        @include mq($from: col2) {
+            display: inline-flex;
+        }
+    }
+    .article-badge {
+        width: 55px;
+        margin-right: base-px(0.5);
+
+        @include mq($from: col2) {
+            width: 70px;
+        }
+
+        & ~ .article-kicker__copy {
+            display: inline-flex;
+            flex-direction: column;
+
+            .article-kicker__section {
+                display: block;
+            }
+
+            .article-kicker__series {
+                font-weight: 400;
+                margin-left: 0;
+            }
+        }
+    }
 }

--- a/ArticleTemplates/assets/scss/modules/content/_article-kicker.scss
+++ b/ArticleTemplates/assets/scss/modules/content/_article-kicker.scss
@@ -62,10 +62,13 @@
 
             .article-kicker__section {
                 display: block;
+                line-height: 20px;
+                margin-top: 2px;
             }
 
             .article-kicker__series {
                 display: block;
+                line-height: 20px;
                 margin-bottom: 14px;
                 font-weight: 400;
                 margin-left: 0;

--- a/ArticleTemplates/liveblogTemplate.html
+++ b/ArticleTemplates/liveblogTemplate.html
@@ -33,9 +33,12 @@
                 </div>
                 <div class="article-kicker">
                     <div class='article-kicker__live'>__LIVE_TAG__</div>
-                    <div class='article-kicker__section'>__SECTION__</div>
-                    <div class='article-kicker__series'>
-                        <span class='article-kicker__highlight'>__SERIES__</span>
+                    __BADGE__
+                    <div class="article-kicker__copy">
+                        <div class='article-kicker__section'>__SECTION__</div>
+                        <div class='article-kicker__series'>
+                            <span class='article-kicker__highlight'>__SERIES__</span>
+                        </div>
                     </div>
                 </div>
                 <h1 class="headline selectable">__TITLE__</h1>

--- a/ArticleTemplates/videoTemplate.html
+++ b/ArticleTemplates/videoTemplate.html
@@ -26,9 +26,12 @@
             </div>
 
             <div class="article-kicker">
-                <div class='article-kicker__section'>__SECTION__</div>
-                <div class='article-kicker__series'>
-                    <span class='article-kicker__highlight'>__SERIES__</span>
+                __BADGE__
+                <div class="article-kicker__copy">
+                    <div class='article-kicker__section'>__SECTION__</div>
+                    <div class='article-kicker__series'>
+                        <span class='article-kicker__highlight'>__SERIES__</span>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
## Why are you doing this?

We'd like to show badges in the kicker on articles related to the upcoming general election. This provides new placeholders and styling/layout changes needed by the apps, so they can inject the new badge information. Immersives coming in later PR.

- Corresponding PR on Android [here](https://github.com/guardian/android-news-app/pull/5689).
- Corresponding branch on iOS [here](https://github.com/guardian/ios-live/compare/temporary-ge2019-badge).

cc @benwuersching 

## Changes

- New `articleTemplateBadge` template with `__BADGE_URL__` and `__BADGE_NAME__` placeholders.
- Tweaked the templates for standard articles, opinion, features, liveblogs and video to accommodate the new badge.
- CSS changes to re-style the kicker; I've scoped these as much as possible to pages that include the badge, so hopefully other pages won't be affected.

## Screenshots

| | Article | Liveblog | Opinion | w/ Series | Video
|-|-|-|-|-|-
iPhone 11 | ![gebadge](https://user-images.githubusercontent.com/53781962/69351290-fa197980-0c72-11ea-9fd6-5eecf94f487d.jpeg) | ![gebadge-liveblog](https://user-images.githubusercontent.com/53781962/69351289-fa197980-0c72-11ea-9b2f-c99f526c4b8e.jpeg) | ![gebadge-opinion](https://user-images.githubusercontent.com/53781962/69351287-f980e300-0c72-11ea-808a-5aee874e4c31.jpeg) | ![gebadge-series](https://user-images.githubusercontent.com/53781962/69351286-f980e300-0c72-11ea-8e41-e09163e36e83.jpeg) | ![gebadge-video](https://user-images.githubusercontent.com/53781962/69351285-f8e84c80-0c72-11ea-8ebd-b9ac0faf0541.jpeg)
iPad Pro 11" | ![ipad](https://user-images.githubusercontent.com/53781962/69351867-e02c6680-0c73-11ea-9248-055c917611f4.jpeg) | ![ipad-liveblog](https://user-images.githubusercontent.com/53781962/69351866-df93d000-0c73-11ea-85e3-55e9c2fd8020.jpeg) | ![ipad-opinion](https://user-images.githubusercontent.com/53781962/69351864-df93d000-0c73-11ea-9c7c-78e0e6a57b48.jpeg) | ![ipad-series](https://user-images.githubusercontent.com/53781962/69351863-df93d000-0c73-11ea-8b81-b7e33e2d9576.jpeg) | ![ipad-video](https://user-images.githubusercontent.com/53781962/69351862-df93d000-0c73-11ea-879e-a74f78de4788.jpeg)
