### PR TITLE
move ad slots further to the right

### DIFF
--- a/ArticleTemplates/articleTemplate.html
+++ b/ArticleTemplates/articleTemplate.html
@@ -54,8 +54,7 @@
             disableEnhancedTweets: "__DISABLE_ENHANCED_TWEETS__" === "true" ? true : false,
             atoms: atoms,
             hasEpic: "__HAS_EPIC__" === "true",
-            campaignsUrl: "__CAMPAIGNS_URL__",
-            maximumAdverts: "__MAXIMUM_ARTICLE_ADVERTS__"
+            campaignsUrl: "__CAMPAIGNS_URL__"
         });
     }());
     </script>

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -225,7 +225,7 @@ function setupGlobals() {
 
 function init(config) {
     adsType = config.adsType;
-    const maximumAdverts = config.maximumAdverts || 15;
+    const maximumAdverts = 15;
     setupGlobals();
 
     if (adsType === 'liveblog') {

--- a/ArticleTemplates/assets/scss/modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/modules/_advert-slot.scss
@@ -92,7 +92,7 @@
 
     @include mq($from: col3) {
         float: right;
-        margin: 0 -300px base-px(1) 24px;
+        margin: 0 -330px base-px(1) 24px;
     }
 
     .advert-slot__label {

--- a/ArticleTemplates/liveblogTemplate.html
+++ b/ArticleTemplates/liveblogTemplate.html
@@ -108,8 +108,7 @@
                 nativeYoutubeEnabled: "__NATIVE_YOUTUBE_ENABLED__" === "true",
                 disableEnhancedTweets: "__DISABLE_ENHANCED_TWEETS__" === "true",
                 atoms: atoms,
-                hasEpic: "__HAS_EPIC__" === "true",
-                maximumAdverts: 2
+                hasEpic: "__HAS_EPIC__" === "true"
             });
         </script>
     </body>

--- a/test/spec/unit/modules/ads.test.js
+++ b/test/spec/unit/modules/ads.test.js
@@ -401,8 +401,7 @@ describe('ArticleTemplates/assets/js/modules/ads', function () {
             container.appendChild(articleBody);
 
             config = {
-                mpuAfterParagraphs: 3,
-                maximumAdverts: 2
+                mpuAfterParagraphs: 3
             };
 
             const getElementOffsetMock = jest.spyOn(util, "getElementOffset");


### PR DESCRIPTION
- Move adverts further to the right to avoid clashes with body content.
- Remove remote configuration as this needs to be added in iOS and Android

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/11618797/77658238-4f8dcc00-6f6e-11ea-85c3-08d72b11db3c.png" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/77658280-603e4200-6f6e-11ea-82f6-7d0a3f117eb9.png" width="300px" />|
