### PR TITLE
center gallery adverts on tablets

### DIFF
--- a/ArticleTemplates/assets/scss/modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/modules/_advert-slot.scss
@@ -183,8 +183,21 @@
             clear: both;
             position: relative;
             top: auto;
-            right: auto;
             margin-left: 8px;
+            margin-right: 8px;
+            width: calc(100% - 8px*2);
+            display: block;
+
+            .advert-slot__wrapper {
+                margin-left: calc(50% - 150px);
+                margin-top: -24px;
+                margin-bottom: 12px;
+            }
+        }
+
+        @include mq($from: col3) {
+            float: left;
+            width: calc(70% - #{$gs-unit}*2);
         }
     }
 }


### PR DESCRIPTION
A recent change to ad slots caused this issue on gallery pages.

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/11618797/77923609-934c4280-729a-11ea-90b6-de9342dc39cc.png" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/77923657-a6f7a900-729a-11ea-869d-ab5f04a5b18d.png" width="300px" />|
