### PR TITLE
[LIVE-3944] Fix tablet now then interactives sizing bug

### DIFF
--- a/ArticleTemplates/assets/scss/layout/_article--shared.scss
+++ b/ArticleTemplates/assets/scss/layout/_article--shared.scss
@@ -52,7 +52,7 @@
         .element-interactive {
             width: auto;
 
-            // Needed to solve tablet bug in interactive-now-and-then-embed
+            // Prevents uneven sizes of now-and-then images in interactive embeds on Android tablets
             max-width: 570px;
 
             @include inverted-colors

--- a/ArticleTemplates/assets/scss/layout/_article--shared.scss
+++ b/ArticleTemplates/assets/scss/layout/_article--shared.scss
@@ -52,6 +52,9 @@
         .element-interactive {
             width: auto;
 
+            // Needed to solve tablet bug in interactive-now-and-then-embed
+            max-width: 570px;
+
             @include inverted-colors
         }
 


### PR DESCRIPTION
Fix bug in now and then interactive where on tablet the now photo is taller than the before photo and half the image is cropped (width ways).

The fix for this is very simple. By setting a max width of 570px for the interactives container, this prevents the container from reaching a width of 575px at which point something within the now/then interactive code causes the second image to have a width of 635px (about the width of the iFrame it is contained within). Because this is a max width is has no effect on devices with less wide displays/windows (e.g phones).

## Android Tablet
| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/3285072/161799932-73c849e5-053e-489b-81db-5ad491246c28.png" width="300px" />|<img src="https://user-images.githubusercontent.com/3285072/161799957-256dfc99-b2e0-46e3-b1df-0e2f4cd06f40.png" width="300px" />|

## Android Phone
| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/3285072/161802818-9ce5c5fb-59cb-405f-85f8-f421646abc7b.png" width="300px" />|<img src="https://user-images.githubusercontent.com/3285072/161802832-d5547534-d80d-46e1-a17e-8af2f83413ba.png" width="300px" />|

## After on Android Tablet and iOS Tablet
<img width="1295" alt="Screenshot 2022-04-12 at 16 47 06" src="https://user-images.githubusercontent.com/3285072/163007610-90cf95d0-2d74-4417-a191-b2c0aadfe16c.png">

