### PR TITLE
Migrate `fence` and `curl` dependencies from GitHub to `npm`

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/common.js
+++ b/ArticleTemplates/assets/js/bootstraps/common.js
@@ -1,5 +1,5 @@
 import { attach } from 'fastclick';
-import { render } from 'fence';
+import { render } from '@guardian/fence';
 import {
     getClosestParentWithTag,
     debounce,

--- a/package.json
+++ b/package.json
@@ -64,13 +64,13 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
+    "@guardian/fence": "^0.2.12",
     "classlist-polyfill": "^1.2.0",
     "curl": "cujojs/curl#0.8.13",
     "d3": "^7.1.0",
     "d3-shape": "^3.1.0",
     "domready": "^1.0.7",
     "fastclick": "^1.0.6",
-    "fence": "guardian/fence",
     "intersection-observer": "^0.12.0",
     "raf": "^3.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@babel/polyfill": "^7.4.4",
     "@guardian/fence": "^0.2.12",
     "classlist-polyfill": "^1.2.0",
-    "curl": "cujojs/curl#0.8.13",
+    "curl-amd": "^0.8.12",
     "d3": "^7.1.0",
     "d3-shape": "^3.1.0",
     "domready": "^1.0.7",

--- a/test/spec/unit/bootstraps/common.test.js
+++ b/test/spec/unit/bootstraps/common.test.js
@@ -1,6 +1,6 @@
 import { init, formatImages } from 'bootstraps/common';
 
-jest.mock('fence', () => {});
+jest.mock('@guardian/fence', () => {});
 
 function buildFigElem (opts) {
     let figElem = document.createElement('figure');

--- a/test/spec/unit/bootstraps/liveblog.test.js
+++ b/test/spec/unit/bootstraps/liveblog.test.js
@@ -5,7 +5,7 @@ import * as common from 'bootstraps/common';
 import * as creative from 'modules/creativeInjector';
 import * as relativeDates from 'modules/relativeDates';
 
-jest.mock('fence', () => {});
+jest.mock('@guardian/fence', () => {});
 
 describe('ArticleTemplates/assets/js/bootstraps/liveblog', function () {
     let container;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,7 +85,7 @@ module.exports = (env, argv) => {
         }),
         new CopyWebpackPlugin({
           patterns: [{
-            from: './node_modules/curl/dist/curl',
+            from: './node_modules/curl-amd/dist/curl',
             to: path.resolve(__dirname, 'ArticleTemplates/assets/build'),
           },
           {


### PR DESCRIPTION
The PR updates the existing `fence` and `curl` dependencies to be provided via `npm` instead of directly from Github.

#### Why

Something changed over the weekend so that Github now doesn't provide node dependencies without authenticated pulls. The ssh keys for `guardian-android` that we use on TeamCity aren't available inside the Docker container where the Android app is built. As a result, the build is unable to fetch the two dependencies that are provided from github - `fence` and `curl`. This is causing all Android builds to fail on TeamCity.

Moving to npm-hosted versions of these dependencies will help resolve the issue by removing the need for a gihub recognised ssh key inside the docker container.