### PR TITLE
Add main media image to football liveblogs

### DIFF
--- a/ArticleTemplates/footballTemplateLiveblog.html
+++ b/ArticleTemplates/footballTemplateLiveblog.html
@@ -12,9 +12,11 @@
                         <div class="meta__published__date"><span class="screen-readable" id="pubdate">Published: </span><span id="published-date">__PUBDATE__</span></div>
                     </div>
                 </div>
-            </div>            
+            </div>
         </div>
-
+        <div class="main-media main-media--hidden-caption">
+            __MAIN_MEDIA__
+        </div>
         __KEY_EVENTS__
 
         <div class="article__body article__body--liveblog">


### PR DESCRIPTION
This adds a main media image to football liveblogs, to match behaviour seen in standard liveblogs

Paired with @marjisound 

| Before | After |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/19835654/207299626-bed57ea2-3342-4d1b-a547-a66dd1836375.png" width="300px" />|<img src="https://user-images.githubusercontent.com/19835654/207299728-72e9f597-da08-4697-8084-81b12a68bbd8.png" width="300px" />|
