### PR TITLE
LIVE-4785: load documentary interactives

### DIFF
--- a/ArticleTemplates/interactiveTemplate.html
+++ b/ArticleTemplates/interactiveTemplate.html
@@ -20,8 +20,11 @@
 
     __BODY__
 
+    <!-- This is needed to ensure successful integration with interactive documentaries init script -->
+    <main></main>
+
     <script type="text/javascript">
-        GU.bootstrap.init({             
+        GU.bootstrap.init({
             asyncStylesFilename: "style-async",
             fontSize: "__FONT_SIZE__",
             platform: "__PLATFORM__",


### PR DESCRIPTION
## Why are we making this change?

Documentary interactives are not loading in the app (the content never loads and we are shown only the loading screen):

While we have a workaround for this (redirecting users to an equivalent "video" article) the experience isn't the best, either for the reader or our colleagues in CP/user help.

This change updates the template for interactives to ensure the initialisation scripts used by documentaries can be executed without error, resulting in the documentary successfully loading.

### Changes

When the documentary interactive attempts to load we can see the following error in the console:

<img width="1001" alt="Screenshot 2022-11-14 at 11 22 04" src="https://user-images.githubusercontent.com/45561419/201647848-6afc1ab4-db7b-46c4-ad0c-6fdca92a5c56.png">

^ I understand this to mean that we need to ensure an element exists before some function attempts to set an attribute.


This PR adds a new `main` element into the body of the interactive template. The reason for this is:
- the content type of the documentary interactives is `interactive`, therefore the interactive template is used to render content
- the body of the interactive template contains a script which runs an init script
- when the dom is ready we invoke a function that inits a common [bootstrap](https://github.com/guardian/mobile-apps-article-templates/blob/f64d78693e1a88ec7eb349031f7e5327579680c7/ArticleTemplates/assets/js/boot.js#L158)
- the common bootstrap executes successfully until the `loadInteractives` [function](https://github.com/guardian/mobile-apps-article-templates/blob/414a81167819d4aaccb83f3b2293a04671c50e97/ArticleTemplates/assets/js/bootstraps/common.js#L365)
- this init script invoked inside `loadInteractives` attempts to execute [boot.js](https://github.com/guardian/docs-interactive-template/blob/master/src/js/boot.js.tpl) for the documentaries interactive 
- the documentaries boot.js executes successfully until we try and execute [main.js](https://github.com/guardian/docs-interactive-template/blob/9f78a048abd5129dafa737c1ac964a201501aa20/src/js/main.js#L61)
- the script attempts to add an id to a `main` element, which currently doesn't exist in the dom
- after adding the main element to the body of the interactives template, the documentaries init function executes successfully.

For apps, it doesn't appear that the `main` element is actually used in the rendering of the article, so I'm not quite sure why this exists in the documentaries script, maybe it's needed in web.

## Screenshots

The screenshots below are for a single article but I tested this change with all documentaries previously flagged as broken:
https://www.theguardian.com/global/ng-interactive/2022/nov/10/climate-carnage-whose-job-is-it-to-save-the-planet-documentary
https://www.theguardian.com/world/ng-interactive/2022/sep/29/lady-of-the-gobi-trucking-coal-across-the-desert-to-china
https://www.theguardian.com/world/ng-interactive/2022/jun/22/one-good-song-can-do-more-than-5000-protests-the-queer-revolution-in-the-middle-east
https://www.theguardian.com/environment/ng-interactive/2021/dec/02/unsafe-passage-on-board-a-refugee-rescue-ship-racing-for-europe-guardian-documentary

Note that when searching for the documentary there are often 2 articles returned. The article with the video icon does not have contentType == "interactive", so loads in a different way. I made sure to test with the interactive article.

<img width="300px" alt="Screenshot 2022-11-14 at 11 12 45" src="https://user-images.githubusercontent.com/45561419/201646239-714c57d2-b023-4094-863d-5d83d91f3c05.png">

NB: after the page has loaded the video can be successfully played.

I also tested on a number of non-documentary interactives to ensure no regression/impact on other types of interactive article. Non-documentary interactives tested with this change:
- https://www.theguardian.com/global-development/ng-interactive/2022/jun/09/the-black-sea-blockade-mapping-the-impact-of-war-in-ukraine-on-the-worlds-food-supply-interactive
- https://www.theguardian.com/world/ng-interactive/2022/jun/01/100-days-of-war-in-ukraine-how-the-conflict-has-developed
- https://www.theguardian.com/business/2022/feb/03/in-numbers-britains-cost-of-living-crisis

### Android

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/45561419/201645353-d5b8cc80-8524-4710-9576-0a10bfdcc2d1.png" width="300px" />|<img src="https://user-images.githubusercontent.com/45561419/201644965-19aa0cb6-6dc4-470f-a15e-84878294032b.png" width="300px" />|

### iOS

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/45561419/201998847-addf403d-d71a-4619-843a-7e85815aab88.png" width="300px" />|<img src="https://user-images.githubusercontent.com/45561419/201999255-6576272d-1313-4eee-a204-0576b47557c0.png" width="300px" />|

