### PR TITLE
use white text for quiz message in dark mode

### DIFF
--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeQuiz.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeQuiz.scss
@@ -53,4 +53,8 @@
     .quiz-scores .quiz-scores__score::before {
         color: $blackThree;
     }
+
+    .quiz-scores .quiz-scores__message {
+        color: $whiteTwo;
+    }
 }


### PR DESCRIPTION
| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/11618797/81161138-fe1c2800-8f82-11ea-831d-1285ff4fd820.png" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/81161159-08d6bd00-8f83-11ea-8d50-2f48b9494425.png" width="300px" />|