### PR TITLE
Add listener for email embed resize messages

### DIFF
--- a/ArticleTemplates/assets/js/boot.js
+++ b/ArticleTemplates/assets/js/boot.js
@@ -158,6 +158,37 @@ const init = opts => {
                 common.init();
             });
         }
+
+        const listenForEmailEmbedIFrameResize = () => {
+            const allIframes = [].slice.call(
+                document.querySelectorAll('.email-sub__iframe')
+            );
+            window.addEventListener('message', (event) => {
+                const iframes = allIframes.filter((i) => {
+                    try {
+                        return i.contentWindow === event.source;
+                    } catch (e) {
+                        return false;
+                    }
+                });
+                if (iframes.length !== 0) {
+                    try {
+                        const message = JSON.parse(event.data);
+                        switch (message.type) {
+                        case 'set-height':
+                            iframes.forEach((iframe) => {
+                                iframe.height = message.value;
+                            });
+                            break;
+                        default:
+                        }
+                        // eslint-disable-next-line no-empty
+                    } catch (e) {}
+                }
+            });
+        };
+
+        listenForEmailEmbedIFrameResize();
     };
 
     if (test) {

--- a/ArticleTemplates/assets/js/boot.js
+++ b/ArticleTemplates/assets/js/boot.js
@@ -158,45 +158,6 @@ const init = opts => {
                 common.init();
             });
         }
-
-        const listenForEmailEmbedIFrameResize = () => {
-            const allowedOrigins = ['https://www.theguardian.com'];
-
-            const allIframes = [].slice.call(
-                document.querySelectorAll('.email-sub__iframe')
-            );
-            window.addEventListener('message', (event) => {
-                if (!allowedOrigins.includes(event.origin)) return;
-
-                const iframes = allIframes.filter((i) => {
-                    try {
-                        return i.contentWindow === event.source;
-                    } catch (e) {
-                        return false;
-                    }
-                });
-                if (iframes.length !== 0) {
-                    try {
-                        const message = JSON.parse(event.data);
-                        switch (message.type) {
-                        case 'set-height': {
-                            const value = parseInt(message.value);
-                            if (!Number.isInteger(value)) return;
-
-                            iframes.forEach((iframe) => {
-                                iframe.height = `${value}`;
-                            });
-                            break;
-                        }
-                        default:
-                        }
-                        // eslint-disable-next-line no-empty
-                    } catch (e) {}
-                }
-            });
-        };
-
-        listenForEmailEmbedIFrameResize();
     };
 
     if (test) {

--- a/ArticleTemplates/assets/js/boot.js
+++ b/ArticleTemplates/assets/js/boot.js
@@ -179,11 +179,15 @@ const init = opts => {
                     try {
                         const message = JSON.parse(event.data);
                         switch (message.type) {
-                        case 'set-height':
+                        case 'set-height': {
+                            const value = parseInt(message.value);
+                            if (!Number.isInteger(value)) return;
+
                             iframes.forEach((iframe) => {
-                                iframe.height = message.value;
+                                iframe.height = value;
                             });
                             break;
+                        }
                         default:
                         }
                         // eslint-disable-next-line no-empty

--- a/ArticleTemplates/assets/js/boot.js
+++ b/ArticleTemplates/assets/js/boot.js
@@ -184,7 +184,7 @@ const init = opts => {
                             if (!Number.isInteger(value)) return;
 
                             iframes.forEach((iframe) => {
-                                iframe.height = value;
+                                iframe.height = `${value}`;
                             });
                             break;
                         }

--- a/ArticleTemplates/assets/js/boot.js
+++ b/ArticleTemplates/assets/js/boot.js
@@ -160,10 +160,14 @@ const init = opts => {
         }
 
         const listenForEmailEmbedIFrameResize = () => {
+            const allowedOrigins = ['https://www.theguardian.com/'];
+
             const allIframes = [].slice.call(
                 document.querySelectorAll('.email-sub__iframe')
             );
             window.addEventListener('message', (event) => {
+                if (!allowedOrigins.includes(event.origin)) return;
+
                 const iframes = allIframes.filter((i) => {
                     try {
                         return i.contentWindow === event.source;

--- a/ArticleTemplates/assets/js/boot.js
+++ b/ArticleTemplates/assets/js/boot.js
@@ -160,7 +160,7 @@ const init = opts => {
         }
 
         const listenForEmailEmbedIFrameResize = () => {
-            const allowedOrigins = ['https://www.theguardian.com/'];
+            const allowedOrigins = ['https://www.theguardian.com'];
 
             const allIframes = [].slice.call(
                 document.querySelectorAll('.email-sub__iframe')

--- a/ArticleTemplates/assets/js/bootstraps/common.js
+++ b/ArticleTemplates/assets/js/bootstraps/common.js
@@ -286,6 +286,7 @@ function loadEmbeds() {
 
     fixVineWidth();
     fixEmbedHeights();
+    listenForEmailEmbedIFrameResize();
 
     for (i = 0; i < fenceElems.length; i++) {
         render(fenceElems[i]);
@@ -321,6 +322,43 @@ function fixEmbedHeights() {
         iframe.setAttribute('height', '50px');
         iframe.style.marginTop = '12px';
     }
+}
+
+function listenForEmailEmbedIFrameResize() {
+    const allowedOrigins = ['https://www.theguardian.com'];
+
+    const allIframes = [].slice.call(
+        document.querySelectorAll('.email-sub__iframe')
+    );
+    window.addEventListener('message', (event) => {
+        if (!allowedOrigins.includes(event.origin)) return;
+
+        const iframes = allIframes.filter((i) => {
+            try {
+                return i.contentWindow === event.source;
+            } catch (e) {
+                return false;
+            }
+        });
+        if (iframes.length !== 0) {
+            try {
+                const message = JSON.parse(event.data);
+                switch (message.type) {
+                case 'set-height': {
+                    const value = parseInt(message.value);
+                    if (!Number.isInteger(value)) return;
+
+                    iframes.forEach((iframe) => {
+                        iframe.height = `${value}`;
+                    });
+                    break;
+                }
+                default:
+                }
+                // eslint-disable-next-line no-empty
+            } catch (e) {}
+        }
+    });
 }
 
 function loadInteractives(force) {


### PR DESCRIPTION
# What does this change do?

* Adds an event listener for `set-height` messages from email embed iframes
* Allows the email embed iframe to resize itself, such as to show a reCAPTCHA challenge