### PR TITLE
Removed grey background-color from dark mode sponsorship logos

### DIFF
--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
@@ -176,7 +176,6 @@ figure[data-alt="Sign up to the daily Business Today email"] {
 }
 
 .sponsorship img {
-    background-color: $whiteTwo;
     padding: 8px;
 }
 
@@ -185,7 +184,7 @@ figure[data-alt="Sign up to the daily Business Today email"] {
     color: $whiteTwo;
     &::before {
         color: $warmGreyFour;
-    }    
+    }
 }
 
 .campaign--snippet {


### PR DESCRIPTION
## Removes grey background from sponsor logos in dark mode articles.


### Context:
I moved to dark-mode sponsor logos on fronts in an earlier pr in `android-news-app`. However, the grey background in articles prevented me from making the same change in articles.

This PR removes the grey background so that articles can also be switched to the dark-mode `altLogo` in `android-news-app`.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/34686302/112474028-ff0aa380-8d66-11eb-9bfb-386e8b12bf93.png) | ![image](https://user-images.githubusercontent.com/34686302/112474047-05008480-8d67-11eb-998f-de61b233a5af.png) |
