### PR TITLE
Restore checkout, setup node and install dependencies on ci script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,17 @@ jobs:
         if: github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/master' && success()
         runs-on: ubuntu-latest
         steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: Setup Node
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 14
+
+            - name: Install dependencies
+              run: npm install
+
             - name: Set up npm auth token
               run: echo "//registry.npmjs.org/:_authToken=\${NODE_TOKEN}" >> ~/.npmrc
               env:


### PR DESCRIPTION
In a [previous pr](https://github.com/guardian/mobile-apps-article-templates/pull/1660) I removed some steps from a workflow that were necessary for the script to run properly.  In GitHub Actions, each job is a separate unit of work, and steps within a job execute in a fresh environment, hence I need to add these steps back in. 