### PR TITLE
Remove `smooth-scroll` From `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12916,11 +12916,6 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
-    "smooth-scroll": {
-      "version": "16.1.3",
-      "resolved": "https://registry.npmjs.org/smooth-scroll/-/smooth-scroll-16.1.3.tgz",
-      "integrity": "sha512-ca9U+neJS/cbdScTBuUTCZvUWNF2EuMCk7oAx3ImdeRK5FPm+xRo9XsVHIkeEVkn7MBRx+ufVEhyveM4ZhaTGA=="
-    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",


### PR DESCRIPTION
## Why?

It's no longer a dependency as of #1360.

## Changes

- Remove `smooth-scroll` from `package-lock.json`
