### PR TITLE
Bump `d3` To `7.0.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6465,9 +6465,9 @@
       "dev": true
     },
     "d3": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.0.0.tgz",
-      "integrity": "sha512-t+jEKGO2jQiSBLJYYq6RFc500tsCeXBB4x41oQaSnZD3Som95nQrlw9XJGrFTMUOQOkwSMauWy9+8Tz1qm9UZw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.0.1.tgz",
+      "integrity": "sha512-74zonD4nAtxF9dtwFwJ3RuoHPh2D/UTFX26midBuMVH+7pRbOezuyLUIb8mbQMuYFlcUXT+xy++orCmnvMM/CA==",
       "requires": {
         "d3-array": "3",
         "d3-axis": "3",
@@ -6517,9 +6517,9 @@
       }
     },
     "d3-array": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.0.1.tgz",
-      "integrity": "sha512-l3Bh5o8RSoC3SBm5ix6ogaFW+J6rOUm42yOtZ2sQPCEvCqUMepeX7zgrlLLGIemxgOyo9s2CsWEidnLv5PwwRw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.0.2.tgz",
+      "integrity": "sha512-nTN4OC6ufZueotlexbxBd2z8xmG1eIfhvP2m1auH2ONps0L+AZn1r0JWuzMXZ6XgOj1VBOp7GGZmEs9NUFEBbA==",
       "requires": {
         "internmap": "1 - 2"
       }

--- a/package.json
+++ b/package.json
@@ -65,12 +65,12 @@
     "@babel/polyfill": "^7.4.4",
     "classlist-polyfill": "^1.2.0",
     "curl": "cujojs/curl#0.8.13",
-    "d3": "^7.0.0",
+    "d3": "^7.0.1",
+    "d3-shape": "^2.0.0",
     "domready": "^1.0.7",
     "fastclick": "^1.0.6",
     "fence": "git://github.com/guardian/fence",
     "intersection-observer": "^0.12.0",
-    "raf": "^3.4.0",
-    "d3-shape": "^2.0.0"
+    "raf": "^3.4.0"
   }
 }


### PR DESCRIPTION
## Why?

Keeping dependencies up-to-date.

## Changes

- Bump `d3` to `7.0.1`
