### PR TITLE
media dark mode links

### DIFF
--- a/ArticleTemplates/assets/scss/modules/_resizable.scss
+++ b/ArticleTemplates/assets/scss/modules/_resizable.scss
@@ -23,7 +23,7 @@
 .resizable-media {
     .garnett--type-media[data-content-type='gallery'] & {
         font-size: 1.6rem;
-        line-height: 2.0rem;
+        line-height: 2.2rem;
     }
 
     @for $i from 1 through 3 {

--- a/ArticleTemplates/assets/scss/modules/galleryImageViewCaption.scss
+++ b/ArticleTemplates/assets/scss/modules/galleryImageViewCaption.scss
@@ -9,7 +9,7 @@ html.gallery-image-view body {
     .gallery-caption {
         color: color(brightness-86);
         font-size: 1.6rem;
-        line-height: 2.0rem;
+        line-height: 2.2rem;
 
         a {
             color: color(brightness-86);
@@ -20,6 +20,6 @@ html.gallery-image-view body {
     .gallery-credit {
         color: color(brightness-74);
         font-size: 1.6rem;
-        line-height: 2.0rem;
+        line-height: 2.2rem;
     }
 }

--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeArticle.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeArticle.scss
@@ -9,6 +9,7 @@
 &.garnett--type-guardianview,
 &.garnett--type-recipe,
 &.garnett--type-quiz,
+&.garnett--type-media,
 &.tone--deadBlog {
     background-color: $blackThree;
 
@@ -36,9 +37,10 @@
         color: $p-inverted;
     }
 
-    .standfirst .standfirst__inner a {
-        background-image: linear-gradient(rgba(153, 153, 153, 0.33) 0%, rgba(153, 153, 153, 0.5) 100%);
-        color: $warmGreyFour;
+    .standfirst .standfirst__inner a,
+    .standfirst a {
+        background-image: linear-gradient(rgba(153, 153, 153, 0.33) 0%, rgba(153, 153, 153, 0.5) 100%) !important;
+        color: $warmGreyFour !important;
     }
 
     .article__body .from-content-api.prose a {
@@ -116,6 +118,7 @@
 
     .element-rich-link a {
         color: $whiteTwo !important;
+        text-decoration: none;
     }
 
     @include mq($to: col4) {

--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeArticle.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeArticle.scss
@@ -104,7 +104,7 @@
     .byline,
     .alerts,
     .sponsorship__formatted-sponsor-name {
-        color: $warmGreyFour;
+        color: $warmGreyFour !important;
     }
 
     .alerts span[data-icon]:before {

--- a/ArticleTemplates/assets/scss/type/_media-gallery.scss
+++ b/ArticleTemplates/assets/scss/type/_media-gallery.scss
@@ -46,7 +46,7 @@
         }
         .header-photo-credit {
             font-size: 1.4rem;
-            line-height: 1.8rem;
+            line-height: 2rem;
             margin: $gs-unit $gs-unit 2*$gs-unit $gs-unit;
         }
     }
@@ -118,7 +118,7 @@
             }
             &__credit {
                 font-size: 1.4rem;
-                line-height: 1.8rem;
+                line-height: 2rem;
             }
         }
     }


### PR DESCRIPTION
- Increased line-height for text on gallery pages
- Use grey with underline for media links (dark mode)
- Remove underline in rich links (dark mode)

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/11618797/76762747-c61a1500-6789-11ea-85b3-0adce297dace.png" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/76762765-cdd9b980-6789-11ea-8f18-626e02209c5f.png" width="300px" />|
|<img src="https://user-images.githubusercontent.com/11618797/76762784-daf6a880-6789-11ea-9f3c-9d84ca2d13e8.png" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/76762809-e3e77a00-6789-11ea-946c-78b8375682eb.png" width="300px" />|
|<img src="https://user-images.githubusercontent.com/11618797/76762823-eb0e8800-6789-11ea-9e3b-d64fe5829bb4.png" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/76762840-f3ff5980-6789-11ea-9661-4cf5c79dc24c.png" width="300px" />|
