### PR TITLE
LIVE-5221 show image credit in immersive articles

### DIFF
--- a/ArticleTemplates/articleTemplateContainerImmersive.html
+++ b/ArticleTemplates/articleTemplateContainerImmersive.html
@@ -16,6 +16,16 @@
             __IMMERSIVE_BYLINE__
         </div>
 
+        <div class="article__meta __IMMERSIVE_IMAGE_NO_CAPTION__">
+            <div class="immersive__caption">
+                <span class="meta__image__caption__icon" data-icon="&#xe044;" aria-hidden="true"></span>
+                <p class="meta__image__caption__text">
+                    <span>__IMMERSIVE_IMAGE_CAPTION__</span>
+                    <span class="meta__image__caption__credit">__IMMERSIVE_IMAGE_CREDIT__</span>
+                </p>
+            </div>
+        </div>
+
         <div class="article__meta keyline-4">
             <div class="immersive__meta">
                 <div class="meta__published__comments">__COMMENT_CTA__</div>

--- a/ArticleTemplates/assets/scss/modules/content/_meta.scss
+++ b/ArticleTemplates/assets/scss/modules/content/_meta.scss
@@ -78,6 +78,8 @@
         }
     }
 
+    &__image__caption__icon,
+    &__image__caption__text,
     &__published,
     &__published__comments {
         font-size: 1.4rem;
@@ -91,6 +93,8 @@
         }
     }
 
+    &__image__caption__icon,
+    &__image__caption__text,
     &__published {
         padding-top: 0;
         padding-bottom: .25em;

--- a/ArticleTemplates/assets/scss/modules/content/_meta.scss
+++ b/ArticleTemplates/assets/scss/modules/content/_meta.scss
@@ -103,6 +103,10 @@
         }
     }
 
+    &__image__caption__text {
+        display: inline;
+    }
+
     &__published__comments {
         float: right;
         text-align: right;

--- a/ArticleTemplates/assets/scss/type/_immersive.scss
+++ b/ArticleTemplates/assets/scss/type/_immersive.scss
@@ -128,7 +128,7 @@
                 display: flex;
                 align-items: flex-start;
             }
-            
+
             .article__series-copy > a > span {
                 font-size: 16px;
                 display: block;
@@ -288,6 +288,23 @@
             margin-left: 240px;
             width: 620px;
         }
+    }
+
+    .immersive__caption {
+        color: color(brightness-46);
+        font: 1.8rem/1.4rem $guardian-sans;
+        padding: base-px(0, 1, 1, 1);
+
+        @include mq($from: col4) {
+            padding-left: 0;
+            padding-right: 0;
+            margin-left: 240px;
+            width: 620px;
+        }
+    }
+
+    .immersive-caption--hidden {
+        display: none;
     }
 
     .section__rule {


### PR DESCRIPTION
CP team reported that the main image caption / credit were not displayed on immersive articles.  We saw this problem with immersive articles when they were rendered using legacy templates.

The Editorials pointed out that for some pieces (such as [this one](https://www.theguardian.com/uk-news/2023/apr/29/the-crowd-were-saying-kill-him-kick-him-to-death-what-happened-to-the-people-who-protested-against-king-charles)), it was very important readers see the credit on the illustration. 

This PR fixed the problem by adding the image caption to immersive article templates.  We changed the template based on the same design as immersive articles rendered by AR.

The following PRs have been raised to make changes to the native apps in order to show the caption information with the updated template:
Android: guardian/android-news-app#8699
iOS: guardian/ios-live#6971

| Before | After |
| --- | --- |
| iOS (Phone - Light mode) | iOS (Phone - Light mode)
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/07882675-cdb1-429f-8302-0f8f00e59dc8" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/9bb65079-7d83-4964-a13d-765b9208e9f6" width="300px" />|
| iOS (Phone - Dark mode) | iOS (Phone - Dark mode)
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/a3fd103c-271f-4d44-971d-ebc3a36033e5" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/be4102cf-2d8d-4365-8738-e2e788cdaa65" width="300px" />|
| iOS (iPad - Light mode) | iOS (iPad - Light mode)
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/7422e125-ff1b-4ac1-b4d1-ca9536665d07" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/16b99bf3-46c6-40f8-8f83-e254353398d3" width="300px" />|
| iOS (iPad - Dark mode) | iOS (iPad - Dark mode)
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/3fe7371d-fac1-45bf-9726-c5d8a65e1c81" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/dd24e686-c97b-421c-bf49-6938655c8b4b" width="300px" />|
| Android (Phone - Light mode) | Android (Phone - Light mode)
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/f9224c5a-cd4b-45ff-8c9c-3cd02c197dd1" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/5b186dd3-d000-4d6c-a3f1-4f1b01c1827a" width="300px" />|
| Android (Phone - Dark mode) | Android (Phone - Dark mode)
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/9fcec2cb-b530-45e4-b92c-75b35cc6f41e" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/f620eb17-4932-4f9f-80bb-c55e52d56d94" width="300px" />|
| Android (Tablet - Light mode) | Android (Tablet - Light mode)
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/0041dd62-a9fe-4d8a-9179-459dad4385aa" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/5b9ccf59-2021-4de5-b078-0ef7b0aefd7a" width="300px" />|
| Android (Tablet - Dark mode) | Android (Tablet - Dark mode)
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/f492875f-68f1-4324-84cd-c13f16d73100" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/f740f9f3-6153-4d80-891e-4bad61a8fbd3" width="300px" />|

