### PR TITLE
Bump `intersection-observer` Polyfill To 0.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7733,9 +7733,9 @@
       "dev": true
     },
     "intersection-observer": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.12.0.tgz",
-      "integrity": "sha512-2Vkz8z46Dv401zTWudDGwO7KiGHNDkMv417T5ItcNYfmvHR/1qCTVBO9vwH8zZmQ0WkA/1ARwpysR9bsnop4NQ=="
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.12.2.tgz",
+      "integrity": "sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg=="
     },
     "is-bigint": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "d3-shape": "^3.1.0",
     "domready": "^1.0.7",
     "fastclick": "^1.0.6",
-    "intersection-observer": "^0.12.0",
+    "intersection-observer": "^0.12.2",
     "raf": "^3.4.0"
   }
 }


### PR DESCRIPTION
## Why?

Keeps our dependencies up-to-date.
