### PR TITLE
add blinking dot in liveblog kicker

### DIFF
--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeLiveblog.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeLiveblog.scss
@@ -18,6 +18,10 @@
                 background-color: $dark-1;
             }
 
+            .pulsing-dot {
+                color: $dark-3;
+            }
+
             .article-kicker__highlight a {
                 color: $dark-3;
             }

--- a/ArticleTemplates/assets/scss/type/_live.scss
+++ b/ArticleTemplates/assets/scss/type/_live.scss
@@ -36,6 +36,12 @@
             }
         }
 
+        @media (prefers-reduced-motion) {
+            .pulsing-dot {
+                animation-name: none;
+            }
+        }
+
         .article__header {
             color: color(brightness-100);
 

--- a/ArticleTemplates/assets/scss/type/_live.scss
+++ b/ArticleTemplates/assets/scss/type/_live.scss
@@ -1,8 +1,39 @@
+@keyframes pulse {
+    0% {
+        opacity: 1;
+    }
+    10% {
+        opacity: .25;
+    }
+    40% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 1;
+    }
+}
+
 .garnett--type-live {
-    &.is-live {
+    &.is-live{
         .alerts {
             margin: base-px(.5, 1, .5, -.15);
             border-color: rgba(color(tone-sandy-light), .5);
+        }
+
+        .pulsing-dot {
+            animation: pulse 1s infinite;
+            color: color(brightness-100);
+            &:before {
+                border-radius: 62.5rem;
+                display: inline-block;
+                position: relative;
+                background-color: currentColor;
+                width: 0.75em;
+                height: 0.75em;
+                content: '';
+                margin-right: 0.1875rem;
+                vertical-align: initial;
+            }
         }
 
         .article__header {

--- a/ArticleTemplates/liveblogTemplate.html
+++ b/ArticleTemplates/liveblogTemplate.html
@@ -37,6 +37,7 @@
                     <div class="article-kicker__copy">
                         <div class='article-kicker__section'>__SECTION__</div>
                         <div class='article-kicker__series'>
+                            <span class="pulsing-dot"></span>
                             <span class='article-kicker__highlight'>__SERIES__</span>
                         </div>
                     </div>


### PR DESCRIPTION
This PR adds a blinking dot to liveblogs article title section in order to better indicate to users the liveness on a live blog. 

The accessibility was also tested both in ios and android, and the blinking dot is with no pulsation when the motion/animation is switched off in the device accessibility setting. 

## ios light mode
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/15894063/165324166-b93a8a74-4a8d-4684-8b4d-1f9c35fedede.png) | ![ezgif-1-f22ab65e00](https://user-images.githubusercontent.com/15894063/165323720-5d1f8566-bdc8-49d0-8e20-d18351403800.gif) |

## ios dark mode
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/15894063/165354895-e71e5cf0-92ca-410f-9852-eabee9c0e889.png) | ![ezgif-2-0ed1b7ca31](https://user-images.githubusercontent.com/15894063/165354736-37526aa9-54c4-4f95-8c4b-73a198b961a1.gif) |

## android dark mode
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/15894063/165355150-3c222244-d928-47da-ba94-0293e754958a.png) | ![ezgif-2-6a0c2b35f3](https://user-images.githubusercontent.com/15894063/165355495-d14d6da8-da9c-4457-888c-e6e748b0916c.gif) |

## android light mode
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/15894063/165356065-9f96efb4-30c7-49fd-a684-43a359e48ba7.png) | ![ezgif-2-20b8a7edab](https://user-images.githubusercontent.com/15894063/165355912-c2e257f4-9182-4593-a5e4-987b7a4831db.gif) |






