### PR TITLE
Fix Special Report Series Highlight Bugs

### DIFF
--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeSpecialReport.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeSpecialReport.scss
@@ -18,7 +18,7 @@
 
         &:not(.garnett--type-media) .article-kicker__highlight {
             background: $ratingYellow;
-            box-shadow: 0 0 0 2px $ratingYellow;
+            box-shadow: 2px 0 $ratingYellow, -2px 0 $ratingYellow;
             color: $blackThree;
         }
 

--- a/ArticleTemplates/assets/scss/tones/_tone--special.scss
+++ b/ArticleTemplates/assets/scss/tones/_tone--special.scss
@@ -42,7 +42,11 @@
 
         // Prevents highlight overlapping section copy
         .article-kicker__copy .article-kicker__series {
-            line-height: 22px;
+            line-height: 2.2rem;
+
+            @include mq($from: col2) {
+                line-height: 2.8rem;
+            }
         }
 
         .article-kicker__highlight {

--- a/ArticleTemplates/assets/scss/tones/_tone--special.scss
+++ b/ArticleTemplates/assets/scss/tones/_tone--special.scss
@@ -40,10 +40,14 @@
             color: color(tone-special-dark);
         }
 
+        // Prevents highlight overlapping section copy
+        .article-kicker__copy .article-kicker__series {
+            line-height: 22px;
+        }
+
         .article-kicker__highlight {
             background-color: color(tone-highlight);
-            box-shadow: 0 0 0 2px color(tone-highlight);
-            padding: 0 2px;
+            box-shadow: 2px 0 color(tone-highlight), -2px 0 color(tone-highlight);
         }
     }
 


### PR DESCRIPTION
## Why?

Fixes some visual bugs that occur for the series highlight on special reports.

Removing the padding fixes the vertical yellow line on articles with no series. Altering the box shadow makes the highlight smaller (partially solving the overlap bug), and takes on the work that the padding was doing. Tweaking the line height also helps with the overlap.

## Changes

- Removed padding, used box-shadow instead
- Tweaked line height to prevent overlap with section
- Applied to dark mode as well

## Screenshots

|| Before | After |
| - | --- | --- |
| Series Highlight | ![before](https://user-images.githubusercontent.com/53781962/75684812-6e5fb200-5c91-11ea-9487-803b903a1619.jpg) | ![after](https://user-images.githubusercontent.com/53781962/75684811-6dc71b80-5c91-11ea-8cb7-6ed60a463a4a.jpg)
| iPad Series Highlight | ![ipad-before](https://user-images.githubusercontent.com/53781962/75687035-132fbe80-5c95-11ea-8e63-ad454716517b.jpg) | ![ipad-after](https://user-images.githubusercontent.com/53781962/75687022-0f9c3780-5c95-11ea-8c80-fcbcd5a91992.jpg) |
| No Series Text | ![before-no-series](https://user-images.githubusercontent.com/53781962/75684808-6d2e8500-5c91-11ea-956d-3568ebc687ea.jpg) | ![after-no-series](https://user-images.githubusercontent.com/53781962/75684802-6a339480-5c91-11ea-9370-15a550cbd7b4.jpg) |
