### PR TITLE
Live: 2399 - Dead contributor links not working with `cut_out image`-present

### DIFF
--- a/ArticleTemplates/assets/scss/modules/_cutout.scss
+++ b/ArticleTemplates/assets/scss/modules/_cutout.scss
@@ -42,6 +42,7 @@
     }
 
     .cutout__image {
+        pointer-events: none;
         background-repeat: no-repeat;
         background-position: bottom right;
         background-size: auto 160px;


### PR DESCRIPTION
Contributors Link not working specifically when a cut_out image is present on the comment article.

The `cutout_image` layer is in front of the `headline` tag and therefore not allowing us to click on the contributor anchor.
The cut out `<div>` is covering the whole top area.

- Finally decided to use `pointer-events:none`
- Adding css property pointer-events: none; to the #other-div will let clicks or other pointer-related events to pass through the div and reach both the canvas and the container


**_For Reference_**

1. Initial investigation:


| Cut_Image Layer with bg-color | Headline layer  and cut_out image with z-index of 100 |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/49187886/117962003-a727fc00-b316-11eb-913f-b881bddfbc3e.png" width="300px" />|<img src="https://user-images.githubusercontent.com/49187886/117962527-3af9c800-b317-11eb-9cef-d2d71e5c8a61.png" width="300px" />|

2. Initially amended z-index of cut_out image to 50 - however chose not to do this due to potential layer conflicts


| Amended z-index to 50 |
| --- | 
|<img src="https://user-images.githubusercontent.com/49187886/117963480-59ac8e80-b318-11eb-8661-002782542e54.png" width="300px" />|


- **Final Solution includes `pointer-events: none` (tested in xcode and android studio)**


| Opinion Article | Result of clicking contributor |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/49187886/117963974-f3743b80-b318-11eb-86a1-46fab2f08e0f.png" width="300px" />|<img src="https://user-images.githubusercontent.com/49187886/117964038-0ab32900-b319-11eb-856d-fb04416263dd.png" width="300px" />|
