### PR TITLE
LIVE-4578: ensure h2 elements are visible at larger font sizes

### DIFF
--- a/ArticleTemplates/assets/scss/modules/content/_prose.scss
+++ b/ArticleTemplates/assets/scss/modules/content/_prose.scss
@@ -165,7 +165,6 @@
         font-family: $egyptian-display;
         font-weight: 600;
         font-size: 1em;
-        overflow: hidden;
         text-overflow: ellipsis;
         margin: 0;
 


### PR DESCRIPTION
## Why are you doing this?

It has been reported that "when an associated reference or side bar is dropped in an article, particularly lists,  it overrides/erases the heading for the next item, so you may not have a clue what it's referring to"

This happens particularly at larger font sizes, and has been noticed on a number of articles by both CP and readers via User Help.

This PR attempts to ensure that headings (h2 elements) remain visible, even at larger font sizes.

NB: the default property for the `overflow` property is `visible`, so I'm assuming we're ok to simply remove the property entirely for elements prose > h2.


## Screenshots

### Android

Font size 6 (all h2s now visible):
| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/45561419/201365164-4fdcc7a8-2731-45a7-b1e8-075fd71f8e27.png" width="300px" />|<img src="https://user-images.githubusercontent.com/45561419/201365524-0ab926ba-d20d-4cd7-b626-fd5cc4c55e00.png" width="300px" />|

### iOS

Font size 6 (all h2s now visible)
| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/45561419/201993242-4b2ce8e6-272e-4c6b-b382-a99b4c0f403d.png" width="300px" />|<img src="https://user-images.githubusercontent.com/45561419/201997996-ab679c13-1ba6-427f-aeb4-28dae0177bca.png" width="300px" />|

