### PR TITLE
Fixed missing kicker in live blogs

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -111,7 +111,7 @@ function liveblogNewBlockDump() {
 }
 
 function decideKicker() {
-    if (document.getElementsByClassName('article-kicker__highlight') !== undefined) {
+    if (document.getElementsByClassName('article-kicker__highlight')[0] !== undefined) {
         if (document.getElementsByClassName('article-kicker__highlight')[0].innerHTML === '') {
             document.getElementsByClassName('article-kicker__highlight')[0].style.color = '#F09686';
             document.getElementsByClassName('article-kicker__highlight')[0].innerHTML = document.getElementsByClassName('article-kicker__section')[0].innerHTML;

--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -110,6 +110,13 @@ function liveblogNewBlockDump() {
     }
 }
 
+function decideKicker() {
+    if (document.getElementsByClassName('article-kicker__highlight')[0].innerHTML === '') {
+        document.getElementsByClassName('article-kicker__highlight')[0].style.color = '#F09686';
+        document.getElementsByClassName('article-kicker__highlight')[0].innerHTML = document.getElementsByClassName('article-kicker__section')[0].innerHTML;
+    }
+}
+
 function liveMore() {
     const liveMoreElem = document.getElementsByClassName('more--live-blogs')[0];
 
@@ -430,6 +437,7 @@ function init() {
     setupTryLive();
     initYoutube();
     setInterval(window.liveblogTime, 30000);
+    decideKicker();
 
     const articleBody = document.getElementsByClassName('article__body')[0];
 

--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -111,9 +111,11 @@ function liveblogNewBlockDump() {
 }
 
 function decideKicker() {
-    if (document.getElementsByClassName('article-kicker__highlight')[0].innerHTML === '') {
-        document.getElementsByClassName('article-kicker__highlight')[0].style.color = '#F09686';
-        document.getElementsByClassName('article-kicker__highlight')[0].innerHTML = document.getElementsByClassName('article-kicker__section')[0].innerHTML;
+    if (document.getElementsByClassName('article-kicker__highlight') !== undefined) {
+        if (document.getElementsByClassName('article-kicker__highlight')[0].innerHTML === '') {
+            document.getElementsByClassName('article-kicker__highlight')[0].style.color = '#F09686';
+            document.getElementsByClassName('article-kicker__highlight')[0].innerHTML = document.getElementsByClassName('article-kicker__section')[0].innerHTML;
+        }
     }
 }
 

--- a/ArticleTemplates/liveblogTemplate.html
+++ b/ArticleTemplates/liveblogTemplate.html
@@ -111,13 +111,6 @@
                 hasEpic: "__HAS_EPIC__" === "true"
             });
 
-            function decideKicker() {
-                if (document.getElementsByClassName('article-kicker__highlight')[0].innerHTML == "") {
-                    document.getElementsByClassName('article-kicker__highlight')[0].innerHTML = document.getElementsByClassName('article-kicker__section')[0].innerHTML
-                }
-            }
-            decideKicker();
-
         </script>
     </body>
 </html>

--- a/ArticleTemplates/liveblogTemplate.html
+++ b/ArticleTemplates/liveblogTemplate.html
@@ -110,6 +110,14 @@
                 atoms: atoms,
                 hasEpic: "__HAS_EPIC__" === "true"
             });
+
+            function decideKicker() {
+                if (document.getElementsByClassName('article-kicker__highlight')[0].innerHTML == "") {
+                    document.getElementsByClassName('article-kicker__highlight')[0].innerHTML = document.getElementsByClassName('article-kicker__section')[0].innerHTML
+                }
+            }
+            decideKicker();
+
         </script>
     </body>
 </html>


### PR DESCRIPTION
This fixes a bug where the kicker was missing from some live blogs. On line 41 in the` liveBlogTemplate.html` file we are displaying the `__SERIES__` as the kicker. The problem is, not every live blog will be part of a series. In these cases we need to revert to displaying the `__SECTION__` so that we are in line with the website. 

Jamie Byers has mentioned that there are some slightly more complicated rules around what to display as the "kicker" on Dotcom and therefore this change isn't necessarily "perfect". However, it should still cover the large majority of cases and will mean there is no more blank space where there should be a kicker. In any case, it probably isn't worth spending too much time on as the Apps Rendering rollout will make these templates obsolete in the near future. 

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/102960825/202247758-a2ece114-2ff4-45ec-a92a-9175598f4b6f.png" width="300px" />|<img src="https://user-images.githubusercontent.com/102960825/202247747-27e850ad-5e58-4ecd-9978-e40697b2789f.png" width="300px" />|
