### PR TITLE
Compatibility with dotcom on 'Guardian Egyptian Web' font name

### DIFF
--- a/ArticleTemplates/assets/scss/base/_typography.scss
+++ b/ArticleTemplates/assets/scss/base/_typography.scss
@@ -145,35 +145,29 @@ $fontMap: (
     // LEGACY FONTS:
 
     // Display Egyptian
-    GuardianEgyptianWeb100: (
-        family: 'Guardian Egyptian Web',
-        weight: 100,
-        android-src: 'url("../fonts/egyptiandisplay-thin.otf")',
-        ios-src: 'url("../fonts/egyptiandisplay-thin.otf")'
-    ),
     GuardianEgyptianWeb200: (
         family: 'Guardian Egyptian Web',
         weight: 200,
-        android-src: 'url("../fonts/egyptiandisplay-light.otf")',
-        ios-src: 'url("../fonts/egyptiandisplay-light.otf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Light.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Light.ttf")'
     ),
     GuardianEgyptianWeb300: (
         family: 'Guardian Egyptian Web',
         weight: 300,
-        android-src: 'url("../fonts/egyptiandisplay-regular.otf")',
-        ios-src: 'url("../fonts/egyptiandisplay-regular.otf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Regular.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Regular.ttf")'
     ),
     GuardianEgyptianWeb400: (
         family: 'Guardian Egyptian Web',
         weight: 400,
-        android-src: 'url("../fonts/egyptiandisplay-medium.otf")',
-        ios-src: 'url("../fonts/egyptiandisplay-medium.otf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Medium.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Medium.ttf")'
     ),
     GuardianEgyptianWeb600: (
         family: 'Guardian Egyptian Web',
         weight: 600,
-        android-src: 'url("../fonts/egyptiandisplay-bold.otf")',
-        ios-src: 'url("../fonts/egyptiandisplay-bold.otf")'
+        android-src: 'url("../fonts/GHGuardianHeadline-Bold.ttf")',
+        ios-src: 'url("../fonts/GHGuardianHeadline-Bold.ttf")'
     ),
 
     // Agate


### PR DESCRIPTION
Warning • This is confusing:

The app currently loads a font, 'Guardian Egyptian Web', which is no longer in use — and can be replaced by 'Guardian Headline' in all instances.

Unfortunately, dotcom loads 'Guardian Headline' under the 'Guardian Egyptian Web' name (i.e the wrong name, which is likely done for backwards compatibility). This leads to things on the app using the wrong font occasionally — mostly in things that are originally implemented for the web. We can fix them individually (like #1160) but we'd always be playing catch-up.

This PR makes 'Guardian Egyptian Web' an alias for 'Guardian Headline' for compatibility with dotcom. It doesn't delete the font files, in case they're needed by the native layer (another PR will follow for that).