### PR TITLE
use darker slot for gallery adverts

### DIFF
--- a/ArticleTemplates/assets/scss/modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/modules/_advert-slot.scss
@@ -158,18 +158,19 @@
 }
 
 .garnett--type-media {
-    .advert-slot {
-        background: color(brightness-46);
-        color: color(brightness-100);
+    .advert-slot--mpu {
+        $whiteTwo: #dcdcdc;
+        $warmGrey: #767676;
+        $blackTwo: #333333;
+
+        border-top: solid 1px $warmGrey;
+        border-bottom: solid 1px $warmGrey;
+        background: $blackTwo;
+        color: $whiteTwo;
 
         .advert-slot__action {
-            color: color(brightness-100) !important;
+            color: $whiteTwo !important;
         }
-    }
-
-    .advert-slot--mpu {
-        border-top: 1px solid color(brightness-20);
-        border-bottom: 1px solid color(brightness-20);
     }
 }
 


### PR DESCRIPTION
Use dark mode ad slot styles for light mode gallery pages. 

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/11618797/77643612-9de3a080-6f57-11ea-8eee-28164fbf4d1f.png" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/77643642-a8059f00-6f57-11ea-8503-146f6518ced6.png" width="300px" />|
