### PR TITLE
[LIVE-2684] Remove width constraint on first ad slot

### DIFF
--- a/ArticleTemplates/assets/scss/modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/modules/_advert-slot.scss
@@ -148,7 +148,6 @@
     .advert-slot__wrapper--1 {
         @include mq($to: col3) {
             height: 344px;
-            width: 320px;
             margin-left: auto;
             margin-right: auto;
         }


### PR DESCRIPTION
**Jira ticket**: https://theguardian.atlassian.net/browse/LIVE-2671

This change allows us to show non-square ads as full width on Android. The square ads are still limited by the container height specified here (344px) and the ratio constraints in the native code.

Need to confirm this change works for iOS.

| | Before | After |
| --- | --- | --- |
| Horizontal ad | ![Screenshot_20210816-180834](https://user-images.githubusercontent.com/79363218/129603112-b1fc1797-be7a-473f-9607-a566d43f3005.png)|![Screenshot_20210816-174643](https://user-images.githubusercontent.com/79363218/129603143-4518cf25-47c6-467e-b4e1-331804c0b536.png)|
| Square ad |![Screenshot_20210816-180711](https://user-images.githubusercontent.com/79363218/129603124-1414ff1f-db6b-4671-a629-d36454cc3de8.png)|![Screenshot_20210816-181225](https://user-images.githubusercontent.com/79363218/129603162-cb810117-c007-4a7b-96e1-c296c1b9c6bd.png)|
