### PR TITLE
Narrower standfirsts

### DIFF
--- a/ArticleTemplates/assets/scss/modules/content/_standfirst.scss
+++ b/ArticleTemplates/assets/scss/modules/content/_standfirst.scss
@@ -19,11 +19,15 @@
     font-weight: 400;
     @include standfirst();
     clear: left;
-    width: calc(100% - #{$gs-unit*6});
-    max-width: 600px;
 
     strong,
     b {
         font-weight: 700;
     }
+
+    body:not(.garnett--type-live) &,
+    body:not(.garnett--type-analysis) & {
+        padding-right: $gs-unit*6;
+    }
+
 }

--- a/ArticleTemplates/assets/scss/modules/content/_standfirst.scss
+++ b/ArticleTemplates/assets/scss/modules/content/_standfirst.scss
@@ -19,6 +19,8 @@
     font-weight: 400;
     @include standfirst();
     clear: left;
+    width: calc(100% - #{$gs-unit*6});
+    max-width: 600px;
 
     strong,
     b {

--- a/ArticleTemplates/assets/scss/modules/content/_standfirst.scss
+++ b/ArticleTemplates/assets/scss/modules/content/_standfirst.scss
@@ -25,8 +25,7 @@
         font-weight: 700;
     }
 
-    body:not(.garnett--type-live) &,
-    body:not(.garnett--type-analysis) & {
+    body:not(.garnett--type-analysis):not(.garnett--type-live) & {
         padding-right: $gs-unit*6;
     }
 

--- a/ArticleTemplates/assets/scss/modules/content/_standfirst.scss
+++ b/ArticleTemplates/assets/scss/modules/content/_standfirst.scss
@@ -25,7 +25,7 @@
         font-weight: 700;
     }
 
-    body:not(.garnett--type-analysis):not(.garnett--type-live) & {
+    body:not(.garnett--type-analysis):not(.garnett--type-live):not(.garnett--type-media) & {
         padding-right: $gs-unit*6;
     }
 

--- a/ArticleTemplates/assets/scss/modules/content/_standfirst.scss
+++ b/ArticleTemplates/assets/scss/modules/content/_standfirst.scss
@@ -25,7 +25,7 @@
         font-weight: 700;
     }
 
-    body:not(.garnett--type-analysis):not(.garnett--type-live):not(.garnett--type-media) & {
+    body:not(.garnett--type-analysis):not(.garnett--type-live):not(.tone--media[data-content-type='video']) & {
         padding-right: $gs-unit*6;
     }
 


### PR DESCRIPTION
This reapplies #1165 but now plays well with liveblogs and comment articles.

Comment — keylines still full-width
<img src=https://user-images.githubusercontent.com/4561/83028462-c2302c00-a031-11ea-8404-82829b953a42.png width=414>

Liveblog — the narrow standfirst no longer applies to these:
<img src=https://user-images.githubusercontent.com/4561/83032399-11785b80-a036-11ea-9db7-b32cfb037b73.png width=414>

(Edit fixed a :not, :not logic mistake)
