### PR TITLE
format all images

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -276,10 +276,8 @@ function liveblogInsertBlocks(afterBlockId, html) {
 
     blocks = articleBody.getElementsByClassName('block');
 
-    const lastLoadedBlock = afterBlockId ? 9 : oldBlockCount;
-
-    for (i = blocks.length; i > lastLoadedBlock; i--) {
-        images.push(...blocks[i-1].getElementsByTagName('img'));
+    for (i = 0; i < blocks.length; i++) {
+        images.push(...blocks[i].getElementsByTagName('img'));
     }
 
     formatImages(images);


### PR DESCRIPTION
With the new key event link feature, blocks can be loaded in at any point of the liveBlog. This means they may not be in the most recent 10.
