### PR TITLE
Space two buttons side-by-side in injected creatives

### DIFF
--- a/ArticleTemplates/assets/scss/modules/_injectedCreative.scss
+++ b/ArticleTemplates/assets/scss/modules/_injectedCreative.scss
@@ -23,7 +23,7 @@
         color: color(brightness-7);
         background: color(tone-highlight);
         border-radius: 100px;
-        margin: 0 0 $gs-unit*1.5;
+        margin: 0 $gs-unit*1.5 $gs-unit*1.5 0;
         padding: $gs-unit/4 $gs-unit*1.5 0 $gs-unit*2;
         font-size: 16px;
         font-weight: 700;


### PR DESCRIPTION
I realised my PR from yesterday removed a right margin on the button that is necessary — when two buttons are side-by-side, rather than vertically stacked!