### PR TITLE
Reduce height of immersive header background images

### DIFF
--- a/ArticleTemplates/articleTemplateImmersiveHeight.html
+++ b/ArticleTemplates/articleTemplateImmersiveHeight.html
@@ -1,1 +1,1 @@
-height: calc(100vh - __BODY_OFFSET_TOP__px);
+height: calc(90vh - __BODY_OFFSET_TOP__px);

--- a/ArticleTemplates/assets/js/modules/immersive.js
+++ b/ArticleTemplates/assets/js/modules/immersive.js
@@ -103,7 +103,7 @@ function onImmersiveScroll() {
 }
 
 function getImageHeight() {
-    const viewPortHeight = document.documentElement.clientHeight;
+    const viewPortHeight = document.documentElement.clientHeight * 0.9;
     const marginTop = document.body.style.marginTop.replace('px', '');
 
     return viewPortHeight - marginTop;


### PR DESCRIPTION
## Why

On web the height of immersive header background images was reduced (https://github.com/guardian/dotcom-rendering/pull/4671). This change ensures consistency across mobile too.

Note that, because of the top margin calculation, specifying 80vh in these templates resulted in a much reduced background image size. I thought specifying 90vh more closely matched the output in web.

## iOS

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/45561419/165104952-9e3ca535-545b-47c9-8ec5-cd15004f76b0.png" width="300px" />|<img src="https://user-images.githubusercontent.com/45561419/165102961-fded8723-b8f2-43fb-a701-0df501d576c0.png" width="300px" />|


## Android

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/45561419/165103989-f5c4dada-e5da-4213-a112-7dc5de37a110.png" width="300px" />|<img src="https://user-images.githubusercontent.com/45561419/165103130-b6915769-1064-4c1f-97ce-1f9792bed7b8.png" width="300px" />|