### PR TITLE
Fix a11y for premium taster indicators

### DIFF
--- a/ArticleTemplates/assets/js/modules/premiumTaster.js
+++ b/ArticleTemplates/assets/js/modules/premiumTaster.js
@@ -71,8 +71,6 @@ function indicatorHtml(taster) {
         svg = offlineSvg
     }
 
-    window.a11yText = accessibilityText
-
     return `
         <span class="icon">${svg}</span>
         <section role="text" aria-label="${accessibilityText}">${text}</section>

--- a/ArticleTemplates/assets/js/modules/premiumTaster.js
+++ b/ArticleTemplates/assets/js/modules/premiumTaster.js
@@ -57,20 +57,25 @@ function init() {
 function indicatorHtml(taster) {
     if (taster !== "adFree" && taster !== "offline") return "";
     let text = ""
+    let accessibilityText = ""
     let svg = ""
     if (taster === "adFree") {
         text = "Experiencing the app ad free is a Premium feature. As a new user you can enjoy it for <strong>free for one week.</strong>"
+        accessibilityText = "Experiencing the app ad-free is a Premium feature. As a new user you can enjoy it for free for one week."
         svg = adFreeSvg
     }
 
     if (taster === "offline") {
         text = "Enhanced offline reading is a Premium feature. As a new user you can enjoy it for <strong>free for one week.</strong>"
+        accessibilityText = "Enhanced off-line reeding is a Premium feature. As a new user you can enjoy it for free for one week."
         svg = offlineSvg
     }
 
+    window.a11yText = accessibilityText
+
     return `
         <span class="icon">${svg}</span>
-        ${text}
+        <section role="text" aria-label="${accessibilityText}">${text}</section>
         <button>OK</button>
     `
 }


### PR DESCRIPTION
Paired with @GiuliaAriu on this

The web premium taster indicators' accessibility was broken. This PR fixes it.