### PR TITLE
Callouts

### DIFF
--- a/ArticleTemplates/assets/js/article.js
+++ b/ArticleTemplates/assets/js/article.js
@@ -2,12 +2,14 @@ import { init as commonInit } from 'bootstraps/common';
 import { init as articleInit } from 'bootstraps/article';
 import { init as atomsInit } from 'bootstraps/atoms';
 import { init as campaignInit } from 'bootstraps/campaign';
+import { init as communityCalloutInit } from 'bootstraps/communityCallout';
 
 const init = () => {
     commonInit();
     articleInit();
     atomsInit();
     campaignInit();
+    communityCalloutInit();
 };
 
 export { init };

--- a/ArticleTemplates/assets/js/bootstraps/campaign.js
+++ b/ArticleTemplates/assets/js/bootstraps/campaign.js
@@ -5,7 +5,7 @@ import { POST } from 'modules/http';
 import { scrollToElement } from 'modules/util';
 
 const endpoint = GU.opts.campaignsUrl;
-
+const confirmationHtml = '<div class="success__container"><div class="success__icon"><svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M16 32C24.8366 32 32 24.8366 32 16C32 7.16344 24.8366 0 16 0C7.16344 0 0 7.16344 0 16C0 24.8366 7.16344 32 16 32ZM13.1636 19.435L9.53052 15.9642L8.25228 17.2425L12.5856 23.3091H13.3114L25.2403 10.9631L23.9273 9.68294L13.1636 19.435Z" fill="#22874D" /></svg></div><div class="success__header">Thank you!</div><div class="success__body">Your story has been submitted successfully. One of our journalists will be in touch if we wish to take your submission further.</div></div>';
 function init() {
     var campaign = document.querySelector('.campaign--snippet');
     if (campaign) {
@@ -77,7 +77,6 @@ function initCampaign(campaign) {
             results.map((result, index) => {
                 data[keys[index]] = result;
             })
-
             submit(data, campaign, form);
         }).catch(() => {
             displayFileError(campaign, form);
@@ -103,8 +102,7 @@ function hideOfflineMessage(campaign) {
 }
 
 function displayConfirmation(campaign, form) {
-    form.innerHTML = '<p>Thank you for your contribution</p>';
-    campaign.className += ' campaign--success';
+    form.innerHTML = confirmationHtml
     scrollToElement(campaign);
     resetAndCheckForVideos();
     initPositionPoller();

--- a/ArticleTemplates/assets/js/bootstraps/campaign.js
+++ b/ArticleTemplates/assets/js/bootstraps/campaign.js
@@ -69,8 +69,8 @@ function initCampaign(campaign) {
             } else if (e.value) {
                 o[e.name] = e.value;
             }
-            
-            return o;    
+
+            return o;
         }, {});
 
         Promise.all(promises).then(results => {
@@ -156,4 +156,4 @@ function enableButton(form) {
     button.textContent = 'Share with the Guardian';
 }
 
-export { init };
+export { init, initCampaign };

--- a/ArticleTemplates/assets/js/bootstraps/communityCallout.js
+++ b/ArticleTemplates/assets/js/bootstraps/communityCallout.js
@@ -68,8 +68,7 @@ function handleTabClick(tab, evt) {
 
 const onShare = async () => {
     const url = window.location.href;
-    console.log("url", url);
-    const title = document.querySelector(".calllout--snippet_title").innerHTML;
+    const title = document.querySelector(".callout--snippet_title").innerHTML;
     const formId = document.querySelector(".formId").value;
 
     if ("share" in navigator) {

--- a/ArticleTemplates/assets/js/bootstraps/communityCallout.js
+++ b/ArticleTemplates/assets/js/bootstraps/communityCallout.js
@@ -1,7 +1,8 @@
+import { initCampaign } from "./campaign";
+
 function init() {
     let i;
     var tabs = document.getElementsByClassName("tabButton");
-
     if (tabs) {
         for (i = 0; i < tabs.length; i++) {
             tabs[i].addEventListener(
@@ -13,6 +14,11 @@ function init() {
     document
         .querySelector(".share-link")
         .addEventListener("click", onShare.bind(null));
+
+    var callout = document.querySelector(".callout--container");
+    if (callout) {
+        initCampaign(callout);
+    }
 }
 
 function handleTabClick(tab, evt) {

--- a/ArticleTemplates/assets/js/bootstraps/communityCallout.js
+++ b/ArticleTemplates/assets/js/bootstraps/communityCallout.js
@@ -1,0 +1,89 @@
+function init() {
+    let i;
+    var tabs = document.getElementsByClassName("tabButton");
+
+    if (tabs) {
+        for (i = 0; i < tabs.length; i++) {
+            tabs[i].addEventListener(
+                "click",
+                handleTabClick.bind(null, tabs[i])
+            );
+        }
+    }
+    document
+        .querySelector(".share-link")
+        .addEventListener("click", onShare.bind(null));
+}
+
+function handleTabClick(tab, evt) {
+    const messageUs = document.querySelector(".messageTabBody");
+    const form = document.querySelector(".formTabBody");
+    const formTab = document.querySelector(".tabButtonTell");
+    const messageTab = document.querySelector(".tabButtonMessage");
+
+    messageUs.style.display = "flex";
+    if (evt.target.id === "messageTab") {
+        //set active tab color
+        tab.style.backgroundColor = "#F6F6F6";
+
+        // set inactive tab color
+        formTab.style.backgroundColor = "#DCDCDC";
+        //show line
+        formTab.style.borderBottom = "1px solid #999999";
+
+        //remove line from active tab
+        messageTab.style.borderBottomWidth = "0px";
+
+        //display body of active tab
+        messageUs.style.display = "flex";
+
+        // hide body of inactive tab
+        form.style.display = "none";
+    } else {
+        //set active tab color
+        tab.style.backgroundColor = "#F6F6F6";
+
+        // set inactive tab color
+        messageTab.style.backgroundColor = "#DCDCDC";
+
+        //show line
+        messageTab.style.borderBottom = "1px solid #999999";
+
+        //remove line from active tab
+        formTab.style.borderBottomWidth = "0px";
+
+        //display body of active tab
+        form.style.display = "block";
+
+        // hide body of inactive tab
+        messageUs.style.display = "none";
+    }
+}
+
+const onShare = async () => {
+    const url = window.location.href;
+    console.log("url", url);
+    const title = document.querySelector(".titleStyling").innerHTML;
+    const formId = document.querySelector(".formId").value;
+
+    if ("share" in navigator) {
+        const shareTitle = `Share your experience: ${title.innerHTML}`;
+
+        const shareText = `
+        I saw this callout in an article: ${url}#${formId}
+        You can share your story by using the form on this article, or by contacting the Guardian on WhatsApp, Signal or Telegram.`;
+
+        await navigator.share({
+            title: shareTitle,
+            text: shareText,
+        });
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), 3000);
+    } else if ("clipboard" in navigator) {
+        await navigator.clipboard.writeText(`${url}#${formId}`);
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), 3000);
+    }
+};
+
+export { init };

--- a/ArticleTemplates/assets/js/bootstraps/communityCallout.js
+++ b/ArticleTemplates/assets/js/bootstraps/communityCallout.js
@@ -2,7 +2,7 @@ import { initCampaign } from "./campaign";
 
 function init() {
     let i;
-    var tabs = document.getElementsByClassName("tabButton");
+    var tabs = document.getElementsByClassName("tab__button");
     if (tabs) {
         for (i = 0; i < tabs.length; i++) {
             tabs[i].addEventListener(
@@ -22,10 +22,10 @@ function init() {
 }
 
 function handleTabClick(tab, evt) {
-    const messageUs = document.querySelector(".messageTabBody");
-    const form = document.querySelector(".formTabBody");
-    const formTab = document.querySelector(".tabButtonTell");
-    const messageTab = document.querySelector(".tabButtonMessage");
+    const messageUs = document.querySelector(".message__body");
+    const form = document.querySelector(".form__body");
+    const formTab = document.querySelector(".tab__button--form");
+    const messageTab = document.querySelector(".tab__button--message");
 
     messageUs.style.display = "flex";
     if (evt.target.id === "messageTab") {
@@ -69,7 +69,7 @@ function handleTabClick(tab, evt) {
 const onShare = async () => {
     const url = window.location.href;
     console.log("url", url);
-    const title = document.querySelector(".titleStyling").innerHTML;
+    const title = document.querySelector(".calllout--snippet_title").innerHTML;
     const formId = document.querySelector(".formId").value;
 
     if ("share" in navigator) {

--- a/ArticleTemplates/assets/scss/base/_colour.scss
+++ b/ArticleTemplates/assets/scss/base/_colour.scss
@@ -98,7 +98,9 @@ $gu-colours: (
 
     tone-gallery-link: #5fa794,
 
-    brand400: #052962
+    brand400: #052962,
+    brand500: #0077b6
+
 );
 
 // Colour palette

--- a/ArticleTemplates/assets/scss/helpers/_mixins.scss
+++ b/ArticleTemplates/assets/scss/helpers/_mixins.scss
@@ -109,7 +109,7 @@ $meta-lead: 2.2rem;
 
 // Link Underline Style
 @mixin text-underline($color, $color-accent, $bottom-space: .15em) {
-    a:not(.video-URL, .social-URL) {
+    a:not(.video-URL, .contact-URL, .social-URL) {
         color: $color;
         text-decoration: none;
         padding-bottom: $bottom-space;
@@ -127,8 +127,8 @@ $meta-lead: 2.2rem;
         }
     }
 
-    a:not(.video-URL, .social-URL) a:active,
-    a:not(.video-URL, .social-URL):hover {
+    a:not(.video-URL, .contact-URL, .social-URL) a:active,
+    a:not(.video-URL, .contact-URL, .social-URL):hover {
         color: $color-accent;
         background-image: linear-gradient(to bottom, darken($color-accent, 6%) 0%, darken($color-accent, 6%) 100%);
     }

--- a/ArticleTemplates/assets/scss/helpers/_mixins.scss
+++ b/ArticleTemplates/assets/scss/helpers/_mixins.scss
@@ -109,7 +109,7 @@ $meta-lead: 2.2rem;
 
 // Link Underline Style
 @mixin text-underline($color, $color-accent, $bottom-space: .15em) {
-    a:not(.video-URL) {
+    a:not(.video-URL, .social-URL) {
         color: $color;
         text-decoration: none;
         padding-bottom: $bottom-space;
@@ -127,8 +127,8 @@ $meta-lead: 2.2rem;
         }
     }
 
-    a:not(.video-URL) a:active,
-    a:not(.video-URL):hover {
+    a:not(.video-URL, .social-URL) a:active,
+    a:not(.video-URL, .social-URL):hover {
         color: $color-accent;
         background-image: linear-gradient(to bottom, darken($color-accent, 6%) 0%, darken($color-accent, 6%) 100%);
     }

--- a/ArticleTemplates/assets/scss/modules/_callout.scss
+++ b/ArticleTemplates/assets/scss/modules/_callout.scss
@@ -3,66 +3,86 @@
     position: relative;
 }
 
+.callout--snippet_heading {
+    display: block;
+    font-family: $egyptian-display;
+    font-size: 20px;
+    font-weight: 700;
+    color: #0077b6;
+}
+
+.callout--snippet_title {
+    display: block;
+    font-family: $egyptian-display;
+    font-size: 20px;
+    font-weight: 500;
+}
+
+.callout__description {
+    font-family: $egyptian-text;
+    font-weight: 400;
+    font-size: 17px;
+}
 .callout--details {
     margin: 16px 0 36px;
     background: #f6f6f6;
     color: black;
     padding: 0 5px 6px;
     border-image: repeating-linear-gradient(
-            to bottom,
-            #dcdcdc,
-            #dcdcdc 1px,
-            transparent 1px,
-            transparent 4px
+        to bottom,
+        #dcdcdc,
+        #dcdcdc 1px,
+        transparent 1px,
+        transparent 4px
         )
         13;
-    border-top: 13px solid black;
-    position: relative;
-}
+        border-top: 13px solid black;
+        position: relative;
+    }
 
-.callout--snippet {
-    &.campaign--success form {
-        color: color(brightness-7);
-        padding: 8px 0px 10px 10px;
+    .callout--snippet {
+        &.campaign--success form {
+            color: color(brightness-7);
+            padding: 8px 0px 10px 10px;
+            p {
+                font-weight: 700;
+                font-family: $guardian-sans;
+            }
+        }
+    }
+
+    .campaign__error {
+        padding: 0 12px 24px 12px;
+        margin-top: -35px;
+        margin-bottom: 20px;
+        color: color(news-feature-headline);
+
         p {
-            font-weight: 700;
             font-family: $guardian-sans;
+            padding-top: 0;
         }
     }
-}
 
-.campaign__error {
-    padding: 0 12px 24px 12px;
-    margin-top: -35px;
-    margin-bottom: 20px;
-    color: color(news-feature-headline);
-
-    p {
+    p.campaign__info {
+        color: color(global-adv-shade-1);
         font-family: $guardian-sans;
-        padding-top: 0;
     }
-}
 
-p.campaign__info {
-    color: color(global-adv-shade-1);
-    font-family: $guardian-sans;
-}
+    .callout--snippet .form_submit button {
+        color: color(brightness-100);
+        background-color: color(news-kicker);
 
-.campaign--snippet .form_submit button {
-    color: color(brightness-100);
-    background-color: color(news-kicker);
-
-    &:enabled {
-        &:hover,
-        :active {
-            background-color: darken(color(news-kicker), 5%);
+        &:enabled {
+            &:hover,
+            :active {
+                background-color: darken(color(news-kicker), 5%);
+            }
         }
     }
-}
 
 /* SUMMARY */
 
-.campaign--snippet > summary {
+.callout--snippet > summary {
     outline: none;
     padding: 0;
     list-style: none;
@@ -74,7 +94,7 @@ p.campaign__info {
 
 /* FORM */
 
-.campaign--snippet form {
+.callout--snippet form {
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
@@ -89,7 +109,7 @@ p.campaign__info {
     }
 }
 
-.campaign--snippet .form_input {
+.callout--snippet .form_input {
     &:not(:first-child) {
         margin: 0 0 20px;
     }
@@ -149,7 +169,7 @@ p.campaign__info {
     }
 }
 
-.campaign--snippet .form_field {
+.callout--snippet .form_field {
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
@@ -194,7 +214,7 @@ p.campaign__info {
     justify-content: center;
 }
 
-.campaign--snippet .form_footer {
+.callout--snippet .form_footer {
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
@@ -242,53 +262,28 @@ summary:focus {
     outline: none;
 }
 
-.showLess,
-.showMore {
+.callout__toggle--isOpen,
+.callout__toggle--isClosed {
     align-items: center;
 }
 
-.showLess,
-details[open] > summary .showMore {
+.callout__toggle--isOpen,
+details[open] > summary .callout__toggle--isClosed {
     display: none;
 }
 
-.showMore,
-details[open] > summary .showLess {
+.callout__toggle--isClosed,
+details[open] > summary .callout__toggle--isOpen {
     display: flex;
     align-items: start;
     padding-top: 4px;
 }
-.titleStyling {
+.calllout--snippet_title {
     font-weight: "medium";
     margin: 0;
     line-height: 22px;
 }
-
-.plusStyling {
-
-    margin-top: 4px;
-    svg {
-        margin-right: 12px;
-        fill: white;
-    }
-}
-
-.minusStyling {
-    margin-right: 14px;
-    margin-bottom: 6px;
-    width: 30px;
-    fill: white;
-    height: 25px;
-    padding-left: 4px;
-}
-
-.atomTitleStyling {
-    display: block;
-    font-weight: 700;
-    color: #0077b6;
-}
-
-.showHideStyling {
+.callout__toggle {
     font-family: $guardian-sans;
     font-weight: 700;
     background: black;
@@ -304,17 +299,26 @@ details[open] > summary .showLess {
     margin: 0;
 }
 
-.bodyArea {
+.callout__toggle__svg {
+    margin-top: 4px;
+    svg {
+        margin-right: 12px;
+        fill: white;
+    }
+}
+
+
+.callout__body {
     height: auto;
     margin-bottom: 36px;
 }
 
-.shareContainer {
+.share__container {
     margin: 12px 0px;
     display: flex;
     flex-direction: row;
 }
-.shareIcon {
+.share__icon {
     border: 1px #0077b6 solid;
     height: 32px;
     width: 32px;
@@ -337,7 +341,7 @@ details[open] > summary .showLess {
     padding: 0px 8px;
 }
 
-.tabContainer {
+.tab__container {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -347,7 +351,7 @@ details[open] > summary .showLess {
     position: relative;
 }
 
-.tabContainer::before {
+.tab__container::before {
     content: "";
     display: block;
     width: 14px;
@@ -357,7 +361,7 @@ details[open] > summary .showLess {
     position: absolute;
     left: -5px;
 }
-.tabContainer::after {
+.tab__container::after {
     content: "";
     display: block;
     width: 14px;
@@ -368,7 +372,7 @@ details[open] > summary .showLess {
     right: -5px;
 }
 
-.tabButton {
+.tab__button {
     width: 100%;
     height: 65px;
     padding: 12px 0px;
@@ -381,21 +385,22 @@ details[open] > summary .showLess {
     font-weight: 700;
 }
 
-.tabButtonLeft {
+.tab__button--form {
     border-radius: 8px 0px 0px 0px;
     border-bottom-width: 0px;
 }
 
-.tabButtonRight {
+.tab__button--message {
     border-radius: 0px 8px 0px 0px;
     border-bottom: 1px solid #999999;
+    background-color: #DCDCDC;
 }
 
 .message {
     height: auto;
     display: flex;
 }
-.socialMessageButton {
+.form_submit__button {
     all: unset;
     cursor: pointer;
     margin: 6px 0px;
@@ -404,8 +409,8 @@ details[open] > summary .showLess {
     flex-direction: row;
     justify-content: center;
     align-items: center;
-    padding: 10px 20px;
-    width: 280px;
+    padding: 10px 24px;
+    width: 100%;
     height: 44px;
     background: #052962;
     border: 1px solid #052962;
@@ -419,16 +424,48 @@ details[open] > summary .showLess {
     }
 }
 
-.messageTabBody {
+.message__body {
     display: flex;
     flex-direction: column;
     align-items: center;
 }
 
-.termsAndConditionsStyles {
+.terms-and-conditions {
     margin-bottom: 16px;
 }
 
 .contact-URL {
-    @include text-underline(color(brand500), color(brand400));
+        color: #0077b6;
+        text-decoration: none;
+        padding-bottom: .15em;
+
+        // Underline via gradient background
+        background-image: linear-gradient(rgba(#0077b6, .33) 0%, rgba(#0077b6, .33) 100%);
+        background-repeat: repeat-x;
+        background-size: 1px 1px;
+        background-position: 0 bottom;
+
+        // Tweak position + thickness for high res (1.75x and up) displays
+        @media (-webkit-min-device-pixel-ratio: 1.75), (min-resolution: 168dpi) {
+            background-image: linear-gradient(rgba(#0077b6, .33) 0%, rgba(#0077b6, .33) 100%);
+            background-position: 0 93%;
+        }
+
+
+    a:active,
+    a:hover {
+        color: #052962;
+        background-image: linear-gradient(to bottom, darken(#052962, 6%) 0%, darken(#052962, 6%) 100%);
+    }
+
+}
+
+.form_option_row {
+    margin-bottom: 6px;
+    input {
+        margin-right: 6px;
+    }
+    label {
+        font-weight:500;
+    }
 }

--- a/ArticleTemplates/assets/scss/modules/_callout.scss
+++ b/ArticleTemplates/assets/scss/modules/_callout.scss
@@ -469,3 +469,24 @@ details[open] > summary .callout__toggle--isOpen {
         font-weight:500;
     }
 }
+
+.success__container {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 40px;
+  }
+  .success__icon {
+    padding: 8px 0px;
+  }
+  .success__header {
+    font-family: $egyptian-display;
+    font-weight: 700;
+    font-size: 20px;
+    line-height: 27px;
+  }
+  .success__body {
+    font-family: $guardian-sans;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 18.9px;
+  }

--- a/ArticleTemplates/assets/scss/modules/_callout.scss
+++ b/ArticleTemplates/assets/scss/modules/_callout.scss
@@ -1,0 +1,789 @@
+.campaign--snippet {
+    position: relative;
+    padding: 12px;
+    margin: 16px -10px 36px;
+
+    &:not([open]) .is-on,
+    &[open] .is-off {
+        display: none;
+    }
+
+    &[open] {
+        background: color(brightness-93);
+    }
+
+    p {
+        font-size: 14px;
+        line-height: 18px;
+        font-family: $guardian-sans;
+        font-weight: 400;
+        padding-top: 2px;
+    }
+
+    &.campaign--success form {
+        color: color(brightness-7);
+        padding: 8px 0px 10px 10px;
+        p {
+            font-weight: 700;
+            font-family: $guardian-sans;
+        }
+    }
+}
+
+.campaign__error {
+    padding: 0 12px 24px 12px;
+    margin-top: -35px;
+    margin-bottom: 20px;
+    color: color(news-feature-headline);
+
+    p {
+        font-family: $guardian-sans;
+        padding-top: 0;
+    }
+}
+
+p.campaign__info {
+    color: color(global-adv-shade-1);
+    font-family: $guardian-sans;
+}
+
+.campaign--snippet .form_submit button {
+    color: color(brightness-100);
+    background-color: color(news-kicker);
+
+    &:enabled {
+        &:hover,
+        :active {
+            background-color: darken(color(news-kicker), 5%);
+        }
+
+        .garnett--pillar-news & {
+            &:hover,
+            &:active {
+                background-color: darken(color(news-kicker), 5%);
+            }
+        }
+
+        .garnett--pillar-sport & {
+            &:hover,
+            &:active {
+                background-color: darken(color(sport-feature-headline), 5%);
+            }
+        }
+
+        .garnett--pillar-opinion & {
+            &:hover,
+            &:active {
+                background-color: darken(color(opinion-feature-headline), 5%);
+            }
+        }
+
+        .garnett--pillar-arts & {
+            &:hover,
+            &:active {
+                background-color: darken(color(arts-feature-headline), 5%);
+            }
+        }
+
+        .garnett--pillar-lifestyle & {
+            &:hover,
+            &:active {
+                background-color: darken(color(lifestyle-kicker), 5%);
+            }
+        }
+    }
+
+    &:disabled {
+        .garnett--pillar-news & {
+            background-color: lighten(color(news-kicker), 5%);
+        }
+
+        .garnett--pillar-sport & {
+            background-color: lighten(color(sport-feature-headline), 5%);
+        }
+
+        .garnett--pillar-opinion & {
+            background-color: lighten(color(opinion-feature-headline), 5%);
+        }
+
+        .garnett--pillar-arts & {
+            background-color: lighten(color(arts-feature-headline), 5%);
+        }
+
+        .garnett--pillar-lifestyle & {
+            background-color: lighten(color(lifestyle-kicker), 5%);
+        }
+    }
+
+    .garnett--pillar-news & {
+        color: color(brightness-100);
+        background-color: color(news-kicker);
+    }
+
+    .garnett--pillar-sport & {
+        color: color(brightness-100);
+        background-color: color(sport-feature-headline);
+    }
+
+    .garnett--pillar-opinion & {
+        color: color(brightness-100);
+        background-color: color(opinion-feature-headline);
+    }
+
+    .garnett--pillar-arts & {
+        color: color(brightness-100);
+        background-color: color(arts-feature-headline);
+    }
+
+    .garnett--pillar-lifestyle & {
+        color: color(brightness-100);
+        background-color: color(lifestyle-kicker);
+    }
+}
+
+.campaign--snippet__handle {
+    color: color(brightness-100);
+    background-color: color(brightness-7);
+
+    &:hover,
+    :active {
+        color: color(brightness-7);
+        .icon {
+            fill: color(brightness-7);
+        }
+    }
+
+    .garnett--pillar-news & {
+        &:hover,
+        :active {
+            color: color(brightness-100);
+            background-color: color(news-kicker);
+            .icon {
+                fill: color(brightness-100);
+            }
+        }
+    }
+
+    .garnett--pillar-sport & {
+        &:hover,
+        :active {
+            color: color(brightness-100);
+            background-color: color(sport-feature-headline);
+            .icon {
+                fill: color(brightness-100);
+            }
+        }
+    }
+
+    .garnett--pillar-opinion & {
+        &:hover,
+        :active {
+            color: color(brightness-100);
+            background-color: color(opinion-feature-headline);
+            .icon {
+                fill: color(brightness-100);
+            }
+        }
+    }
+
+    .garnett--pillar-arts & {
+        &:hover,
+        :active {
+            color: color(brightness-100);
+            background-color: color(arts-feature-headline);
+
+            .icon {
+                fill: color(brightness-100);
+            }
+        }
+    }
+
+    .garnett--pillar-lifestyle & {
+        &:hover,
+        :active {
+            color: color(brightness-100);
+            background-color: color(lifestyle-kicker);
+            .icon {
+                fill: color(brightness-100);
+            }
+        }
+    }
+}
+
+/* SUMMARY */
+
+.campaign--snippet > summary {
+    outline: none;
+    padding: 0;
+    list-style: none;
+
+    &::-webkit-details-marker {
+        display: none;
+    }
+
+    .campaign--kicker {
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-box-orient: horizontal;
+        -webkit-box-direction: normal;
+        -ms-flex-direction: row;
+        flex-direction: row;
+
+        .heading {
+            margin-right: 10px;
+        }
+
+        > .campaign--snippet__heading-logo {
+            -webkit-box-flex: initial;
+            -ms-flex: initial;
+            flex: initial;
+            margin-right: 10px;
+
+            .speech-bubble {
+                color: color(brightness-7);
+                background-color: color(tone-highlight);
+                padding: 6px 10px 10px;
+                line-height: 18px;
+                min-width: 84px;
+
+                &::after {
+                    color: color(brightness-7);
+                    background-color: color(tone-highlight);
+                }
+
+                .garnett--pillar-news & {
+                    color: color(brightness-100);
+                    background-color: color(news-kicker);
+                    &::after {
+                        color: color(brightness-100);
+                        background-color: color(news-kicker);
+                    }
+                }
+
+                .garnett--pillar-sport & {
+                    color: color(brightness-100);
+                    background-color: color(sport-feature-headline);
+                    &::after {
+                        color: color(brightness-100);
+                        background-color: color(sport-feature-headline);
+                    }
+                }
+
+                .garnett--pillar-opinion & {
+                    color: color(brightness-100);
+                    background-color: color(opinion-feature-headline);
+                    &::after {
+                        background-color: color(opinion-feature-headline);
+                    }
+                }
+
+                .garnett--pillar-arts & {
+                    color: color(brightness-100);
+                    background-color: color(arts-feature-headline);
+                    &::after {
+                        background-color: color(arts-feature-headline);
+                    }
+                }
+
+                .garnett--pillar-lifestyle & {
+                    color: color(brightness-100);
+                    background-color: color(lifestyle-kicker);
+                    &::after {
+                        background-color: color(lifestyle-kicker);
+                    }
+                }
+            }
+        }
+    }
+}
+
+.campaign--snippet__header {
+    margin: 0 0 6px;
+}
+
+.campaign--snippet__headline {
+    font-size: 18px;
+    line-height: 22px;
+    font-family: $guardian-sans;
+    font-weight: 500;
+    padding-top: 1px;
+}
+
+.campaign--snippet__heading-logo {
+    font-size: 18px;
+    font-family: $guardian-sans;
+    font-weight: 500;
+}
+
+.campaign--snippet__handle {
+    font-family: $guardian-sans;
+    font-size: 13px;
+    font-weight: bold;
+    position: absolute;
+    bottom: 0;
+    -webkit-transform: translate(0, 50%);
+    -ms-transform: translate(0, 50%);
+    transform: translate(0, 50%);
+    padding: 3px 15px 0 6px;
+    margin-left: 5px;
+    span {
+        display: -webkit-inline-box;
+        display: -ms-inline-flexbox;
+        display: inline-flex;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+    }
+    .icon {
+        fill: color(brightness-100);
+        width: 16px;
+        height: 16px;
+        margin: -3px 6px 0 4px;
+    }
+}
+
+.campaign__button--rounded {
+    border-radius: 100em;
+}
+.campaign__button--large {
+    height: 2.25em;
+}
+
+.campaign__button {
+    display: -webkit-inline-box;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    border: 0;
+    margin: 0 0 0 10px;
+
+    svg:not(:root) {
+        overflow: hidden;
+    }
+}
+
+.garnett--pillar-news .campaign--snippet__handle:focus {
+    background-color: color(news-kicker);
+}
+
+.speech-bubble {
+    position: relative;
+
+    &::after {
+        content: "";
+        width: 20px;
+        height: 22px;
+        border-radius: 0 0 18px;
+        position: absolute;
+        bottom: -12px;
+        left: 10px;
+    }
+}
+
+/* FORM */
+
+.campaign--snippet form {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
+    flex-direction: column;
+
+    [type="radio"],
+    [type="checkbox"] {
+        margin-left: 0;
+    }
+}
+
+.campaign--snippet .form_input {
+    &:not(:first-child) {
+        margin: 0 0 20px;
+    }
+    &.form_input--radio .form_field,
+    &.form_input--checkbox .form_field {
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        label {
+            -webkit-box-flex: initial;
+            -ms-flex: initial;
+            flex: initial;
+        }
+        input {
+            -webkit-box-flex: initial;
+            -ms-flex: initial;
+            flex: initial;
+            margin: 2px 4px 0 13px;
+            min-width: 16px;
+        }
+    }
+
+    textarea {
+        max-width: 100%;
+        min-height: 80px;
+    }
+
+    .form_option_container {
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: flex;
+        padding-right: 10px;
+
+        label {
+            -webkit-box-flex: initial;
+            -ms-flex: initial;
+            flex: initial;
+            margin: 2px 0 0 4px;
+            font-size: 14px;
+            line-height: 18px;
+            font-weight: 400;
+            font-family: $guardian-sans;
+        }
+    }
+}
+
+.form_field {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 16px;
+    label {
+        font-weight: 700;
+    }
+}
+
+.campaign--snippet .form_field {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
+    flex-direction: column;
+
+    input {
+        -ms-flex-item-align: stretch;
+        -ms-grid-row-align: stretch;
+        align-self: stretch;
+        padding: 10px 0 10px 4px;
+    }
+
+    input,
+    select,
+    textarea {
+        border: 1px solid #707070;
+        font-family: $guardian-sans;
+        font-size: 14px;
+        line-height: 20px;
+        margin: 0 10px;
+    }
+
+    .form_field_label {
+        margin: 1px 0 6px 3px;
+        padding: 0 10px;
+        font-size: 16px;
+        line-height: 20px;
+        font-weight: 700;
+        font-family: $guardian-sans;
+
+        span {
+            font-weight: 200;
+            margin-right: 10px;
+        }
+    }
+}
+.form_footer {
+    display: flex;
+    justify-content: center;
+}
+
+.campaign--snippet .form_footer {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: row;
+    flex-direction: row;
+    // border-top: 1px color(brightness-86) solid;
+    padding-right: 12px;
+    display: flex;
+    justify-content: center;
+
+    .form_submit {
+        -webkit-box-flex: 1;
+        -ms-flex: auto;
+        flex: auto;
+        padding: 4px 0 40px 10px;
+        .button {
+            padding: 6px 16px;
+            border: 0;
+        }
+    }
+
+    .t_and_c {
+        -webkit-box-flex: 1;
+        -ms-flex: auto;
+        flex: auto;
+        text-align: right;
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: flex;
+        font-family: $guardian-sans;
+        font-size: 12px;
+
+        a {
+            -webkit-box-flex: 1;
+            -ms-flex: auto;
+            flex: auto;
+            color: color(brightness-7);
+            margin: 8px 0 0;
+            background-image: none !important;
+        }
+    }
+}
+
+.form_field_description {
+    color: #707070;
+}
+
+input[type="file"]::file-selector-button {
+    margin-top: 10px;
+    background-color: white;
+    border: black 1px solid;
+    font-family: $guardian-sans;
+    font-weight: 700;
+    color: black;
+}
+
+.containerStyling {
+    display: block;
+    position: relative;
+}
+
+.detailStyling {
+    margin: 16px 0 36px;
+    background: #f6f6f6;
+    color: black;
+    padding: 0 5px 6px;
+    border-image: repeating-linear-gradient(
+            to bottom,
+            #dcdcdc,
+            #dcdcdc 1px,
+            transparent 1px,
+            transparent 4px
+        )
+        13;
+    border-top: 13px solid black;
+    position: relative;
+}
+
+summary {
+    list-style: none;
+    margin: 0 0 16px;
+}
+summary::-webkit-details-marker {
+    display: none;
+}
+summary:focus {
+    outline: none;
+}
+
+.showLess,
+.showMore {
+    align-items: center;
+}
+
+.showLess,
+details[open] > summary .showMore {
+    display: none;
+}
+
+.showMore,
+details[open] > summary .showLess {
+    display: flex;
+    align-items: start;
+    padding-top: 4px;
+}
+.titleStyling {
+    font-weight: "medium";
+    margin: 0;
+    line-height: 22px;
+}
+
+.plusStyling {
+
+    margin-top: 4px;
+    svg {
+        margin-right: 12px;
+        fill: white;
+    }
+}
+
+.minusStyling {
+    margin-right: 14px;
+    margin-bottom: 6px;
+    width: 30px;
+    fill: white;
+    height: 25px;
+    padding-left: 4px;
+}
+
+.atomTitleStyling {
+    display: block;
+    font-weight: 700;
+    color: #0077b6;
+}
+
+.showHideStyling {
+    font-family: $guardian-sans;
+    font-weight: 700;
+    background: black;
+    color: white;
+    height: 33px;
+    position: absolute;
+    bottom: 0;
+    transform: translate(0, 50%);
+    padding: 0 18px;
+    border-radius: 100em;
+    cursor: pointer;
+    border: 0;
+    margin: 0;
+}
+
+.bodyArea {
+    height: auto;
+    margin-bottom: 36px;
+}
+
+.shareContainer {
+    margin: 12px 0px;
+    display: flex;
+    flex-direction: row;
+}
+.shareIcon {
+    border: 1px #0077b6 solid;
+    height: 32px;
+    width: 32px;
+    border-radius: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 10px;
+    flex-shrink: 0;
+
+    svg {
+        height: 16px;
+        width: 16px;
+        fill: #0077b6;
+    }
+}
+
+.tab,
+.message {
+    padding: 0px 8px;
+}
+
+.tabContainer {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 16px;
+    padding: 0px 8px;
+    position: relative;
+}
+
+.tabContainer::before {
+    content: "";
+    display: block;
+    width: 14px;
+    height: 1px;
+    background-color: #999999;
+    bottom: 0;
+    position: absolute;
+    left: -5px;
+}
+.tabContainer::after {
+    content: "";
+    display: block;
+    width: 14px;
+    height: 1px;
+    background-color: #999999;
+    bottom: 0;
+    position: absolute;
+    right: -5px;
+}
+
+.tabButton {
+    width: 100%;
+    height: 65px;
+    padding: 12px 0px;
+    gap: 10px;
+    background: #f6f6f6;
+    border-left: 1px solid #999999;
+    border-top: 1px solid #999999;
+    border-right: 1px solid #999999;
+    font-family: $guardian-sans;
+    font-weight: 700;
+}
+
+.tabButtonLeft {
+    border-radius: 8px 0px 0px 0px;
+    border-bottom-width: 0px;
+}
+
+.tabButtonRight {
+    border-radius: 0px 8px 0px 0px;
+    border-bottom: 1px solid #999999;
+}
+
+.message {
+    height: auto;
+    display: flex;
+}
+.socialMessageButton {
+    all: unset;
+    cursor: pointer;
+    margin: 6px 0px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    padding: 10px 20px;
+    width: 280px;
+    height: 44px;
+    background: #052962;
+    border: 1px solid #052962;
+    border-radius: 30px;
+    color: white;
+    font-family: $guardian-sans;
+    font-weight: 700;
+    font-size: 17px;
+    svg {
+        margin-right: 8px;
+    }
+}
+
+.messageTabBody {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.termsAndConditionsStyles {
+    margin-bottom: 16px;
+}
+
+.contact-URL {
+    @include text-underline(color(brand500), color(brand400));
+}

--- a/ArticleTemplates/assets/scss/modules/_callout.scss
+++ b/ArticleTemplates/assets/scss/modules/_callout.scss
@@ -1,25 +1,26 @@
-.campaign--snippet {
+.callout--container {
+    display: block;
     position: relative;
-    padding: 12px;
-    margin: 16px -10px 36px;
+}
 
-    &:not([open]) .is-on,
-    &[open] .is-off {
-        display: none;
-    }
+.callout--details {
+    margin: 16px 0 36px;
+    background: #f6f6f6;
+    color: black;
+    padding: 0 5px 6px;
+    border-image: repeating-linear-gradient(
+            to bottom,
+            #dcdcdc,
+            #dcdcdc 1px,
+            transparent 1px,
+            transparent 4px
+        )
+        13;
+    border-top: 13px solid black;
+    position: relative;
+}
 
-    &[open] {
-        background: color(brightness-93);
-    }
-
-    p {
-        font-size: 14px;
-        line-height: 18px;
-        font-family: $guardian-sans;
-        font-weight: 400;
-        padding-top: 2px;
-    }
-
+.callout--snippet {
     &.campaign--success form {
         color: color(brightness-7);
         padding: 8px 0px 10px 10px;
@@ -56,157 +57,6 @@ p.campaign__info {
         :active {
             background-color: darken(color(news-kicker), 5%);
         }
-
-        .garnett--pillar-news & {
-            &:hover,
-            &:active {
-                background-color: darken(color(news-kicker), 5%);
-            }
-        }
-
-        .garnett--pillar-sport & {
-            &:hover,
-            &:active {
-                background-color: darken(color(sport-feature-headline), 5%);
-            }
-        }
-
-        .garnett--pillar-opinion & {
-            &:hover,
-            &:active {
-                background-color: darken(color(opinion-feature-headline), 5%);
-            }
-        }
-
-        .garnett--pillar-arts & {
-            &:hover,
-            &:active {
-                background-color: darken(color(arts-feature-headline), 5%);
-            }
-        }
-
-        .garnett--pillar-lifestyle & {
-            &:hover,
-            &:active {
-                background-color: darken(color(lifestyle-kicker), 5%);
-            }
-        }
-    }
-
-    &:disabled {
-        .garnett--pillar-news & {
-            background-color: lighten(color(news-kicker), 5%);
-        }
-
-        .garnett--pillar-sport & {
-            background-color: lighten(color(sport-feature-headline), 5%);
-        }
-
-        .garnett--pillar-opinion & {
-            background-color: lighten(color(opinion-feature-headline), 5%);
-        }
-
-        .garnett--pillar-arts & {
-            background-color: lighten(color(arts-feature-headline), 5%);
-        }
-
-        .garnett--pillar-lifestyle & {
-            background-color: lighten(color(lifestyle-kicker), 5%);
-        }
-    }
-
-    .garnett--pillar-news & {
-        color: color(brightness-100);
-        background-color: color(news-kicker);
-    }
-
-    .garnett--pillar-sport & {
-        color: color(brightness-100);
-        background-color: color(sport-feature-headline);
-    }
-
-    .garnett--pillar-opinion & {
-        color: color(brightness-100);
-        background-color: color(opinion-feature-headline);
-    }
-
-    .garnett--pillar-arts & {
-        color: color(brightness-100);
-        background-color: color(arts-feature-headline);
-    }
-
-    .garnett--pillar-lifestyle & {
-        color: color(brightness-100);
-        background-color: color(lifestyle-kicker);
-    }
-}
-
-.campaign--snippet__handle {
-    color: color(brightness-100);
-    background-color: color(brightness-7);
-
-    &:hover,
-    :active {
-        color: color(brightness-7);
-        .icon {
-            fill: color(brightness-7);
-        }
-    }
-
-    .garnett--pillar-news & {
-        &:hover,
-        :active {
-            color: color(brightness-100);
-            background-color: color(news-kicker);
-            .icon {
-                fill: color(brightness-100);
-            }
-        }
-    }
-
-    .garnett--pillar-sport & {
-        &:hover,
-        :active {
-            color: color(brightness-100);
-            background-color: color(sport-feature-headline);
-            .icon {
-                fill: color(brightness-100);
-            }
-        }
-    }
-
-    .garnett--pillar-opinion & {
-        &:hover,
-        :active {
-            color: color(brightness-100);
-            background-color: color(opinion-feature-headline);
-            .icon {
-                fill: color(brightness-100);
-            }
-        }
-    }
-
-    .garnett--pillar-arts & {
-        &:hover,
-        :active {
-            color: color(brightness-100);
-            background-color: color(arts-feature-headline);
-
-            .icon {
-                fill: color(brightness-100);
-            }
-        }
-    }
-
-    .garnett--pillar-lifestyle & {
-        &:hover,
-        :active {
-            color: color(brightness-100);
-            background-color: color(lifestyle-kicker);
-            .icon {
-                fill: color(brightness-100);
-            }
-        }
     }
 }
 
@@ -219,167 +69,6 @@ p.campaign__info {
 
     &::-webkit-details-marker {
         display: none;
-    }
-
-    .campaign--kicker {
-        display: -webkit-box;
-        display: -ms-flexbox;
-        display: flex;
-        -webkit-box-orient: horizontal;
-        -webkit-box-direction: normal;
-        -ms-flex-direction: row;
-        flex-direction: row;
-
-        .heading {
-            margin-right: 10px;
-        }
-
-        > .campaign--snippet__heading-logo {
-            -webkit-box-flex: initial;
-            -ms-flex: initial;
-            flex: initial;
-            margin-right: 10px;
-
-            .speech-bubble {
-                color: color(brightness-7);
-                background-color: color(tone-highlight);
-                padding: 6px 10px 10px;
-                line-height: 18px;
-                min-width: 84px;
-
-                &::after {
-                    color: color(brightness-7);
-                    background-color: color(tone-highlight);
-                }
-
-                .garnett--pillar-news & {
-                    color: color(brightness-100);
-                    background-color: color(news-kicker);
-                    &::after {
-                        color: color(brightness-100);
-                        background-color: color(news-kicker);
-                    }
-                }
-
-                .garnett--pillar-sport & {
-                    color: color(brightness-100);
-                    background-color: color(sport-feature-headline);
-                    &::after {
-                        color: color(brightness-100);
-                        background-color: color(sport-feature-headline);
-                    }
-                }
-
-                .garnett--pillar-opinion & {
-                    color: color(brightness-100);
-                    background-color: color(opinion-feature-headline);
-                    &::after {
-                        background-color: color(opinion-feature-headline);
-                    }
-                }
-
-                .garnett--pillar-arts & {
-                    color: color(brightness-100);
-                    background-color: color(arts-feature-headline);
-                    &::after {
-                        background-color: color(arts-feature-headline);
-                    }
-                }
-
-                .garnett--pillar-lifestyle & {
-                    color: color(brightness-100);
-                    background-color: color(lifestyle-kicker);
-                    &::after {
-                        background-color: color(lifestyle-kicker);
-                    }
-                }
-            }
-        }
-    }
-}
-
-.campaign--snippet__header {
-    margin: 0 0 6px;
-}
-
-.campaign--snippet__headline {
-    font-size: 18px;
-    line-height: 22px;
-    font-family: $guardian-sans;
-    font-weight: 500;
-    padding-top: 1px;
-}
-
-.campaign--snippet__heading-logo {
-    font-size: 18px;
-    font-family: $guardian-sans;
-    font-weight: 500;
-}
-
-.campaign--snippet__handle {
-    font-family: $guardian-sans;
-    font-size: 13px;
-    font-weight: bold;
-    position: absolute;
-    bottom: 0;
-    -webkit-transform: translate(0, 50%);
-    -ms-transform: translate(0, 50%);
-    transform: translate(0, 50%);
-    padding: 3px 15px 0 6px;
-    margin-left: 5px;
-    span {
-        display: -webkit-inline-box;
-        display: -ms-inline-flexbox;
-        display: inline-flex;
-        -webkit-box-align: center;
-        -ms-flex-align: center;
-        align-items: center;
-    }
-    .icon {
-        fill: color(brightness-100);
-        width: 16px;
-        height: 16px;
-        margin: -3px 6px 0 4px;
-    }
-}
-
-.campaign__button--rounded {
-    border-radius: 100em;
-}
-.campaign__button--large {
-    height: 2.25em;
-}
-
-.campaign__button {
-    display: -webkit-inline-box;
-    display: -ms-inline-flexbox;
-    display: inline-flex;
-    -webkit-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    border: 0;
-    margin: 0 0 0 10px;
-
-    svg:not(:root) {
-        overflow: hidden;
-    }
-}
-
-.garnett--pillar-news .campaign--snippet__handle:focus {
-    background-color: color(news-kicker);
-}
-
-.speech-bubble {
-    position: relative;
-
-    &::after {
-        content: "";
-        width: 20px;
-        height: 22px;
-        border-radius: 0 0 18px;
-        position: absolute;
-        bottom: -12px;
-        left: 10px;
     }
 }
 
@@ -513,7 +202,6 @@ p.campaign__info {
     -webkit-box-direction: normal;
     -ms-flex-direction: row;
     flex-direction: row;
-    // border-top: 1px color(brightness-86) solid;
     padding-right: 12px;
     display: flex;
     justify-content: center;
@@ -526,27 +214,6 @@ p.campaign__info {
         .button {
             padding: 6px 16px;
             border: 0;
-        }
-    }
-
-    .t_and_c {
-        -webkit-box-flex: 1;
-        -ms-flex: auto;
-        flex: auto;
-        text-align: right;
-        display: -webkit-box;
-        display: -ms-flexbox;
-        display: flex;
-        font-family: $guardian-sans;
-        font-size: 12px;
-
-        a {
-            -webkit-box-flex: 1;
-            -ms-flex: auto;
-            flex: auto;
-            color: color(brightness-7);
-            margin: 8px 0 0;
-            background-image: none !important;
         }
     }
 }
@@ -562,28 +229,6 @@ input[type="file"]::file-selector-button {
     font-family: $guardian-sans;
     font-weight: 700;
     color: black;
-}
-
-.containerStyling {
-    display: block;
-    position: relative;
-}
-
-.detailStyling {
-    margin: 16px 0 36px;
-    background: #f6f6f6;
-    color: black;
-    padding: 0 5px 6px;
-    border-image: repeating-linear-gradient(
-            to bottom,
-            #dcdcdc,
-            #dcdcdc 1px,
-            transparent 1px,
-            transparent 4px
-        )
-        13;
-    border-top: 13px solid black;
-    position: relative;
 }
 
 summary {

--- a/ArticleTemplates/assets/scss/modules/_callout.scss
+++ b/ArticleTemplates/assets/scss/modules/_callout.scss
@@ -410,7 +410,7 @@ details[open] > summary .callout__toggle--isOpen {
     justify-content: center;
     align-items: center;
     padding: 10px 24px;
-    width: 100%;
+    width: 87vw;
     height: 44px;
     background: #052962;
     border: 1px solid #052962;

--- a/ArticleTemplates/assets/scss/style-async.scss
+++ b/ArticleTemplates/assets/scss/style-async.scss
@@ -21,6 +21,7 @@
 @import 'modules/sponsorship';
 @import 'modules/atoms';
 @import 'modules/campaign';
+@import 'modules/callout';
 @import 'modules/error';
 @import 'modules/blocks/block--discussion';
 @import 'modules/blocks/block--live';

--- a/ArticleTemplates/assets/scss/type/_article.scss
+++ b/ArticleTemplates/assets/scss/type/_article.scss
@@ -2,6 +2,7 @@
 
     .standfirst {
         color: inherit;
+        background-color:yellow;
         font-family: $egyptian-text;
         font-weight: 600;
         font-size: 1.6rem;

--- a/ArticleTemplates/assets/scss/type/_article.scss
+++ b/ArticleTemplates/assets/scss/type/_article.scss
@@ -2,7 +2,6 @@
 
     .standfirst {
         color: inherit;
-        background-color:yellow;
         font-family: $egyptian-text;
         font-weight: 600;
         font-size: 1.6rem;


### PR DESCRIPTION
The EdEx team have built out a new callout component across the AR and DCR rendering platforms. 

Some articles, however, are still rendered using legacy templates. In this circumstance, we see the legacy callout component which is missing the message us functionality. 

This PR updates the CSS and JS for callouts to more closely align the design of callouts in the legacy templates to those from the modern rendering platforms. The html for this can be found [here](https://github.com/guardian/mobile-apps-api/pull/2440).


https://user-images.githubusercontent.com/20416599/229814720-80c0ca62-73de-4692-9d38-cf5da1a864d3.mov





| Before | After |
| --- | --- |
|<img src="" width="300px" />|<img src="" width="300px" />|
