### PR TITLE
Use the correct fonts in injected creatives

### DIFF
--- a/ArticleTemplates/assets/scss/modules/_injectedCreative.scss
+++ b/ArticleTemplates/assets/scss/modules/_injectedCreative.scss
@@ -13,7 +13,6 @@
         font-size: 20px;
         font-weight: 900;
         font-family: $egyptian-display;
-        color: tomato !important;
         margin-bottom: 12px;
         line-height: 1.4;
     }

--- a/ArticleTemplates/assets/scss/modules/_injectedCreative.scss
+++ b/ArticleTemplates/assets/scss/modules/_injectedCreative.scss
@@ -5,7 +5,7 @@
     border-top: 1px solid color(tone-highlight);
     background: color(brightness-96);
     width: 100%;
-    padding: 12px;
+    padding: $gs-unit/2 $gs-unit 3*$gs-unit;
     font-family: $egyptian-text;
     clear: left;
 
@@ -13,7 +13,7 @@
         font-size: 20px;
         font-weight: 900;
         font-family: $egyptian-display;
-        margin-bottom: 12px;
+        margin-bottom: $gs-unit*1.5;
         line-height: 1.4;
     }
 
@@ -23,16 +23,16 @@
         color: color(brightness-7);
         background: color(tone-highlight);
         border-radius: 100px;
-        margin: 0 12px 12px 0;
-        padding: 6px 6px 4px 15px;
+        margin: 0;
+        padding: $gs-unit/4 $gs-unit*1.5 0 $gs-unit*2;
         font-size: 16px;
-        font-weight: 900;
+        font-weight: 700;
         font-family: $guardian-sans;
-        line-height: 26px;
+        line-height: $gs-unit*4.75;
     }
 
     .button-container {
-        margin-top: 24px;
+        margin-top: $gs-unit*3;
     }
 
     .epic-button-arrow {
@@ -43,5 +43,6 @@
     mark {
         background: color(tone-highlight);
         padding: 4px 0;
+        color: color(brightness-7);
     }
 }

--- a/ArticleTemplates/assets/scss/modules/_injectedCreative.scss
+++ b/ArticleTemplates/assets/scss/modules/_injectedCreative.scss
@@ -6,17 +6,18 @@
     background: color(brightness-96);
     width: 100%;
     padding: 12px;
-    font-family: "Guardian Headline", "Guardian Text Egyptian Web", Georgia, serif;
+    font-family: $egyptian-text;
     clear: left;
 
     h1:first-of-type {
         font-size: 20px;
         font-weight: 900;
-        font-family: "Guardian Egyptian Web", "Guardian Headline", "Guardian Text Egyptian Web", Georgia, serif;
+        font-family: $egyptian-display;
+        color: tomato !important;
         margin-bottom: 12px;
         line-height: 1.4;
     }
-    
+
     .epic-button {
         display: inline-block;
         background-image: none;
@@ -27,19 +28,19 @@
         padding: 6px 6px 4px 15px;
         font-size: 16px;
         font-weight: 900;
-        font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+        font-family: $guardian-sans;
         line-height: 26px;
     }
-    
+
     .button-container {
         margin-top: 24px;
     }
-    
+
     .epic-button-arrow {
         margin-left: 6px;
         vertical-align: middle;
     }
-    
+
     mark {
         background: color(tone-highlight);
         padding: 4px 0;

--- a/ArticleTemplates/assets/scss/modules/_injectedCreative.scss
+++ b/ArticleTemplates/assets/scss/modules/_injectedCreative.scss
@@ -5,7 +5,7 @@
     border-top: 1px solid color(tone-highlight);
     background: color(brightness-96);
     width: 100%;
-    padding: $gs-unit/2 $gs-unit 3*$gs-unit;
+    padding: $gs-unit/2 $gs-unit 2*$gs-unit;
     font-family: $egyptian-text;
     clear: left;
 
@@ -23,7 +23,7 @@
         color: color(brightness-7);
         background: color(tone-highlight);
         border-radius: 100px;
-        margin: 0;
+        margin: 0 0 $gs-unit*1.5;
         padding: $gs-unit/4 $gs-unit*1.5 0 $gs-unit*2;
         font-size: 16px;
         font-weight: 700;


### PR DESCRIPTION
Fix for the epic using the pre-garnett _Guardian Egyptian_ instead of _Guardian Headline_ for headlines, and _Guardian Headline_ instead of _Guardian Text Egyptian_ for body text.

<h3>Before</h3>
<img src='https://user-images.githubusercontent.com/4561/80389455-672cdd00-88ab-11ea-9ab0-3fee4c5a1d98.png' width=375>


<h3>After</h3>
<img src='https://user-images.githubusercontent.com/4561/80389512-74e26280-88ab-11ea-9288-f2af2126fd8c.png' width=375>
