### PR TITLE
set image sizes on support articles

### DIFF
--- a/ArticleTemplates/assets/scss/layout/_support.scss
+++ b/ArticleTemplates/assets/scss/layout/_support.scss
@@ -22,6 +22,13 @@
         h3 {
             @include body();
         }
+
+        figure.element-image {
+            img {
+                width: 100%;
+                height: 100%;
+            }
+        }
     }
 
     @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
I think this might have been the first image used on one of our support articles...

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/11618797/95738018-7c8e9b80-0c80-11eb-9bae-915fe83ed64a.png" width="300px" />|<img src="https://user-images.githubusercontent.com/11618797/95738035-844e4000-0c80-11eb-8678-ca54829d81f2.png" width="300px" />|
