### PR TITLE
Fix text size disparity between legacy templates and AR

### DIFF
--- a/ArticleTemplates/assets/scss/base/_global.scss
+++ b/ArticleTemplates/assets/scss/base/_global.scss
@@ -5,6 +5,6 @@ html {
 }
 
 body {
-    font-size: 1.6em;
+    font-size: 1.7em;
     line-height: 1.5em;
 }


### PR DESCRIPTION
## What does this change
We had reports of a difference in the text size between articles rendered via AR compared to legacy templates. Given we're about to start asking people to pay for the app, this kind of difference isn't really acceptable.

We are updating the legacy templates to ensure the body text (`p` tags) font size matches that of AR articles. Readers can scale the font size on the apps so we need to ensure comparable font sizes across this range. 

On legacy templates the font size in the standfirst and byline do not scale. This feature was added for AR. This feature is not going to be back-ported to the legacy templates and so is excluded from this change.

The body text of AR articles resolve to the following font sizes:

| Smallest | Default | Largest |
| --- | --- | --- |
| 13.6px | 17px | 27.2px |

### Android

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/45561419/166900605-a85379e6-31d2-47b9-b16e-f922824efe59.png" width="300px" />|<img src="https://user-images.githubusercontent.com/45561419/166900685-8ad0f066-2e34-47f0-9849-868144c55c42.png" width="300px" />|

| --- | Before | After |
| --- | --- | --- |
| Smallest | 12.8px | 13.6px |
| Default | 16px | 17px |
| Largest | 25.6px | 27.2px |


### iOS

| Before | After |
| --- | --- |
|<img src="" />|<img src="" width="300px" />|

| --- | Before | After |
| --- | --- | --- |
| Smallest |  |  |
| Default | 16px | 17px |
| Largest |  |  |


