### PR TITLE
use light background in dark mode for chart atoms

### DIFF
--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
@@ -129,7 +129,8 @@
 }
 
 .interactive,
-figure[data-atom-type="interactive"] {
+figure[data-atom-type="interactive"],
+figure[data-atom-type="chart"] {
     background-color: white;
     padding: 8px;
 }


### PR DESCRIPTION

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/11618797/89394444-fdbb3680-d703-11ea-814a-737d3308ef72.png" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/89394474-06ac0800-d704-11ea-9b4a-63ff8362ea93.png" width="300px" />|
