### PR TITLE
Remove border for dismiss button in premium taster explainers

### DIFF
--- a/ArticleTemplates/assets/scss/modules/_premium-taster.scss
+++ b/ArticleTemplates/assets/scss/modules/_premium-taster.scss
@@ -58,6 +58,7 @@
         position: absolute;
         bottom: -60px;
         font-weight: 700;
+        border-width: 0px;
 
         @include mq($to: mobileMedium) {
             padding: 8px 22px;


### PR DESCRIPTION
Native browser css on Android draws a 3D border around the dismiss button in premium taster card. This update explicitly sets border-width to zero to remove any border, in line with the designs.

| | Before | After |
| --- | --- | --- |
| No Ads |<img src="https://user-images.githubusercontent.com/2292388/100249207-36da1980-2f34-11eb-82fb-a14c9841b9c2.png" width="300px" />|<img src="https://user-images.githubusercontent.com/2292388/100249217-3a6da080-2f34-11eb-9458-1601b4a823bb.png" width="300px" />|
| Offline |<img src="https://user-images.githubusercontent.com/2292388/100249215-393c7380-2f34-11eb-9d6d-2923425538b7.png" width="300px" />|<img src="https://user-images.githubusercontent.com/2292388/100249221-3b063700-2f34-11eb-8e1b-3c815721be33.png" width="300px" />|
