### PR TITLE
Remove setting of colour

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/liveblog.js
+++ b/ArticleTemplates/assets/js/bootstraps/liveblog.js
@@ -113,7 +113,6 @@ function liveblogNewBlockDump() {
 function decideKicker() {
     if (document.getElementsByClassName('article-kicker__highlight')[0] !== undefined) {
         if (document.getElementsByClassName('article-kicker__highlight')[0].innerHTML === '') {
-            document.getElementsByClassName('article-kicker__highlight')[0].style.color = '#F09686';
             document.getElementsByClassName('article-kicker__highlight')[0].innerHTML = document.getElementsByClassName('article-kicker__section')[0].innerHTML;
         }
     }


### PR DESCRIPTION
A previous PR fixed the missing kicker in live blogs: https://github.com/guardian/mobile-apps-article-templates/pull/1604

However, it also introduced a bug where the kicker colour is now the wrong colour on pillars other than news. This is because the original PR assumed it is necessary to give the kicker a faded colour, when in fact the default on light mode is white anyway. This PR now brings it in line with default behaviour.

 The slight trade off here is that in dark mode the kicker will be slightly brighter than the headline text. This is probably better than a missing space where there should be a kicker, however. In any case, these templates are soon to be superseded by AR liveblogs so this is a somewhat temporary fix until they are in production. 

| Before | After | Dark mode |
| --- | --- | --- |
|<img src="https://user-images.githubusercontent.com/102960825/206444227-394d005f-433c-4186-9c7d-567ce84236de.png" width="300px" />|<img src="https://user-images.githubusercontent.com/102960825/206444238-96101d60-5281-4797-ab75-9282e12b2ab6.png" width="300px" />|<img src="https://user-images.githubusercontent.com/102960825/206445359-28def67b-825a-405e-be9e-67d9ec31cc9c.png" width="300px" />|
