### PR TITLE
LIVE:4733: Fix duplicate videos appearing on iOS

### DIFF
--- a/ArticleTemplates/assets/js/modules/youtube.js
+++ b/ArticleTemplates/assets/js/modules/youtube.js
@@ -53,7 +53,7 @@ function checkForVideos() {
         as it's preceeding sibling then we must report it's position to
         the native layer
     **/
-    sdkPlaceholders = Array.prototype.map.call(iframes, iframe => {
+    sdkPlaceholders = sdkPlaceholders.concat(Array.prototype.map.call(iframes, iframe => {
          if (isPreviousElementSDKPlaceholder(iframe)) {
             const previousElementSibling = iframe.previousElementSibling;
 
@@ -61,7 +61,7 @@ function checkForVideos() {
 
             return previousElementSibling;
          }
-    }).filter(Boolean).concat(sdkPlaceholders);
+    }).filter(Boolean));
 
     if (videos.length) {
         if (!scriptReady) {


### PR DESCRIPTION
This PR makes sure to concat the list of videos correctly, so when two videos appear with the said ID it renders the video in the correct position. 

The videos were being added to the beginning of the list rather than the end, and causing issues on render. The javascript did not know what position to render the video on the page and so appeared duplicated.

Here, we just make sure the concatenation of the list happens first, ensuring videos are appended in the correct order. So iOS can use the correct order of videos to show to the user. 

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/19835654/199222553-591c79dd-5f79-4d72-8bbf-e75e15febc5a.png" width="300px" />|<img src="https://user-images.githubusercontent.com/19835654/199222455-813c1ec4-415b-4000-85e3-3df4074d5a63.png" width="300px" />|
