### PR TITLE
Check for null before comparing

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/common.js
+++ b/ArticleTemplates/assets/js/bootstraps/common.js
@@ -335,10 +335,11 @@ function listenForEmailEmbedIFrameResize() {
 
         const iframes = allIframes.filter((i) => {
             try {
-                return i.contentWindow === event.source;
+                if (i.contentWindow && event.source) return i.contentWindow === event.source;
             } catch (e) {
                 return false;
             }
+            return false;
         });
         if (iframes.length !== 0) {
             try {


### PR DESCRIPTION
`iframe.contentWindow` and `event.source` could be null. Check they are not null before checking for equality
