### PR TITLE
Fix Contrast On Atoms

### DIFF
--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
@@ -173,8 +173,8 @@ figure[data-alt="Subscribe to the Guardian morning briefing"] {
 }
 
 .campaign--snippet {
-    .heading {
-        color: $whiteTwo;
+    a {
+        color: $blackThree !important;
     }
 }
 


### PR DESCRIPTION
## Why?

@rupertbates reported low contrast on interactive atoms in dark mode. This should fix that, although I'm not sure if there's likely to be a knock-on effect of this change elsewhere.

## Changes

- Removed white colour from heading
- Applied dark colour to links

## Screenshots

| Before | After |
| --- | --- |
| ![dark-before](https://user-images.githubusercontent.com/53781962/75875953-a5a69e00-5e0c-11ea-9278-f74250d81ab2.png) | ![dark-fix](https://user-images.githubusercontent.com/53781962/75875950-a2abad80-5e0c-11ea-89fc-8af25be354ad.png) |
