### PR TITLE
variable ad slots

### DIFF
--- a/ArticleTemplates/articleTemplate.html
+++ b/ArticleTemplates/articleTemplate.html
@@ -54,7 +54,8 @@
             disableEnhancedTweets: "__DISABLE_ENHANCED_TWEETS__" === "true" ? true : false,
             atoms: atoms,
             hasEpic: "__HAS_EPIC__" === "true",
-            campaignsUrl: "__CAMPAIGNS_URL__"
+            campaignsUrl: "__CAMPAIGNS_URL__",
+            maximumAdverts: "__MAXIMUM_ARTICLE_ADVERTS__"
         });
     }());
     </script>

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -140,16 +140,6 @@ function getMpuPosCommaSeparated() {
     return getMpuPos();
 }
 
-function getMpuOffset() {
-    return getMpuPos(getMpuOffsetCallback);
-}
-
-function getMpuOffsetCallback(params) {
-    return (numberOfMpus > 1)
-        ? `${params.x1}-${params.y1}:${params.x2}-${params.y2}`
-        : `${params.x1}-${params.y1}`;
-}
-
 function updateAndroidPosition() {
     if (adsType === 'liveblog') {
         getMpuPos(updateAndroidPositionLiveblogCallback);
@@ -172,13 +162,13 @@ function initMpuPoller(interval = 1000, firstRun = true) {
     }
 
     poller(interval,
-        getMpuOffset(),
+        getMpuPosCommaSeparated(),
         firstRun
     );
 }
 
 function poller(interval, adPositions, firstRun) {
-    let newAdPositions = getMpuOffset();
+    let newAdPositions = getMpuPosCommaSeparated();
 
     if (firstRun && GU.opts.platform === 'android') {
         updateAndroidPosition();
@@ -186,7 +176,7 @@ function poller(interval, adPositions, firstRun) {
         signalDevice('ad_moved');
     }
 
-    if (newAdPositions !== adPositions) {
+    if (JSON.stringify(newAdPositions) !== JSON.stringify(adPositions)) {
         if (GU.opts.platform === 'android'){
             updateAndroidPosition();
         } else {
@@ -239,7 +229,7 @@ function setupGlobals() {
 
 function init(config) {
     adsType = config.adsType;
-    const maximumAdverts = config.maximumAdverts;
+    const maximumAdverts = config.maximumAdverts || 15;
     setupGlobals();
 
     if (adsType === 'liveblog') {

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -108,6 +108,7 @@ function createMpu(id) {
     return mpu;
 }
 
+// this function is called by iOS
 function getMpuPos(formatter) {
     const advertSlots = document.getElementsByClassName('advert-slot__wrapper');
     const scrollLeft = document.scrollingElement ? document.scrollingElement.scrollLeft : document.body.scrollLeft;
@@ -135,11 +136,6 @@ function getMpuPos(formatter) {
     return null;
 }
 
-// this function is called by iOS
-function getMpuPosCommaSeparated() {
-    return getMpuPos();
-}
-
 function updateAndroidPosition() {
     if (adsType === 'liveblog') {
         getMpuPos(updateAndroidPositionLiveblogCallback);
@@ -162,13 +158,13 @@ function initMpuPoller(interval = 1000, firstRun = true) {
     }
 
     poller(interval,
-        getMpuPosCommaSeparated(),
+        getMpuPos(),
         firstRun
     );
 }
 
 function poller(interval, adPositions, firstRun) {
-    let newAdPositions = getMpuPosCommaSeparated();
+    let newAdPositions = getMpuPos();
 
     if (firstRun && GU.opts.platform === 'android') {
         updateAndroidPosition();
@@ -221,7 +217,7 @@ function updateMPUPosition(yPos) {
 function setupGlobals() {
     window.initMpuPoller = initMpuPoller;
     window.killMpuPoller = killMpuPoller;
-    window.getMpuPosCommaSeparated = getMpuPosCommaSeparated;
+    window.getMpuPos = getMpuPos;
     window.updateLiveblogAdPlaceholders = updateLiveblogAdPlaceholders;
 
     window.applyNativeFunctionCall('initMpuPoller');

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -17,11 +17,8 @@ function insertAdPlaceholdersGallery(mpuAfterImages) {
     }
 
     const image = images[nrImages];
-
     image.parentNode.insertBefore(mpu, image);
-
     placeholder.classList.add('advert-slot');
-
     adsReady = true;
 }
 
@@ -39,7 +36,6 @@ function insertAdPlaceholders(mpuAfterParagraphs, amountOfMpu) {
         }
 
         mpuSibling.parentNode.insertBefore(mpu, mpuSibling);
-
         placeholder.classList.add('advert-slot');
 
         // To mimic the correct positioning on full width tablet view, we will need an
@@ -74,11 +70,9 @@ function updateLiveblogAdPlaceholders(reset) {
 
     for (i = 0; i < blocks.length; i++) {
         block = blocks[i];
-
         if (i === 2 || i === 7) {
             numberOfMpus++;
             mpu = createMpu(numberOfMpus);
-
             if (block.nextSibling) {
                 block.parentNode.insertBefore(mpu, block);
             } else {
@@ -122,46 +116,32 @@ function getMpuPos(formatter) {
     const advertSlots = document.getElementsByClassName('advert-slot__wrapper');
     const scrollLeft = document.scrollingElement ? document.scrollingElement.scrollLeft : document.body.scrollLeft;
     const scrollTop = document.scrollingElement ? document.scrollingElement.scrollTop : document.body.scrollTop;
+    const params = [];
     let advertPosition;
-    let i;
-
-    const params = {
-        x1: -1,
-        y1: -1,
-        w1: -1,
-        h1: -1,
-        x2: -1,
-        y2: -1,
-        w2: -1,
-        h2: -1
-    };
 
     if (advertSlots.length) {
-        for (i = 0; i < advertSlots.length; i++) {
+        for (let i = 0; i < advertSlots.length; i++) {
             advertPosition = advertSlots[i].getBoundingClientRect();
 
             if (advertPosition.width !== 0 && advertPosition.height !== 0) {
-                params[`x${i + 1}`] = advertPosition.left + scrollLeft;
-                params[`y${i + 1}`] = advertPosition.top + scrollTop;
-                params[`w${i + 1}`] = advertPosition.width;
-                params[`h${i + 1}`] = advertPosition.height;
+                params.push({
+                    x: advertPosition.left + scrollLeft,
+                    y: advertPosition.top + scrollTop,
+                    width: advertPosition.width,
+                    height: advertPosition.height
+                })
             }
         }
 
-        return formatter(params);
+        return formatter ? formatter(params) : params;
     }
 
     return null;
 }
 
+// this function is called by iOS
 function getMpuPosCommaSeparated() {
-    return getMpuPos(getMpuPosCommaSeparatedCallback);
-}
-
-function getMpuPosCommaSeparatedCallback(params) {
-    return (numberOfMpus > 1)
-        ? `${params.x1},${params.y1},${params.x2},${params.y2}`
-        : `${params.x1},${params.y1}`;
+    return getMpuPos();
 }
 
 function getMpuOffset() {
@@ -186,8 +166,8 @@ function updateAndroidPositionLiveblogCallback({ x1, y1, w1, h1, x2, y2, w2, h2 
     window.GuardianJSInterface.mpuLiveblogAdsPosition(x1, y1, w1, h1, x2, y2, w2, h2);
 }
 
-function updateAndroidPositionDefaultCallback({ x1, y1, w1, h1, x2, y2, w2, h2 }) {
-    window.GuardianJSInterface.mpuAdsPosition(x1, y1, w1, h1, x2, y2, w2, h2);
+function updateAndroidPositionDefaultCallback(adSlots) {
+    window.GuardianJSInterface.mpuAdsPosition(JSON.stringify(adSlots));
 }
 
 function initMpuPoller(interval = 1000, firstRun = true) {
@@ -274,7 +254,7 @@ function init(config) {
         insertAdPlaceholdersGallery(mpuAfterImages);
     } else {
         numberOfMpus = 0;
-        insertAdPlaceholders(config.mpuAfterParagraphs, 2);
+        insertAdPlaceholders(config.mpuAfterParagraphs, 15);
     }
 
     if (adsReady) {

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -96,10 +96,6 @@ function createMpu(id) {
     mpu.classList.add('advert-slot');
     mpu.classList.add('advert-slot--mpu');
 
-    if (id === 1) {
-        mpu.classList.add('first');
-    }
-
     mpu.innerHTML = `
         <div class="advert-slot__label">
             Advertisement<a class="advert-slot__action" href="x-gu://subscribe">Hide<span data-icon="&#xe04F;"></span></a>

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -239,6 +239,7 @@ function setupGlobals() {
 
 function init(config) {
     adsType = config.adsType;
+    const maximumAdverts = config.maximumAdverts;
     setupGlobals();
 
     if (adsType === 'liveblog') {
@@ -248,9 +249,9 @@ function init(config) {
         numberOfMpus = 1;
         const mpuAfterImages = 4;
         insertAdPlaceholdersGallery(mpuAfterImages);
-    } else {
+    } else if (maximumAdverts) {
         numberOfMpus = 0;
-        insertAdPlaceholders(config.mpuAfterParagraphs, 15);
+        insertAdPlaceholders(config.mpuAfterParagraphs, maximumAdverts);
     }
 
     if (adsReady) {

--- a/ArticleTemplates/assets/scss/layout/_article.scss
+++ b/ArticleTemplates/assets/scss/layout/_article.scss
@@ -101,23 +101,6 @@
         }
     }
 
-    // Positon of adverts within article body
-    .advert-slot--mpu {
-        @include mq($from: col2, $to: col3) {
-            margin: 12px 0;
-        }
-
-        @include mq($from: col3) {
-            float: right;
-            margin-left: base-px(1.5);
-            margin-bottom: base-px(1);
-        }
-
-        @include mq($from: col3) {
-            margin-right: 0;
-        }
-    }
-
     // Only show one discalimer on gallery pages
     .affiliate-links-disclaimer {
         display: none;

--- a/ArticleTemplates/assets/scss/modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/modules/_advert-slot.scss
@@ -87,19 +87,12 @@
 
     @include mq($from: col2, $to: col3) {
         width: 100%;
+        margin: 12px 0;
     }
 
     @include mq($from: col3) {
-        position: absolute;
-        right: 15px;
-        margin: 0;
-        top: 348px;
-    }
-
-    &.first {
-        @include mq($from: col3) {
-            top: 24px;
-        }
+        float: right;
+        margin: 0 -300px base-px(1) 24px;
     }
 
     .advert-slot__label {

--- a/ArticleTemplates/liveblogTemplate.html
+++ b/ArticleTemplates/liveblogTemplate.html
@@ -108,7 +108,8 @@
                 nativeYoutubeEnabled: "__NATIVE_YOUTUBE_ENABLED__" === "true",
                 disableEnhancedTweets: "__DISABLE_ENHANCED_TWEETS__" === "true",
                 atoms: atoms,
-                hasEpic: "__HAS_EPIC__" === "true"
+                hasEpic: "__HAS_EPIC__" === "true",
+                maximumAdverts: 2
             });
         </script>
     </body>

--- a/test/spec/unit/modules/ads.test.js
+++ b/test/spec/unit/modules/ads.test.js
@@ -41,7 +41,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
         delete window.initMpuPoller;
         delete window.killMpuPoller;
         delete window.updateLiveblogAdPlaceholders;
-        delete window.getMpuPosCommaSeparated;
+        delete window.getMpuPos;
         delete window.applyNativeFunctionCall;
         delete window.GU;
         delete window.GuardianJSInterface;
@@ -86,7 +86,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
 
                 expect(window.initMpuPoller).toBeDefined();
                 expect(window.killMpuPoller).toBeDefined();
-                expect(window.getMpuPosCommaSeparated).toBeDefined();
+                expect(window.getMpuPos).toBeDefined();
 
                 expect(window.applyNativeFunctionCall).toHaveBeenCalledTimes(1);
                 expect(window.applyNativeFunctionCall).toHaveBeenCalledWith('initMpuPoller');
@@ -120,7 +120,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
 
                 expect(window.initMpuPoller).toBeDefined();
                 expect(window.killMpuPoller).toBeDefined();
-                expect(window.getMpuPosCommaSeparated).toBeDefined();
+                expect(window.getMpuPos).toBeDefined();
 
                 expect(window.applyNativeFunctionCall).toHaveBeenCalledTimes(1);
                 expect(window.applyNativeFunctionCall).toHaveBeenCalledWith('initMpuPoller');
@@ -369,7 +369,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
 
             init(config);
 
-            const adSlotArray = window.getMpuPosCommaSeparated();
+            const adSlotArray = window.getMpuPos();
             expect(adSlotArray.length).toEqual(1);
         });
 
@@ -378,7 +378,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
 
             init(config);
 
-            const adSlotArray = window.getMpuPosCommaSeparated();
+            const adSlotArray = window.getMpuPos();
             expect(adSlotArray.length).toEqual(2);
         });
 
@@ -387,7 +387,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
 
             init(config);
 
-            const adSlotArray = window.getMpuPosCommaSeparated();
+            const adSlotArray = window.getMpuPos();
             expect(adSlotArray.length).toEqual(2);
         });
     });

--- a/test/spec/unit/modules/ads.test.js
+++ b/test/spec/unit/modules/ads.test.js
@@ -342,24 +342,44 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             config = {
                 adsType: 'liveblog'
             };
+
+            Element.prototype.getBoundingClientRect = jest.fn(() => {
+                return {
+                    width: 120,
+                    height: 120,
+                    top: 0,
+                    left: 0,
+                    bottom: 0,
+                    right: 0,
+                }
+            });
         });
 
-        it('returns dimensions of 1 advertSlotWrapper', function () {
+        it('contains 1 adSlot object', function () {
             addBlocks(5);
 
             init(config);
 
-            const mpuPosCommaSeparated = window.getMpuPosCommaSeparated();
-            expect(mpuPosCommaSeparated.split(',').length).toEqual(2);
+            const adSlotArray = window.getMpuPosCommaSeparated();
+            expect(adSlotArray.length).toEqual(1);
         });
 
-        it('returns dimensions of 2 advertSlotWrappers', function () {
+        it('contains 2 adSlot objects', function () {
             addBlocks(10);
 
             init(config);
 
-            const mpuPosCommaSeparated = window.getMpuPosCommaSeparated();
-            expect(mpuPosCommaSeparated.split(',').length).toEqual(4);
+            const adSlotArray = window.getMpuPosCommaSeparated();
+            expect(adSlotArray.length).toEqual(2);
+        });
+
+        it('maximum 2 adSlot objects', function () {
+            addBlocks(25);
+
+            init(config);
+
+            const adSlotArray = window.getMpuPosCommaSeparated();
+            expect(adSlotArray.length).toEqual(2);
         });
     });
 

--- a/test/spec/unit/modules/ads.test.js
+++ b/test/spec/unit/modules/ads.test.js
@@ -76,7 +76,6 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
 
             it('inserts liveblog ad placeholders', function () {
                 config.adsType = 'liveblog';
-                config.maximumAdverts = 2;
 
                 init(config);
 
@@ -114,7 +113,6 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             it('inserts ad placeholder', function () {
                 config.mpuAfterParagraphs = 3;
                 config.adsType = 'default';
-                config.maximumAdverts = 2;
 
                 init(config);
 
@@ -138,7 +136,6 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             it('fires ads ready if has not been fired already', function () {
                 config.mpuAfterParagraphs = 3;
                 config.adsType = 'default';
-                config.maximumAdverts = 2;
 
                 document.body.classList.remove('no-ready');
 
@@ -177,9 +174,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
                 container.appendChild(articleBody);
 
                 config = {
-                    mpuAfterParagraphs: 3,
-                    maximumAdverts: 2
-
+                    mpuAfterParagraphs: 3
                 };
             });
 
@@ -216,8 +211,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             }
 
             config = {
-                adsType: 'liveblog',
-                maximumAdverts: 2
+                adsType: 'liveblog'
             };
         });
 
@@ -285,8 +279,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             articleBody.insertBefore(epic, articleBody.children[2]);
 
             config = {
-                adsType: 'liveblog',
-                maximumAdverts: 2
+                adsType: 'liveblog'
             };
         });
 
@@ -312,8 +305,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             container.appendChild(advertSlotWrapper);
 
             config = {
-                adsType: 'default',
-                maximumAdverts: 2
+                adsType: 'default'
             };
         });
 
@@ -348,8 +340,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             container.appendChild(articleBody);
 
             config = {
-                adsType: 'liveblog',
-                maximumAdverts: 2
+                adsType: 'liveblog'
             };
 
             Element.prototype.getBoundingClientRect = jest.fn(() => {

--- a/test/spec/unit/modules/ads.test.js
+++ b/test/spec/unit/modules/ads.test.js
@@ -76,6 +76,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
 
             it('inserts liveblog ad placeholders', function () {
                 config.adsType = 'liveblog';
+                config.maximumAdverts = 2;
 
                 init(config);
 
@@ -113,6 +114,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             it('inserts ad placeholder', function () {
                 config.mpuAfterParagraphs = 3;
                 config.adsType = 'default';
+                config.maximumAdverts = 2;
 
                 init(config);
 
@@ -136,6 +138,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             it('fires ads ready if has not been fired already', function () {
                 config.mpuAfterParagraphs = 3;
                 config.adsType = 'default';
+                config.maximumAdverts = 2;
 
                 document.body.classList.remove('no-ready');
 
@@ -174,7 +177,9 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
                 container.appendChild(articleBody);
 
                 config = {
-                    mpuAfterParagraphs: 3
+                    mpuAfterParagraphs: 3,
+                    maximumAdverts: 2
+
                 };
             });
 
@@ -211,7 +216,8 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             }
 
             config = {
-                adsType: 'liveblog'
+                adsType: 'liveblog',
+                maximumAdverts: 2
             };
         });
 
@@ -279,7 +285,8 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             articleBody.insertBefore(epic, articleBody.children[2]);
 
             config = {
-                adsType: 'liveblog'
+                adsType: 'liveblog',
+                maximumAdverts: 2
             };
         });
 
@@ -305,7 +312,8 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             container.appendChild(advertSlotWrapper);
 
             config = {
-                adsType: 'default'
+                adsType: 'default',
+                maximumAdverts: 2
             };
         });
 
@@ -340,7 +348,8 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             container.appendChild(articleBody);
 
             config = {
-                adsType: 'liveblog'
+                adsType: 'liveblog',
+                maximumAdverts: 2
             };
 
             Element.prototype.getBoundingClientRect = jest.fn(() => {
@@ -401,7 +410,8 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             container.appendChild(articleBody);
 
             config = {
-                mpuAfterParagraphs: 3
+                mpuAfterParagraphs: 3,
+                maximumAdverts: 2
             };
 
             const getElementOffsetMock = jest.spyOn(util, "getElementOffset");


### PR DESCRIPTION
This pr sends an array of ad slot positions instead of comma separated string values for iOS and individual integers to Android.

Before we were showing two ads per article after the 3rd and 9th paragraphs, now we will show ads after the 3rd, 9th and after every following 6 paragraphs.
- This extends our existing logic but we can tweak it
- I've set a remote limit of 15 but this can be extended too
- `__MAXIMUM_ARTICLE_ADVERTS__` is the remote config value that needs passing from iOS and Android (I've raised a PR in mobile-static)

### iOS

I've not changed the names yet, but I think the function iOS calls `getMpuPosCommaSeparated` should be renamed to something like `getAdSlots`. We might also need to change to postMessage to be able to send arrays and objects from the webview to iOS: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
