### PR TITLE
LIVE-2871: Remove white background and padding for interactive atoms

### DIFF
--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
@@ -131,13 +131,6 @@
         background-image: repeating-linear-gradient(to bottom, transparent, transparent calc(3.6rem - 1px), $whiteTwo);
     }
 
-    .interactive,
-    figure[data-atom-type="interactive"],
-    figure[data-atom-type="chart"] {
-        background-color: white;
-        padding: 8px;
-    }
-
     .element-embed {
         background-color: white;
         @include mq($to: col2) {

--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
@@ -131,6 +131,12 @@
         background-image: repeating-linear-gradient(to bottom, transparent, transparent calc(3.6rem - 1px), $whiteTwo);
     }
 
+    .interactive,
+    figure[data-atom-type="interactive"],
+    figure[data-atom-type="chart"] {
+        background-color: white;
+    }
+
     .element-embed {
         background-color: white;
         @include mq($to: col2) {


### PR DESCRIPTION
Removes padding on all interactive and chart atoms, but keeps the white background. As requested by the visuals team so they can roll out dark mode changes for interactive atoms. Padding will now be added into atoms themselves.

FYI @ajwl 

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/19835654/129373881-d83b1cb1-035e-49fa-a873-54da17c063fb.png" width="300px" />|<img src="https://user-images.githubusercontent.com/19835654/129373938-fea5a700-0db0-4c35-b5d3-f648bd440a94.png" width="300px" />|
