### PR TITLE
white background for embeds in dark mode

### DIFF
--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
@@ -122,6 +122,16 @@ figure[data-atom-type="interactive"] {
     padding: 8px;
 }
 
+.element-embed {
+    background-color: white;
+    @include mq($to: col2) {
+        padding: 8px;
+        margin-left: -12px;
+        margin-right: -12px;
+        width: calc(100% + 24px);
+    }
+}
+
 .player-card {
     background: $backgroundBlack;
     border-top: 2px solid $warmGreyFour;


### PR DESCRIPTION
| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/11618797/69859866-f0a09a80-128c-11ea-91bd-68955be24cda.jpg" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/69859870-f302f480-128c-11ea-884c-673278263fe0.png" width="300px" />|

