### PR TITLE
Include newsletter designType in darkMode selectors

### DIFF
--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeArticle.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeArticle.scss
@@ -13,6 +13,7 @@
     &.garnett--type-recipe,
     &.garnett--type-quiz,
     &.garnett--type-media,
+    &.garnett--type-newsletter,
     &.tone--deadBlog {
         background-color: $blackThree;
 


### PR DESCRIPTION
We recently introduced a new designType for newsletter tone articles. Without including this designType in the legacy templates dark mode selectors the articles do not render as expected in dark mode.

This change is part of a set of changes required:
- the capi client has been updated with the correct set of designTypes https://github.com/guardian/content-api-scala-client/pull/352
- given the latest capi client has been published, it should be consumed by mobile-apps-api https://github.com/guardian/mobile-apps-api/pull/1899
- after mapi uses the latest capi client, newsletter tone articles rendered via legacy templates will include a `body` tag with class `garnett--type-newsletter`
- given the above has taken place and the expected class is included in the body tag, the latest legacy templates (this change) will render newsletter tone articles correctly in dark mode

Considering how `tone/newsletter-tone` articles will render:

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/45561419/165959073-504502e6-af2f-42d4-8e3c-a5c9d020fcf2.png" width="300px" /> | <img src="https://user-images.githubusercontent.com/45561419/165959289-3622f758-be46-4753-9930-5ccc152fd9bd.png" width="300px" /> |

