### PR TITLE
[LIVE-2137] Remove smooth scrolling animations

### DIFF
--- a/ArticleTemplates/assets/js/modules/quiz.js
+++ b/ArticleTemplates/assets/js/modules/quiz.js
@@ -465,8 +465,10 @@ function showScore() {
     initPositionPoller();
 
     // Scroll score panel into view
-    const scoresElement = document.getElementsByClassName('quiz-scores')[0]
-    scoresElement.scrollIntoView()
+    const scoresElement = document.getElementById('quiz-scores')
+    if (scoresElement !== undefined) {
+        scoresElement.scrollIntoView()
+    }
 }
 
 function showResult() {

--- a/ArticleTemplates/assets/js/modules/quiz.js
+++ b/ArticleTemplates/assets/js/modules/quiz.js
@@ -1,4 +1,3 @@
-import SmoothScroll from 'smooth-scroll';
 import { updateMPUPosition } from 'modules/ads';
 import { getStringFromUnicodeVal, getElementOffset } from 'modules/util';
 import { initPositionPoller } from 'modules/cards';
@@ -466,8 +465,8 @@ function showScore() {
     initPositionPoller();
 
     // Scroll score panel into view
-    const scroll = new SmoothScroll();
-    scroll.animateScroll('#quiz-scores', null, {speed: 1500, offset: 40});
+    const scoresElement = document.getElementsByClassName('quiz-scores')[0]
+    scoresElement.scrollIntoView()
 }
 
 function showResult() {

--- a/ArticleTemplates/assets/js/modules/util.js
+++ b/ArticleTemplates/assets/js/modules/util.js
@@ -1,5 +1,3 @@
-import SmoothScroll from 'smooth-scroll';
-
 function isElementPartiallyInViewport(el) {
     const rect = el.getBoundingClientRect();
     const windowHeight = (window.innerHeight || document.documentElement.clientHeight);
@@ -134,8 +132,7 @@ function getAndroidVersion() {
 }
 
 function scrollToElement(element) {
-    const scroll = new SmoothScroll();
-    scroll.animateScroll(element, { speed: 1500 });
+    element.scrollIntoView()
 }
 
 function isAdvertising() {

--- a/ArticleTemplates/simpleBodyTemplatePrepopHelpAndroid.html
+++ b/ArticleTemplates/simpleBodyTemplatePrepopHelpAndroid.html
@@ -135,13 +135,5 @@
 
         </div>
     </div>
-
-    <script type="text/javascript" src="__TEMPLATES_DIRECTORY__assets/build/smooth-scroll.min.js"></script>
-    <script type="text/javascript">
-        if (SmoothScroll) {
-            var smoothScroll = new SmoothScroll();
-            smoothScroll.init();
-        }
-    </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "fence": "git://github.com/guardian/fence",
     "intersection-observer": "^0.12.0",
     "raf": "^3.4.0",
-    "smooth-scroll": "^16.1.3",
     "d3-shape": "^2.0.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,10 +99,6 @@ module.exports = (env, argv) => {
           {
             from: './node_modules/classlist-polyfill/src/index.js',
             to: path.resolve(__dirname, 'ArticleTemplates/assets/build/classlist-polyfill'),
-          },
-          {
-            from: './node_modules/smooth-scroll/dist/smooth-scroll.polyfills.min.js',
-            to: path.resolve(__dirname, 'ArticleTemplates/assets/build'),
           }],
         }),
         new MiniCssExtractPlugin({


### PR DESCRIPTION
Users have written to us about the smooth scrolling animation we use (particularly for skipping to certain live blog blocks) being unsuitable.

Priscilla has confirmed we ought to remove this effect. This came through as an Android ticket, but I found it was actually a templates thing and thought I could probably fix it myself. I did a quick Google search and came up with using the built-in [`scrollIntoView`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) function.

This PR comprises two commits:

1. removes the smooth scroll animation from live blogs as the ticket requires
2. removes one other remaining use of the `smooth-scroll` dependency and that dependency itself.

Please check I've done (2) correctly, but I have built and run this branch locally and it all seems OK!

Jira ticket: https://theguardian.atlassian.net/browse/LIVE-2137

| Before | After |
| --- | --- |
|![before](https://user-images.githubusercontent.com/951849/113708230-e12f2e00-96d8-11eb-836e-21b5229693a4.gif)|![after](https://user-images.githubusercontent.com/951849/113708301-f5732b00-96d8-11eb-9b95-9e5b670e08de.gif)|

