### PR TITLE
GLA-1877: update quotes color to normal body color

### DIFF
--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
@@ -167,9 +167,11 @@ figure[data-alt="Subscribe to the Guardian morning briefing"] {
 }
 
 .prose blockquote,
-.prose blockquote.quoted,
-.prose blockquote.quoted::before {
+.prose blockquote.quoted {
     color: $whiteTwo;
+    &::before {
+        color: $warmGreyFour;
+    }    
 }
 
 .campaign--snippet {

--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
@@ -169,7 +169,7 @@ figure[data-alt="Subscribe to the Guardian morning briefing"] {
 .prose blockquote,
 .prose blockquote.quoted,
 .prose blockquote.quoted::before {
-    color: $warmGreyFour;
+    color: $whiteTwo;
 }
 
 .campaign--snippet {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4647,7 +4647,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -7985,7 +7986,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -20533,7 +20535,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }


### PR DESCRIPTION
Quotes need to be in light gray. Can you please validate @benwuersching ?

https://theguardian.atlassian.net/browse/GLA-1877

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 11 - 2020-03-13 at 17 30 13](https://user-images.githubusercontent.com/1733570/76645269-8fa58580-6550-11ea-9fdb-921be2c1987c.png) | ![Simulator Screen Shot - iPhone 11 - 2020-03-13 at 17 27 50](https://user-images.githubusercontent.com/1733570/76645272-916f4900-6550-11ea-8ecf-63139fe7b5fc.png) |




