### PR TITLE
GLA-2087: dismiss Try Live when pressed

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -143,6 +143,11 @@ function setupTryLive() {
     });
     tryLiveButton.addEventListener('click', () => {
         signalDevice('try-live');
+        // Wait a little bit before removing in case there is some
+        // animation to open the Live tab.
+        setTimeout(() => {
+            elem.remove();
+        }, 1000);
     });
 
     let closeButton = elem.getElementsByClassName('live-promo__close-button')[0];

--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -147,6 +147,7 @@ function setupTryLive() {
         // animation to open the Live tab.
         setTimeout(() => {
             elem.remove();
+            checkInjectedComponents(false);
         }, 1000);
     });
 
@@ -160,6 +161,7 @@ function setupTryLive() {
     closeButton.addEventListener('click', () => {
         elem.remove();
         signalDevice('close-try-live');
+        checkInjectedComponents(false);
     });
 }
 


### PR DESCRIPTION
I forgot to add logic to dismiss the card when pressing the "Try Live" button itself. We do want to do this because once people went ahead and tried it we don't need to advertise it anymore, and it wouldn't show on subsequent LiveBlog renders. @jordanterry does it make sense for Android's logic as well?