### PR TITLE
GLA-2087: Try Live: add close button

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -131,33 +131,31 @@ function onLiveMoreClick(liveMoreElem) {
 }
 
 function setupTryLive() {
-    const elems = document.getElementsByClassName('block--live-promo');
-    for (let i = 0; i < elems.length; ++i) {
-        let elem = elems[i];
+    const elem = document.getElementsByClassName('block--live-promo')[0];
+    if (elem == null) return;
 
-        let tryLiveButton = elem.getElementsByClassName('live-promo__button')[0];
-        tryLiveButton.addEventListener('touchstart', () => {
-            tryLiveButton.classList.add('pressed');
-        });
-        tryLiveButton.addEventListener('touchend', () => {
-            tryLiveButton.classList.remove('pressed');
-        });
-        tryLiveButton.addEventListener('click', () => {
-            signalDevice('try-live');
-        });
+    let tryLiveButton = elem.getElementsByClassName('live-promo__button')[0];
+    tryLiveButton.addEventListener('touchstart', () => {
+        tryLiveButton.classList.add('pressed');
+    });
+    tryLiveButton.addEventListener('touchend', () => {
+        tryLiveButton.classList.remove('pressed');
+    });
+    tryLiveButton.addEventListener('click', () => {
+        signalDevice('try-live');
+    });
 
-        let closeButton = elem.getElementsByClassName('live-promo__close-button')[0];
-        closeButton.addEventListener('touchstart', () => {
-            closeButton.classList.add('pressed');
-        });
-        closeButton.addEventListener('touchend', () => {
-            closeButton.classList.remove('pressed');
-        });
-        closeButton.addEventListener('click', () => {
-            elem.remove();
-            signalDevice('close-try-live');
-        });
-    }
+    let closeButton = elem.getElementsByClassName('live-promo__close-button')[0];
+    closeButton.addEventListener('touchstart', () => {
+        closeButton.classList.add('pressed');
+    });
+    closeButton.addEventListener('touchend', () => {
+        closeButton.classList.remove('pressed');
+    });
+    closeButton.addEventListener('click', () => {
+        elem.remove();
+        signalDevice('close-try-live');
+    });
 }
 
 function liveblogDeleteBlock(blockID) {

--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -131,8 +131,8 @@ function onLiveMoreClick(liveMoreElem) {
 }
 
 function setupTryLive() {
-    const elem = document.getElementsByClassName('block--live-promo')[0];
-    if (elem == null) return;
+    const elem = document.querySelector('.block--live-promo');
+    if (elem === undefined) return;
 
     let tryLiveButton = elem.getElementsByClassName('live-promo__button')[0];
     tryLiveButton.addEventListener('touchstart', () => {

--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -132,7 +132,7 @@ function onLiveMoreClick(liveMoreElem) {
 
 function setupTryLive() {
     const elem = document.querySelector('.block--live-promo');
-    if (elem === undefined) return;
+    if (elem == null) return;
 
     let tryLiveButton = elem.getElementsByClassName('live-promo__button')[0];
     tryLiveButton.addEventListener('touchstart', () => {

--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -131,17 +131,31 @@ function onLiveMoreClick(liveMoreElem) {
 }
 
 function setupTryLive() {
-    const elems = document.getElementsByClassName('live-promo__button');
+    const elems = document.getElementsByClassName('block--live-promo');
     for (let i = 0; i < elems.length; ++i) {
         let elem = elems[i];
-        elem.addEventListener('touchstart', () => {
-            elem.classList.add('pressed');
+
+        let tryLiveButton = elem.getElementsByClassName('live-promo__button')[0];
+        tryLiveButton.addEventListener('touchstart', () => {
+            tryLiveButton.classList.add('pressed');
         });
-        elem.addEventListener('touchend', () => {
-            elem.classList.remove('pressed');
+        tryLiveButton.addEventListener('touchend', () => {
+            tryLiveButton.classList.remove('pressed');
         });
-        elem.addEventListener('click', () => {
+        tryLiveButton.addEventListener('click', () => {
             signalDevice('try-live');
+        });
+
+        let closeButton = elem.getElementsByClassName('live-promo__close-button')[0];
+        closeButton.addEventListener('touchstart', () => {
+            closeButton.classList.add('pressed');
+        });
+        closeButton.addEventListener('touchend', () => {
+            closeButton.classList.remove('pressed');
+        });
+        closeButton.addEventListener('click', () => {
+            elem.remove();
+            signalDevice('close-try-live');
         });
     }
 }

--- a/ArticleTemplates/assets/scss/modules/_live-promo.scss
+++ b/ArticleTemplates/assets/scss/modules/_live-promo.scss
@@ -9,6 +9,7 @@
         font-family: "Guardian Headline";
         display: flex;
         flex-direction: row;
+        position: relative;
     }
 
     .block__time {
@@ -65,6 +66,33 @@
 
         svg {
             display: block;
+        }
+    }
+
+    &__close-button {
+        border-radius: 1000px;
+        border: 1px solid #12121288;
+        position: absolute;
+        top: 12px;
+        right: 0;
+        width: 32px;
+        height: 32px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
+
+        & div {
+            width: 14px;
+            height: 14px;
+
+            & svg {
+                display: block;
+            }
+        }
+
+        &.pressed {
+            background: #00000044;
         }
     }
 }

--- a/ArticleTemplates/assets/scss/modules/_live-promo.scss
+++ b/ArticleTemplates/assets/scss/modules/_live-promo.scss
@@ -77,19 +77,8 @@
         right: 0;
         width: 32px;
         height: 32px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
+        text-align: center;
         padding: 0;
-
-        & div {
-            width: 14px;
-            height: 14px;
-
-            & svg {
-                display: block;
-            }
-        }
 
         &.pressed {
             background: #00000044;

--- a/ArticleTemplates/liveblogTemplateLivePromo.html
+++ b/ArticleTemplates/liveblogTemplateLivePromo.html
@@ -119,11 +119,7 @@
             </svg>
         </div>
         <button class="live-promo__close-button">
-            <div>
-                <svg width="14" height="15" viewBox="0 0 14 15" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M7.01053 8.44211L13.0947 14.0211L14 13.1158L8.44211 7.01053L14 0.905263L13.0947 0L7.01053 5.57895L0.905263 0.0210526L0 0.926316L5.57895 7.01053L0 13.0947L0.905263 14L7.01053 8.44211Z" fill="#121212"/>
-                </svg>
-            </div>
+            <span data-icon="&#xE04F;" aria-hidden="true"></span>
         </button>
     </div>
 </div>

--- a/ArticleTemplates/liveblogTemplateLivePromo.html
+++ b/ArticleTemplates/liveblogTemplateLivePromo.html
@@ -118,5 +118,12 @@
                     fill="#333333" />
             </svg>
         </div>
+        <button class="live-promo__close-button">
+            <div>
+                <svg width="14" height="15" viewBox="0 0 14 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M7.01053 8.44211L13.0947 14.0211L14 13.1158L8.44211 7.01053L14 0.905263L13.0947 0L7.01053 5.57895L0.905263 0.0210526L0 0.926316L5.57895 7.01053L0 13.0947L0.905263 14L7.01053 8.44211Z" fill="#121212"/>
+                </svg>
+            </div>
+        </button>
     </div>
 </div>


### PR DESCRIPTION
When the button is pressed, we remove the card from the DOM. We also need to send a signal to the app so that we register the closure and we don't reopen the card. You can test this PR by following the steps on https://github.com/guardian/ios-live/pull/5203

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/1733570/84163829-d16b9c80-aa69-11ea-8f41-a2cfdc85f675.png" width="300px" />|<img src="https://user-images.githubusercontent.com/1733570/84163849-d597ba00-aa69-11ea-910d-c286c14135a2.png" width="300px" />|
