### PR TITLE
Migrate From `git:` Protocol To `github:` Prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7856,8 +7856,8 @@
       }
     },
     "fence": {
-      "version": "git://github.com/guardian/fence.git#9448f9a059d3264dfe0b3f3465cbacb498b3ffe9",
-      "from": "git://github.com/guardian/fence.git"
+      "version": "github:guardian/fence#9448f9a059d3264dfe0b3f3465cbacb498b3ffe9",
+      "from": "github:guardian/fence"
     },
     "figgy-pudding": {
       "version": "3.5.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "d3-shape": "^3.0.1",
     "domready": "^1.0.7",
     "fastclick": "^1.0.6",
-    "fence": "github:guardian/fence",
+    "fence": "guardian/fence",
     "intersection-observer": "^0.12.0",
     "raf": "^3.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "d3-shape": "^3.0.1",
     "domready": "^1.0.7",
     "fastclick": "^1.0.6",
-    "fence": "git://github.com/guardian/fence",
+    "fence": "github:guardian/fence",
     "intersection-observer": "^0.12.0",
     "raf": "^3.4.0"
   }


### PR DESCRIPTION
## Why?

Github are deprecating the plain `git:` protocol. This switches to using the built-in GitHub support in npm instead.

- https://github.blog/2021-09-01-improving-git-protocol-security-github/
- https://docs.npmjs.com/cli/v6/configuring-npm/package-json#github-urls

## Changes

- Switch `guardian/fence` to npm's GitHub URL syntax over `git:` protocol
