### PR TITLE
LIVE-2854: Make sure personality quizzes have the correct styling and work in dark mode

### DIFF
--- a/ArticleTemplates/assets/scss/modules/_quiz.scss
+++ b/ArticleTemplates/assets/scss/modules/_quiz.scss
@@ -423,7 +423,7 @@
             }
         }
 
-        // Personality quiz overrides
+        // Editorial personality quiz
         &.personality-quiz {
             .question__wrapper .question__text {
                 font-family: $egyptian-display;
@@ -496,66 +496,6 @@
                 background: color(brightness-93);
             }
         }
-
-        @media (prefers-color-scheme: dark) {
-            &.personality-quiz {
-                .question__wrapper .question__text {
-                    color: color(brightness-86);
-
-                    &::before {
-                        color: color(brightness-86);
-                    }
-                }
-
-                .question__answer .answer__text {
-                    color: color(brightness-86);
-                }
-
-                .question__answer {
-                    &.highlight-answer.answer .answer__wrapper,
-                    &.highlight-answer.answer.has-image {
-                        background-color: #707070;
-                    }
-
-                    &:not(.has-image) {
-                        .answer__text {
-                            color: color(brightness-86);
-                        }
-
-                        .answer__marker {
-                            border: 1px solid color(brightness-60);
-
-                            &::before {
-                                content: '';
-                            }
-                        }
-                    }
-                }
-
-                .question__answer {
-                    &.highlight-answer.answer .answer__marker__inner {
-                        opacity: 1;
-                        background: color(brightness-96);
-                    }
-
-                    &.highlight-answer.answer .answer__marker {
-                        border: 1px solid color(brightness-96);
-                    }
-
-                    &.highlight-answer.answer .answer__text {
-                        color: color(brightness-96);
-                    }
-                }
-
-                .question.answered .answer__wrapper {
-                    background: color(brightness-20);
-                }
-
-                .quiz-results__title .quiz-results__description {
-                    color: color(brightness-86);
-                }
-            }
-        }
     }
 }
 
@@ -590,71 +530,15 @@
                 .question__answer {
                     &.highlight-answer.answer .answer__wrapper,
                     &.highlight-answer.answer.has-image {
-                        background-color: color(brightness-86);
                         font-family: $guardian-sans;
                         font-size: 16px;
                         line-height: 20px;
+                        background-color: color(brightness-86);
                     }
                 }
-            }
 
-            @media (prefers-color-scheme: dark) {
-                &.personality-quiz {
-                    .question__wrapper .question__text {
-                        color: color(brightness-86);
-
-                        &::before {
-                            color: color(brightness-86);
-                        }
-                    }
-
-                    .question__answer .answer__text {
-                        color: color(brightness-86);
-                    }
-
-                    .question__answer {
-                        &.highlight-answer.answer .answer__wrapper,
-                        &.highlight-answer.answer.has-image {
-                            background-color: #707070;
-                        }
-
-                        &:not(.has-image) {
-                            .answer__text {
-                                color: color(brightness-86);
-                            }
-
-                            .answer__marker {
-                                border: 1px solid color(brightness-60);
-
-                                &::before {
-                                    content: '';
-                                }
-                            }
-                        }
-                    }
-
-                    .question__answer {
-                        &.highlight-answer.answer .answer__marker__inner {
-                            opacity: 1;
-                            background: color(brightness-96);
-                        }
-
-                        &.highlight-answer.answer .answer__marker {
-                            border: 1px solid color(brightness-96);
-                        }
-
-                        &.highlight-answer.answer .answer__text {
-                            color: color(brightness-96);
-                        }
-                    }
-
-                    .question.answered .answer__wrapper {
-                        background: color(brightness-20);
-                    }
-
-                    .quiz-results__title .quiz-results__description {
-                        color: color(brightness-86);
-                    }
+                .question.answered .answer__wrapper {
+                    background: color(brightness-93);
                 }
             }
         }

--- a/ArticleTemplates/assets/scss/modules/_quiz.scss
+++ b/ArticleTemplates/assets/scss/modules/_quiz.scss
@@ -425,10 +425,26 @@
 
         // Personality quiz overrides
         &.personality-quiz {
+            .question__wrapper .question__text {
+                font-family: $egyptian-display;
+                font-weight: 600;
+                font-size: 18px;
+                line-height: 21px;
+
+                &::before {
+                    content: counter(question-counter);
+                    font: 50px/1 $egyptian-display;
+                    left: 0;
+                    position: absolute;
+                    top: 3px;
+                    width: 60px;
+                }
+            }
+
             .question__answer {
                 &.highlight-answer.answer .answer__wrapper,
                 &.highlight-answer.answer.has-image {
-                    background-color: color(opinion-inverted);
+                    background-color: color(brightness-86);
                 }
 
                 &:not(.has-image) {
@@ -437,7 +453,7 @@
                     }
 
                     .answer__marker {
-                        border: 1px solid color(brightness-20);
+                        border: 1px solid color(brightness-60);
 
                         &::before {
                             content: '';
@@ -448,9 +464,9 @@
                         opacity: 0;
                         background: color(brightness-20);
                         border-radius: 50%;
-                        height: 20px;
-                        margin: 4px;
-                        width: 20px;
+                        height: 16px;
+                        margin: 5.5px;
+                        width: 16px;
                         z-index: 1;
                     }
                 }
@@ -461,6 +477,183 @@
 
                     .answer__marker {
                         display: none;
+                    }
+                }
+            }
+
+            .question__answer {
+                &.highlight-answer.answer .answer__marker__inner {
+                    opacity: 1;
+                    background: color(brightness-7);
+                }
+
+                &.highlight-answer.answer .answer__marker {
+                    border: 1px solid color(brightness-7);
+                }
+            }
+
+            .question.answered .answer__wrapper {
+                background: color(brightness-93);
+            }
+        }
+
+        @media (prefers-color-scheme: dark) {
+            &.personality-quiz {
+                .question__wrapper .question__text {
+                    color: color(brightness-86);
+
+                    &::before {
+                        color: color(brightness-86);
+                    }
+                }
+
+                .question__answer .answer__text {
+                    color: color(brightness-86);
+                }
+
+                .question__answer {
+                    &.highlight-answer.answer .answer__wrapper,
+                    &.highlight-answer.answer.has-image {
+                        background-color: #707070;
+                    }
+
+                    &:not(.has-image) {
+                        .answer__text {
+                            color: color(brightness-86);
+                        }
+
+                        .answer__marker {
+                            border: 1px solid color(brightness-60);
+
+                            &::before {
+                                content: '';
+                            }
+                        }
+                    }
+                }
+
+                .question__answer {
+                    &.highlight-answer.answer .answer__marker__inner {
+                        opacity: 1;
+                        background: color(brightness-96);
+                    }
+
+                    &.highlight-answer.answer .answer__marker {
+                        border: 1px solid color(brightness-96);
+                    }
+
+                    &.highlight-answer.answer .answer__text {
+                        color: color(brightness-96);
+                    }
+                }
+
+                .question.answered .answer__wrapper {
+                    background: color(brightness-20);
+                }
+
+                .quiz-results__title .quiz-results__description {
+                    color: color(brightness-86);
+                }
+            }
+        }
+    }
+}
+
+//labs personality quizzes
+.garnett--type-guardianlabs {
+    .element-atom {
+        .quiz {
+            &.personality-quiz {
+                .question__wrapper .question__text {
+                    font-family: $guardian-sans;
+                    font-weight: 700;
+                    font-size: 18px;
+                    line-height: 21px;
+
+                    &::before {
+                        content: counter(question-counter);
+                        font: 50px/1 $guardian-sans;
+                        left: 0;
+                        position: absolute;
+                        top: 3px;
+                        width: 60px;
+                    }
+                }
+
+                .question__answer .answer__text {
+                    font-family: $guardian-sans;
+                    font-weight: 400;
+                    font-size: 16px;
+                    line-height: 20px;
+                }
+
+                .question__answer {
+                    &.highlight-answer.answer .answer__wrapper,
+                    &.highlight-answer.answer.has-image {
+                        background-color: color(brightness-86);
+                        font-family: $guardian-sans;
+                        font-size: 16px;
+                        line-height: 20px;
+                    }
+                }
+            }
+
+            @media (prefers-color-scheme: dark) {
+                &.personality-quiz {
+                    .question__wrapper .question__text {
+                        color: color(brightness-86);
+
+                        &::before {
+                            color: color(brightness-86);
+                        }
+                    }
+
+                    .question__answer .answer__text {
+                        color: color(brightness-86);
+                    }
+
+                    .question__answer {
+                        &.highlight-answer.answer .answer__wrapper,
+                        &.highlight-answer.answer.has-image {
+                            background-color: #707070;
+                        }
+
+                        &:not(.has-image) {
+                            .answer__text {
+                                color: color(brightness-86);
+                            }
+
+                            .answer__marker {
+                                border: 1px solid color(brightness-60);
+
+                                &::before {
+                                    content: '';
+                                }
+                            }
+                        }
+                    }
+
+                    .question__answer {
+                        &.highlight-answer.answer .answer__marker__inner {
+                            opacity: 1;
+                            background: color(brightness-96);
+                        }
+
+                        &.highlight-answer.answer .answer__marker {
+                            border: 1px solid color(brightness-96);
+                        }
+
+                        &.highlight-answer.answer .answer__text {
+                            color: color(brightness-96);
+                        }
+                    }
+
+                    .question.answered .answer__wrapper {
+                        background: color(brightness-20);
+                    }
+
+                    .quiz-results__title .quiz-results__description {
+                        color: color(brightness-86);
                     }
                 }
             }

--- a/ArticleTemplates/assets/scss/pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/pillar/_colour.scss
@@ -341,8 +341,51 @@
                 background: $p-feature-headline;
                 color: $p-inverted;
             }
+
+            &.personality-quiz {
+                .question__wrapper {
+                    border-top: 2px solid color(brightness-7);
+                }
+
+                .question__text {
+                    &::before {
+                        color:  color(brightness-7);
+                    }
+                }
+
+                .quiz-scores,
+                .quiz-results {
+                    border-color: color(brightness-7);
+                    border-top: 2px solid color(brightness-7);
+                }
+            }
         }
     }
+
+    @media (prefers-color-scheme: dark) {
+        .element-atom {
+            .quiz {
+                &.personality-quiz {
+                    .question__wrapper {
+                        border-top: 2px solid #707070;
+                    }
+
+                    .question__text {
+                        &::before {
+                            color: #707070;
+                        }
+                    }
+
+                    .quiz-scores,
+                    .quiz-results {
+                        border-color: #707070;
+                        border-top: 2px solid #707070;
+                    }
+                }
+            }
+        }
+    }
+
     .prose, .article__header {
         .bullet {
             @include faux-bullet($color: $p-kicker, $right-space: 4px);

--- a/ArticleTemplates/assets/scss/pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/pillar/_colour.scss
@@ -386,6 +386,31 @@
         }
     }
 
+    //for android
+    .body .dark-mode-on {
+        .element-atom {
+            .quiz {
+                &.personality-quiz {
+                    .question__wrapper {
+                        border-top: 2px solid #707070;
+                    }
+
+                    .question__text {
+                        &::before {
+                            color: #707070;
+                        }
+                    }
+
+                    .quiz-scores,
+                    .quiz-results {
+                        border-color: #707070;
+                        border-top: 2px solid #707070;
+                    }
+                }
+            }
+        }
+    }
+
     .prose, .article__header {
         .bullet {
             @include faux-bullet($color: $p-kicker, $right-space: 4px);

--- a/ArticleTemplates/assets/scss/pillar/_colour.scss
+++ b/ArticleTemplates/assets/scss/pillar/_colour.scss
@@ -363,52 +363,12 @@
     }
 
     @media (prefers-color-scheme: dark) {
-        .element-atom {
-            .quiz {
-                &.personality-quiz {
-                    .question__wrapper {
-                        border-top: 2px solid #707070;
-                    }
-
-                    .question__text {
-                        &::before {
-                            color: #707070;
-                        }
-                    }
-
-                    .quiz-scores,
-                    .quiz-results {
-                        border-color: #707070;
-                        border-top: 2px solid #707070;
-                    }
-                }
-            }
-        }
+        @include personality-quiz-dark-mode;
     }
 
     //for android
     .body .dark-mode-on {
-        .element-atom {
-            .quiz {
-                &.personality-quiz {
-                    .question__wrapper {
-                        border-top: 2px solid #707070;
-                    }
-
-                    .question__text {
-                        &::before {
-                            color: #707070;
-                        }
-                    }
-
-                    .quiz-scores,
-                    .quiz-results {
-                        border-color: #707070;
-                        border-top: 2px solid #707070;
-                    }
-                }
-            }
-        }
+        @include personality-quiz-dark-mode;
     }
 
     .prose, .article__header {
@@ -425,6 +385,31 @@
         .article__header, .prose {
             ul > li, .bullet {
                 @include faux-bullet($color: color(brightness-60));
+            }
+        }
+    }
+}
+
+@mixin personality-quiz-dark-mode {
+    .element-atom {
+        .quiz {
+            &.personality-quiz {
+                .question__wrapper {
+                    border-top: 2px solid #707070;
+                }
+
+                .question__text {
+                    &::before {
+                        color: #707070;
+                    }
+                }
+
+                .quiz-scores,
+                .quiz-results {
+                    border-color: #707070;
+                    border-top: 2px solid #707070;
+                    color: color(brightness-86);
+                }
             }
         }
     }

--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeQuiz.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeQuiz.scss
@@ -64,65 +64,67 @@
 }
 
 @mixin darkModePersonalityQuiz($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3) {
-    //editorial personality quiz
-    &.personality-quiz {
-        .question__wrapper .question__text {
-            color: color(brightness-86);
-
-            &::before {
+    .element-atom .quiz {
+        //editorial personality quiz
+        &.personality-quiz {
+            .question__wrapper .question__text {
                 color: color(brightness-86);
-            }
-        }
 
-        .question__answer .answer__text {
-            color: color(brightness-86);
-        }
-
-        .question__answer {
-            &.highlight-answer.answer .answer__wrapper,
-            &.highlight-answer.answer.has-image {
-                background-color: #707070;
-            }
-
-            &:not(.has-image) {
-                .answer__text {
+                &::before {
                     color: color(brightness-86);
                 }
+            }
 
-                .answer__marker {
-                    border: 1px solid color(brightness-60);
+            .question__answer .answer__text {
+                color: color(brightness-86);
+            }
 
-                    &::before {
-                        content: '';
+            .question__answer {
+                &.highlight-answer.answer .answer__wrapper,
+                &.highlight-answer.answer.has-image {
+                    background-color: #707070;
+                }
+
+                &:not(.has-image) {
+                    .answer__text {
+                        color: color(brightness-86);
+                    }
+
+                    .answer__marker {
+                        border: 1px solid color(brightness-60);
+
+                        &::before {
+                            content: '';
+                        }
                     }
                 }
             }
-        }
 
-        .question__answer {
-            &.highlight-answer.answer .answer__marker__inner {
-                opacity: 1;
-                background: color(brightness-96);
+            .question__answer {
+                &.highlight-answer.answer .answer__marker__inner {
+                    opacity: 1;
+                    background: color(brightness-96);
+                }
+
+                &.highlight-answer.answer .answer__marker {
+                    border: 1px solid color(brightness-96);
+                }
+
+                &.highlight-answer.answer .answer__text {
+                    color: color(brightness-96);
+                }
             }
 
-            &.highlight-answer.answer .answer__marker {
-                border: 1px solid color(brightness-96);
+            .question.answered .answer__wrapper {
+                background: color(brightness-20);
             }
 
-            &.highlight-answer.answer .answer__text {
-                color: color(brightness-96);
+            .quiz-results__title .quiz-results__description {
+                color: color(brightness-86);
             }
-        }
-
-        .question.answered .answer__wrapper {
-            background: color(brightness-20);
-        }
-
-        .quiz-results__title .quiz-results__description {
-            color: color(brightness-86);
         }
     }
-    
+
     //labs personality quiz
     &.garnett--type-guardianlabs {
         .element-atom {

--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeQuiz.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeQuiz.scss
@@ -60,5 +60,131 @@
         .quiz-scores .quiz-scores__message {
             color: $whiteTwo;
         }
+
+        //editorial personality quiz
+        &.personality-quiz {
+            .question__wrapper .question__text {
+                color: color(brightness-86);
+
+                &::before {
+                    color: color(brightness-86);
+                }
+            }
+
+            .question__answer .answer__text {
+                color: color(brightness-86);
+            }
+
+            .question__answer {
+                &.highlight-answer.answer .answer__wrapper,
+                &.highlight-answer.answer.has-image {
+                    background-color: #707070;
+                }
+
+                &:not(.has-image) {
+                    .answer__text {
+                        color: color(brightness-86);
+                    }
+
+                    .answer__marker {
+                        border: 1px solid color(brightness-60);
+
+                        &::before {
+                            content: '';
+                        }
+                    }
+                }
+            }
+
+            .question__answer {
+                &.highlight-answer.answer .answer__marker__inner {
+                    opacity: 1;
+                    background: color(brightness-96);
+                }
+
+                &.highlight-answer.answer .answer__marker {
+                    border: 1px solid color(brightness-96);
+                }
+
+                &.highlight-answer.answer .answer__text {
+                    color: color(brightness-96);
+                }
+            }
+
+            .question.answered .answer__wrapper {
+                background: color(brightness-20);
+            }
+
+            .quiz-results__title .quiz-results__description {
+                color: color(brightness-86);
+            }
+        }
+    }
+}
+
+@mixin darkModePersonalityQuiz($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3) {
+    //labs personality quiz
+    &.garnett--type-guardianlabs {
+        .element-atom {
+            .quiz {
+                &.personality-quiz {
+                    .question__wrapper .question__text {
+                        color: color(brightness-86);
+
+                        &::before {
+                            color: color(brightness-86);
+                        }
+                    }
+
+                    .question__answer .answer__text {
+                        color: color(brightness-86);
+                    }
+
+                    .question__answer {
+                        &.highlight-answer.answer .answer__wrapper,
+                        &.highlight-answer.answer.has-image {
+                            background-color: #707070;
+                        }
+
+                        &:not(.has-image) {
+                            .answer__text {
+                                color: color(brightness-86);
+                            }
+
+                            .answer__marker {
+                                border: 1px solid color(brightness-60);
+
+                                &::before {
+                                    content: '';
+                                }
+                            }
+                        }
+                    }
+
+                    .question__answer {
+                        &.highlight-answer.answer .answer__marker__inner {
+                            opacity: 1;
+                            background: color(brightness-96);
+                        }
+
+                        &.highlight-answer.answer .answer__marker {
+                            border: 1px solid color(brightness-96);
+                        }
+
+                        &.highlight-answer.answer .answer__text {
+                            color: color(brightness-96);
+                        }
+                    }
+
+                    .question.answered .answer__wrapper {
+                        background: color(brightness-20);
+                    }
+
+                    .quiz-results__title .quiz-results__description {
+                        color: color(brightness-86);
+                    }
+                }
+            }
+        }
     }
 }

--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeQuiz.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeQuiz.scss
@@ -60,69 +60,69 @@
         .quiz-scores .quiz-scores__message {
             color: $whiteTwo;
         }
-
-        //editorial personality quiz
-        &.personality-quiz {
-            .question__wrapper .question__text {
-                color: color(brightness-86);
-
-                &::before {
-                    color: color(brightness-86);
-                }
-            }
-
-            .question__answer .answer__text {
-                color: color(brightness-86);
-            }
-
-            .question__answer {
-                &.highlight-answer.answer .answer__wrapper,
-                &.highlight-answer.answer.has-image {
-                    background-color: #707070;
-                }
-
-                &:not(.has-image) {
-                    .answer__text {
-                        color: color(brightness-86);
-                    }
-
-                    .answer__marker {
-                        border: 1px solid color(brightness-60);
-
-                        &::before {
-                            content: '';
-                        }
-                    }
-                }
-            }
-
-            .question__answer {
-                &.highlight-answer.answer .answer__marker__inner {
-                    opacity: 1;
-                    background: color(brightness-96);
-                }
-
-                &.highlight-answer.answer .answer__marker {
-                    border: 1px solid color(brightness-96);
-                }
-
-                &.highlight-answer.answer .answer__text {
-                    color: color(brightness-96);
-                }
-            }
-
-            .question.answered .answer__wrapper {
-                background: color(brightness-20);
-            }
-
-            .quiz-results__title .quiz-results__description {
-                color: color(brightness-86);
-            }
-        }
     }
 }
 
 @mixin darkModePersonalityQuiz($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3) {
+    //editorial personality quiz
+    &.personality-quiz {
+        .question__wrapper .question__text {
+            color: color(brightness-86);
+
+            &::before {
+                color: color(brightness-86);
+            }
+        }
+
+        .question__answer .answer__text {
+            color: color(brightness-86);
+        }
+
+        .question__answer {
+            &.highlight-answer.answer .answer__wrapper,
+            &.highlight-answer.answer.has-image {
+                background-color: #707070;
+            }
+
+            &:not(.has-image) {
+                .answer__text {
+                    color: color(brightness-86);
+                }
+
+                .answer__marker {
+                    border: 1px solid color(brightness-60);
+
+                    &::before {
+                        content: '';
+                    }
+                }
+            }
+        }
+
+        .question__answer {
+            &.highlight-answer.answer .answer__marker__inner {
+                opacity: 1;
+                background: color(brightness-96);
+            }
+
+            &.highlight-answer.answer .answer__marker {
+                border: 1px solid color(brightness-96);
+            }
+
+            &.highlight-answer.answer .answer__text {
+                color: color(brightness-96);
+            }
+        }
+
+        .question.answered .answer__wrapper {
+            background: color(brightness-20);
+        }
+
+        .quiz-results__title .quiz-results__description {
+            color: color(brightness-86);
+        }
+    }
+    
     //labs personality quiz
     &.garnett--type-guardianlabs {
         .element-atom {

--- a/ArticleTemplates/assets/scss/themes/darkMode/_main.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_main.scss
@@ -26,6 +26,7 @@
         @include darkModeImmersive($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeNumberedList($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeQuiz($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
+        @include darkModePersonalityQuiz($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeSpecialReport($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeGuardianLabs($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeRelatedContent($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
@@ -45,6 +46,7 @@
         @include darkModeImmersive($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeNumberedList($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeQuiz($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
+        @include darkModePersonalityQuiz($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeSpecialReport($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeGuardianLabs($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeLivePromo($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);


### PR DESCRIPTION
Some changes were requested to make personality quizzes work in dark mode for GLabs, this PR also makes sure the same is true for editorial. 

Based on these designs by @benwuersching: https://www.figma.com/file/00tb4ffXvbReLDmptMVrjx/Quiz-colours?node-id=1%3A679 

| GLabs Light Mode | GLabs Dark Mode |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/19835654/133433871-4729e807-3fb4-4695-8482-54475653da9b.png" width="300px" />|<img src="https://user-images.githubusercontent.com/19835654/133433974-22eea0f9-339b-4f19-abb3-06ff1dc4d271.png" width="300px" />|

| Editorial Light Mode | Editorial Dark Mode |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/19835654/133434088-bc215cfd-5aa6-4c6d-b4ea-98c583f5257a.png" width="300px" />|<img src="https://user-images.githubusercontent.com/19835654/133434150-d72d12e8-b30f-437c-aed4-7e6182b8b2ce.png" width="300px" />|
