### PR TITLE
Support iframe click tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ vendor
 *.log
 config
 fixture
+.idea
 
 # Built files
 ArticleTemplates/assets/css

--- a/ArticleTemplates/assets/js/bootstraps/common.js
+++ b/ArticleTemplates/assets/js/bootstraps/common.js
@@ -15,9 +15,10 @@ import { init as initRichLinks } from 'modules/rich-links';
 import { init as initAB } from 'modules/experiments/ab';
 import { initMpuPoller } from 'modules/ads';
 import { init as initHttp } from 'modules/http';
+import { init as ophanIframeInit } from 'modules/ophan-iframe';
 
 let trackCommentContainerView = true;
-        
+
 function init(liveBlog = false) {
     if ((GU && GU.opts && GU.opts.platform === 'android') || instagramHeader()) {
         // polyfill to remove click delays on browsers with touch
@@ -49,6 +50,7 @@ function init(liveBlog = false) {
     initHttp();
     setupForms();
     darkModeSetup();
+    ophanIframeInit();
 
     if (!document.body.classList.contains('no-ready')) {
         if (!liveBlog) {
@@ -76,7 +78,7 @@ function formatImages(images) {
     for (i = 0; i < images.length; i++) {
         image = images[i];
         figure = getClosestParentWithTag(image, 'figure');
-        
+
         if (figure) {
             figures.push(figure);
         }
@@ -628,7 +630,7 @@ function advertorialUpdates() {
             const metaContainer = metaContainers[i];
             const bylineElem = metaContainer.getElementsByClassName('byline')[0];
 
-            if (bylineElem && 
+            if (bylineElem &&
                 bylineElem.innerHTML === '' &&
                 !metaContainer.getElementsByClassName('sponsorship').length) {
                 const metaParent = metaContainer.parentNode;

--- a/ArticleTemplates/assets/js/modules/ophan-iframe.js
+++ b/ArticleTemplates/assets/js/modules/ophan-iframe.js
@@ -12,7 +12,7 @@ const handleIframeMessage = (messageEvent) => {
 };
 
 const init = () => {
-    window.top.addEventListener('message', handleIframeMessage, false);
+    window.addEventListener('message', handleIframeMessage, false);
 };
 
 export {

--- a/ArticleTemplates/assets/js/modules/ophan-iframe.js
+++ b/ArticleTemplates/assets/js/modules/ophan-iframe.js
@@ -1,0 +1,20 @@
+const handleIframeMessage = (messageEvent) => {
+    const correctType = messageEvent.data.type === 'ophan-iframe-click-event';
+    const correctOrigin = messageEvent.origin === 'https://www.theguardian.com' ||
+        messageEvent.origin === 'https://m.code.dev-theguardian.com/';
+
+    if (correctOrigin && correctType) {
+        const clickEvent = messageEvent.data.value;
+        if (window.GuardianJSInterface && window.GuardianJSInterface.trackInPageClick) {
+            window.GuardianJSInterface.trackInPageClick(JSON.stringify(clickEvent));
+        }
+    }
+};
+
+const init = () => {
+    window.top.addEventListener('message', handleIframeMessage, false);
+};
+
+export {
+    init
+};


### PR DESCRIPTION
This work is part of a larger piece to ensure the newsletter team closes the data gap we have as much as possible.

Part of that work is understanding when people are signing up to newsletters, which are currently implemented using iFrame embeds. Some work [has been done](https://github.com/guardian/frontend/pull/22806/files) on dotcom such that a message is posted from within the iFrame to the outer frame.

This PR implements a handler to receive the message, and forward it to the native layer. Unfortunately, the iOS stack blocks the message because of the security policy of the webview, so we'll only have Android support until the apps-rendering project reaches maturity.

See [this PR](https://github.com/guardian/android-news-app/pull/6241) for the android work that forwards the message to ophan