### PR TITLE
liveblog adverts

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -254,9 +254,8 @@ function liveblogInsertGap(afterBlockId, olderPagination, newerPagination) {
 function liveblogInsertBlocks(afterBlockId, html) {
     let i;
     let images = [];
-    let blocks;
     const articleBody = document.getElementsByClassName('article__body')[0];
-    const oldBlockCount = articleBody.getElementsByClassName('block').length;
+    const oldBlocks = articleBody.getElementsByClassName('block');
     const newBlockElems = getElemsFromHTML(html);
 
     const icons = [].slice.call(document.getElementsByClassName('gap-loading'));
@@ -274,7 +273,7 @@ function liveblogInsertBlocks(afterBlockId, html) {
         }
     }
 
-    blocks = articleBody.getElementsByClassName('block');
+    const blocks = articleBody.getElementsByClassName('block');
 
     for (i = 0; i < blocks.length; i++) {
         images.push(...blocks[i].getElementsByTagName('img'));
@@ -288,6 +287,11 @@ function liveblogInsertBlocks(afterBlockId, html) {
 
     checkInjectedComponents(false);
     safeEnhanceTweets();
+
+    if (afterBlockId) {
+        const advertIndices = [2, 7].map(index => oldBlocks.length + index - 10);
+        setTimeout(updateLiveblogAdPlaceholders(false, advertIndices), 700);
+    }
 }
 
 function setupGlobals() {
@@ -393,7 +397,6 @@ function init() {
     window.addEventListener('scroll', debounce(updateBlocksOnScroll, 100, true));
     liveMore();
     initYoutube();
-    setInterval(window.liveblogTime, 30000);
 
     const articleBody = document.getElementsByClassName('article__body')[0];
 

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -144,8 +144,8 @@ function updateAndroidPosition() {
     }
 }
 
-function updateAndroidPositionLiveblogCallback({ x1, y1, w1, h1, x2, y2, w2, h2 }) {
-    window.GuardianJSInterface.mpuLiveblogAdsPosition(x1, y1, w1, h1, x2, y2, w2, h2);
+function updateAndroidPositionLiveblogCallback(adSlots) {
+    window.GuardianJSInterface.mpuLiveblogAdsPosition(JSON.stringify(adSlots));
 }
 
 function updateAndroidPositionDefaultCallback(adSlots) {

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -49,7 +49,7 @@ function insertAdPlaceholders(mpuAfterParagraphs, amountOfMpu) {
     adsReady = true;
 }
 
-function updateLiveblogAdPlaceholders(reset) {
+function updateLiveblogAdPlaceholders(reset, indicies = [2, 6, 9]) {
     let i;
     let advertSlots;
     let mpu;
@@ -70,7 +70,7 @@ function updateLiveblogAdPlaceholders(reset) {
 
     for (i = 0; i < blocks.length; i++) {
         block = blocks[i];
-        if (i === 2 || i === 6 || i === 9) {
+        if (indicies.indexOf(i) >= 0) {
             numberOfMpus++;
             mpu = createMpu(numberOfMpus);
             if (block.nextSibling) {

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -108,6 +108,7 @@ function createMpu(id) {
     return mpu;
 }
 
+// this function is called by iOS
 function getMpuPos(formatter) {
     const advertSlots = document.getElementsByClassName('advert-slot__wrapper');
     const scrollLeft = document.scrollingElement ? document.scrollingElement.scrollLeft : document.body.scrollLeft;
@@ -135,11 +136,6 @@ function getMpuPos(formatter) {
     return null;
 }
 
-// this function is called by iOS
-function getMpuPosCommaSeparated() {
-    return getMpuPos();
-}
-
 function updateAndroidPosition() {
     if (adsType === 'liveblog') {
         getMpuPos(updateAndroidPositionLiveblogCallback);
@@ -162,13 +158,13 @@ function initMpuPoller(interval = 1000, firstRun = true) {
     }
 
     poller(interval,
-        getMpuPosCommaSeparated(),
+        getMpuPos(),
         firstRun
     );
 }
 
 function poller(interval, adPositions, firstRun) {
-    let newAdPositions = getMpuPosCommaSeparated();
+    let newAdPositions = getMpuPos();
 
     if (firstRun && GU.opts.platform === 'android') {
         updateAndroidPosition();
@@ -221,7 +217,7 @@ function updateMPUPosition(yPos) {
 function setupGlobals() {
     window.initMpuPoller = initMpuPoller;
     window.killMpuPoller = killMpuPoller;
-    window.getMpuPosCommaSeparated = getMpuPosCommaSeparated;
+    window.getMpuPos = getMpuPos;
     window.updateLiveblogAdPlaceholders = updateLiveblogAdPlaceholders;
 
     window.applyNativeFunctionCall('initMpuPoller');

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -70,7 +70,7 @@ function updateLiveblogAdPlaceholders(reset) {
 
     for (i = 0; i < blocks.length; i++) {
         block = blocks[i];
-        if (i === 2 || i === 7) {
+        if (i === 2 || i === 6 || i === 9) {
             numberOfMpus++;
             mpu = createMpu(numberOfMpus);
             if (block.nextSibling) {

--- a/test/spec/unit/modules/ads.test.js
+++ b/test/spec/unit/modules/ads.test.js
@@ -76,13 +76,12 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
 
             it('inserts liveblog ad placeholders', function () {
                 config.adsType = 'liveblog';
-                config.maximumAdverts = 2;
 
                 init(config);
 
                 expect(articleBody.children.length).toEqual(10);
                 expect(articleBody.children[2].classList.contains('advert-slot')).toEqual(true);
-                expect(articleBody.children[9].classList.contains('advert-slot')).toEqual(true);
+                expect(articleBody.children[7].classList.contains('advert-slot')).toEqual(true);
 
                 expect(window.initMpuPoller).toBeDefined();
                 expect(window.killMpuPoller).toBeDefined();
@@ -114,7 +113,6 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             it('inserts ad placeholder', function () {
                 config.mpuAfterParagraphs = 3;
                 config.adsType = 'default';
-                config.maximumAdverts = 2;
 
                 init(config);
 
@@ -138,7 +136,6 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             it('fires ads ready if has not been fired already', function () {
                 config.mpuAfterParagraphs = 3;
                 config.adsType = 'default';
-                config.maximumAdverts = 2;
 
                 document.body.classList.remove('no-ready');
 
@@ -177,9 +174,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
                 container.appendChild(articleBody);
 
                 config = {
-                    mpuAfterParagraphs: 3,
-                    maximumAdverts: 2
-
+                    mpuAfterParagraphs: 3
                 };
             });
 
@@ -209,23 +204,22 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             articleBody.classList.add('article__body');
             container.appendChild(articleBody);
 
-            for (i = 0; i < 10; i++) {
+            for (i = 0; i <= 10; i++) {
                 block = document.createElement('div');
                 block.classList.add('block');
                 articleBody.appendChild(block);
             }
 
             config = {
-                adsType: 'liveblog',
-                maximumAdverts: 2
-            };
+                adsType: 'liveblog'            };
         });
 
-        it('inserts liveblog ads after 2nd and 7th blocks', function () {
+        it('inserts liveblog ads after 2nd, 6th and 9th blocks', function () {
             init(config);
 
             expect(articleBody.children[2].classList.contains('advert-slot--mpu')).toEqual(true);
-            expect(articleBody.children[8].classList.contains('advert-slot--mpu')).toEqual(true);
+            expect(articleBody.children[7].classList.contains('advert-slot--mpu')).toEqual(true);
+            expect(articleBody.children[11].classList.contains('advert-slot--mpu')).toEqual(true);
         });
 
         it('if reset true replaces liveblog ads and calls signalDevice with ad_moved', function () {
@@ -285,9 +279,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             articleBody.insertBefore(epic, articleBody.children[2]);
 
             config = {
-                adsType: 'liveblog',
-                maximumAdverts: 2
-            };
+                adsType: 'liveblog'            };
         });
 
         it('inserts liveblog ad after the 3rd block instead', function () {
@@ -312,8 +304,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             container.appendChild(advertSlotWrapper);
 
             config = {
-                adsType: 'default',
-                maximumAdverts: 2
+                adsType: 'default'
             };
         });
 
@@ -348,8 +339,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             container.appendChild(articleBody);
 
             config = {
-                adsType: 'liveblog',
-                maximumAdverts: 2
+                adsType: 'liveblog'
             };
 
             Element.prototype.getBoundingClientRect = jest.fn(() => {
@@ -379,7 +369,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             init(config);
 
             const adSlotArray = window.getMpuPos();
-            expect(adSlotArray.length).toEqual(2);
+            expect(adSlotArray.length).toEqual(3);
         });
 
         it('maximum 2 adSlot objects', function () {
@@ -388,7 +378,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             init(config);
 
             const adSlotArray = window.getMpuPos();
-            expect(adSlotArray.length).toEqual(2);
+            expect(adSlotArray.length).toEqual(3);
         });
     });
 
@@ -410,8 +400,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             container.appendChild(articleBody);
 
             config = {
-                mpuAfterParagraphs: 3,
-                maximumAdverts: 2
+                mpuAfterParagraphs: 3
             };
 
             const getElementOffsetMock = jest.spyOn(util, "getElementOffset");


### PR DESCRIPTION
This builds on this [PR](https://github.com/guardian/mobile-apps-article-templates/pull/1138).

- Increase ads seen on first liveblog page from 2 to 3
- Insert two additional adverts for every 10 blocks fetched from the server
- Report all of these ad positions back to native layers using the new array structure

iOS and Android should be able to handle the array of advert slots in liveblogs (waiting confirmation)

This PR should get approval from Product before being released ⚠️