### PR TITLE
Migrate build from Team City to Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,17 +34,6 @@ jobs:
         if: github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/master' && success()
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout
-              uses: actions/checkout@v2
-
-            - name: Setup Node
-              uses: actions/setup-node@v2
-              with:
-                  node-version: 14
-
-            - name: Install dependencies
-              run: npm install
-
             - name: Set up npm auth token
               run: echo "//registry.npmjs.org/:_authToken=\${NODE_TOKEN}" >> ~/.npmrc
               env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: Build mobile-apps-article-templates
+
+on:
+    pull_request:
+        branches:
+            - master
+    push:
+        branches:
+            - master
+    workflow_dispatch:
+        inputs:
+            manual_trigger:
+                description: "Manually trigger the workflow"
+                required: false
+
+jobs:
+    CI:
+        if: github.actor != 'dependabot[bot]'
+        permissions:
+            id-token: write
+            contents: read
+        name: mobile-apps-article-templates build
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Setup Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version-file: "./.nvmrc"
+                  cache: "npm"
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Build and test
+              run: |
+                  npm run build
+                  npm run test
+
+            - name: Set up npm auth token
+              run: echo "//registry.npmjs.org/:_authToken=\${NODE_TOKEN}" >> ~/.npmrc
+
+            - name: Bump version and publish
+              run: |
+                  OFFSET=858
+                  PATCH_VERSION=$((OFFSET + ${{ github.run_number }}))
+
+                  npm --no-git-tag-version version 1.0.${PATCH_VERSION}
+                  npm publish --access public
+              env:
+                  NODE_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,39 +1,25 @@
-name: Build mobile-apps-article-templates
+name: Build and Publish mobile-apps-article-templates
 
 on:
-    pull_request:
-        branches:
-            - master
     push:
         branches:
             - master
-    workflow_dispatch:
-        inputs:
-            manual_trigger:
-                description: "Manually trigger the workflow"
-                required: false
+    pull_request:
+        branches:
+            - master
 
 jobs:
-    CI:
-        if: github.actor != 'dependabot[bot]'
-        permissions:
-            id-token: write
-            contents: read
-        name: mobile-apps-article-templates build
+    build_and_test:
+        name: Build and Test
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
               uses: actions/checkout@v2
 
-            - name: Read Node version from .nvmrc
-              id: read-node-version
-              run: echo "::set-output name=node_version::$(cat .nvmrc)"
-
             - name: Setup Node
               uses: actions/setup-node@v2
               with:
-                  node-version: ${{ steps.read-node-version.outputs.node_version }}
-                  cache: "npm"
+                  node-version: 14
 
             - name: Install dependencies
               run: npm install
@@ -43,16 +29,28 @@ jobs:
                   npm run build
                   npm run test
 
-            - name: Set up npm auth token if not Dependabot
-              run: |
-                  if [[ ${{ github.actor }} != 'dependabot[bot]' ]]; then
-                      echo "//registry.npmjs.org/:_authToken=${NODE_TOKEN}" >> ~/.npmrc
-                  fi
+    publish:
+        name: Publish
+        if: github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/master' && success()
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: Setup Node
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 14
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Set up npm auth token
+              run: echo "//registry.npmjs.org/:_authToken=\${NODE_TOKEN}" >> ~/.npmrc
               env:
                   NODE_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-            - name: Bump version and publish if not Dependabot
-              if: success() && github.actor != 'dependabot[bot]'
+            - name: Bump version and publish
               run: |
                   OFFSET=858
                   PATCH_VERSION=$((OFFSET + ${{ github.run_number }}))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,16 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v2
+
+            - name: Read Node version from .nvmrc
+              id: read-node-version
+              run: echo "::set-output name=node_version::$(cat .nvmrc)"
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v2
               with:
-                  node-version-file: "./.nvmrc"
+                  node-version: ${{ steps.read-node-version.outputs.node_version }}
                   cache: "npm"
 
             - name: Install dependencies
@@ -39,15 +43,20 @@ jobs:
                   npm run build
                   npm run test
 
-            - name: Set up npm auth token
-              run: echo "//registry.npmjs.org/:_authToken=\${NODE_TOKEN}" >> ~/.npmrc
-
-            - name: Bump version and publish
+            - name: Set up npm auth token if not Dependabot
               run: |
-                  OFFSET=858
-                  PATCH_VERSION=$((OFFSET + ${{ github.run_number }}))
-
-                  npm --no-git-tag-version version 1.0.${PATCH_VERSION}
-                  npm publish --access public
+                  if [[ ${{ github.actor }} != 'dependabot[bot]' ]]; then
+                      echo "//registry.npmjs.org/:_authToken=${NODE_TOKEN}" >> ~/.npmrc
+                  fi
               env:
                   NODE_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            - name: Bump version and publish if not Dependabot
+              run: |
+                  if [[ ${{ github.actor }} != 'dependabot[bot]' ]]; then
+                      OFFSET=858
+                      PATCH_VERSION=$((OFFSET + ${{ github.run_number }}))
+
+                      npm --no-git-tag-version version 1.0.${PATCH_VERSION}
+                      npm publish --access public
+                  fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,10 @@ jobs:
                   NODE_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Bump version and publish if not Dependabot
+              if: success() && github.actor != 'dependabot[bot]'
               run: |
-                  if [[ ${{ github.actor }} != 'dependabot[bot]' ]]; then
-                      OFFSET=858
-                      PATCH_VERSION=$((OFFSET + ${{ github.run_number }}))
+                  OFFSET=858
+                  PATCH_VERSION=$((OFFSET + ${{ github.run_number }}))
 
-                      npm --no-git-tag-version version 1.0.${PATCH_VERSION}
-                      npm publish --access public
-                  fi
+                  npm --no-git-tag-version version 1.0.${PATCH_VERSION}
+                  npm publish --access public


### PR DESCRIPTION
See [this jira ticket](https://theguardian.atlassian.net/browse/LIVE-5541)

This adds a workflow script to build and publish the app templates as an npm package. I tested my changes by going into both the iOS and Android repos, manually changing their templates version numbers, and then running `npm install`. The new package was installed successfully. I then tested the build on the iOS repo and can confirm templates work as expected.

 I paused all team city builds for templates whilst doing this work to ensure that duplicate packages we're not being published simultaneously. 

 You can see the full successful workflow [here](https://github.com/guardian/mobile-apps-article-templates/actions/runs/5955128736)

<img width="856" alt="Screenshot 2023-08-23 at 23 14 27" src="https://github.com/guardian/mobile-apps-article-templates/assets/102960825/87bacb9d-bca3-43e5-8495-e638a2ec846d">
<img width="1018" alt="Screenshot 2023-08-23 at 23 07 48" src="https://github.com/guardian/mobile-apps-article-templates/assets/102960825/fe23d2ff-3dba-4b67-b7c5-bdffed7b67c2">
<img width="986" alt="Screenshot 2023-08-23 at 23 05 25" src="https://github.com/guardian/mobile-apps-article-templates/assets/102960825/3710bf5e-9cde-407c-b0df-c7640aab17b0">

## Further work

In doing this the iOS/Android repos will no longer automatically pull in the latest apps template updates. A next step would be to try and restore this functionality but I believe that is beyond the scope of this ticket, as Jorge from DevX pointed out (see the jira ticket)