### PR TITLE
GLA-1880: fix Special Report article colours in dark mode

### DIFF
--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeSpecialReport.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeSpecialReport.scss
@@ -71,6 +71,16 @@ $specialReportBackground: rgb(34, 37, 39);
             background-color: transparent;
         }
 
+        .audio-player__button.touchpoint--primary .touchpoint__button,
+        .element-youtube .element-placeholder__button .touchpoint__button,
+        .audio-player__slider__knob {
+            background-color: $ratingYellow;
+
+            &:active {
+                background-color: $ratingYellow;
+            }
+        }
+
         .alerts span[data-icon]:before {
             color: $blackThree;
         }

--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeSpecialReport.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeSpecialReport.scss
@@ -1,3 +1,5 @@
+$specialReportBackground: rgb(34, 37, 39);
+
 &.tone--special,
 &.garnett--type-specialreport.tone--special,
 &.garnett--type-specialreport {
@@ -8,12 +10,14 @@
         .headline,
         .article__body,
         .tags,
+        .standfirst,
         .standfirst__inner,
         .meta,
         .article__meta,
         .sponsorship,
-        .keyline:before {
-            background-color: $backgroundBlack;
+        .keyline:before,
+        .cutout__container#cutout-container {
+            background-color: $specialReportBackground;
         }
 
         &:not(.garnett--type-media) .article-kicker__highlight {
@@ -42,7 +46,7 @@
         .loading--liveblog::before,
         .standfirst,
         .standfirst a:not(.Video-URL) {
-            color: $whiteTwo;
+            color: $whiteTwo !important;
         }
 
         .sponsorship img {
@@ -60,7 +64,7 @@
         .byline,
         .alerts,
         .sponsorship__formatted-sponsor-name {
-            color: $warmGreyFour;
+            color: $whiteTwo !important;
         }
 
         .audio-player {
@@ -95,7 +99,7 @@
 
         @include mq($to: col4) {
             .standfirst {
-                background-color: $backgroundBlack;
+                background-color: $specialReportBackground;
             }
         }
 
@@ -106,14 +110,14 @@
                 .headline,
                 .standfirst__inner,
                 .meta {
-                    background-color: $backgroundBlack;
+                    background-color: $specialReportBackground;
                 }
             }
         }
 
         .standfirst__inner p,
         .meta.keyline-4 {
-            background: $backgroundBlack !important;
+            background: $specialReportBackground !important;
             box-shadow: none !important;
         }
     }


### PR DESCRIPTION
I hate using `!important`. It's one of the most annoying feature of CSS. But I'm not sure I have too much choice here, because I use it only to override others, existing `!important`, located in `_darkModeArticle.scss`. (That's precisely what makes `!important` annoying: once we start using it, it proliferates.)

I don't want to touch/change *these*, in turn, because I suspect this would break other stuff in other places (otherwise they wouldn't be here in the first place), and I don't think it'd be worth to refactor the whole article CSSes just to get Special Report colours done.

So, here you go. These fixes are based on designs available from: https://theguardian.atlassian.net/browse/GLA-1880

You can repro locally by using CODE MAPI and opening the World/Europe front (PROD MAPI would work too I think).

@benwuersching would you like to have a look and give final approval?

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 11 - 2020-03-27 at 11 51 53](https://user-images.githubusercontent.com/1733570/77770341-03f62380-703d-11ea-8d8e-65c6e0e4fb54.png) | ![Simulator Screen Shot - iPhone 11 - 2020-03-27 at 15 00 31](https://user-images.githubusercontent.com/1733570/77770364-0ce6f500-703d-11ea-897f-6cd02edd77b4.png) |

More screenshots of the new colours:

| Podcasts | Opinion | Immersive |
| --- | --- | --- |
|  ![Simulator Screen Shot - iPhone 11 - 2020-03-27 at 15 35 41](https://user-images.githubusercontent.com/1733570/77772940-ceebd000-7040-11ea-8aee-c94a541c18a1.png) | ![Simulator Screen Shot - iPhone 11 - 2020-03-27 at 15 00 12](https://user-images.githubusercontent.com/1733570/77770519-461f6500-703d-11ea-889a-f3566d1e3355.png) |  ![Simulator Screen Shot - iPhone 11 - 2020-03-27 at 15 00 00](https://user-images.githubusercontent.com/1733570/77770533-4a4b8280-703d-11ea-864a-1227fd9b285a.png) |





