### PR TITLE
Square Ads Only On Narrower Devices

### DIFF
--- a/ArticleTemplates/assets/scss/modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/modules/_advert-slot.scss
@@ -144,10 +144,14 @@
         }
     }
 
+    // The first ad slot is square on narrower breakpoints
     .advert-slot__wrapper--1 {
-        height: 324px;
-        margin-left: auto;
-        margin-right: auto;
+        @include mq($to: col3) {
+            height: 344px;
+            width: 320px;
+            margin-left: auto;
+            margin-right: auto;
+        }
     }
 
     .advert-slot__wrapper.test__banner {

--- a/ArticleTemplates/assets/scss/modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/modules/_advert-slot.scss
@@ -145,8 +145,7 @@
     }
 
     .advert-slot__wrapper--1 {
-        height: 344px;
-        width: 320px;
+        height: 324px;
         margin-left: auto;
         margin-right: auto;
     }


### PR DESCRIPTION
## Why?

We want to serve square ads on narrower devices, and rectangular ads on wider devices. This PR uses a media query to apply the square dimensions only on narrower breakpoints.

Will need confirmation from @ab-gnm @aoifemcl15 @petternitter on whether the chosen breakpoint to switch between the two sizes is correct.

## Changes

- Wrapped square ad CSS in a media query
