### PR TITLE
LIVE-3161: Remove premium ads cta when showing labs content

### DIFF
--- a/ArticleTemplates/assets/scss/modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/modules/_advert-slot.scss
@@ -262,3 +262,7 @@
         }
     }
 }
+
+.garnett--type-guardianlabs .advert-slot__upgrade {
+    display: none;
+}


### PR DESCRIPTION
We don't want to show the premium upgrade banner on Guardian Labs pieces, as this is paid for content.

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/19835654/142417631-21ae92bb-82e7-4dd4-9277-3b29971dcba9.png" width="300px" />|<img src="https://user-images.githubusercontent.com/19835654/142417682-9797f5b7-89a7-4f91-b580-dca80559859a.png" width="300px" />|

Paired with @waisingyiu and @JamieB-gu 
