### PR TITLE
clear pullquotes on photo essays

### DIFF
--- a/ArticleTemplates/assets/scss/layout/_article--photo-essay.scss
+++ b/ArticleTemplates/assets/scss/layout/_article--photo-essay.scss
@@ -32,7 +32,8 @@
 
         & + p,
         & + h2,
-        & + blockquote {
+        & + blockquote,
+        & + .element-pullquote:not(.element--halfWidth) {
             clear: both;
         }
     }


### PR DESCRIPTION
Dotcom use these styles, authors will assume they'll also be on apps.

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/11618797/79765070-10a92700-831e-11ea-8d98-2e6da60618d6.png" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/79765146-2880ab00-831e-11ea-9184-f420549de960.png" width="300px" />|
