### PR TITLE
Fix string interpolation error, only execute build and test on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
 
             - name: Bump version and publish
               run: |
+                  set -e
                   OFFSET=858
                   PATCH_VERSION=$((OFFSET + ${{ github.run_number }}))
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     build_and_test:
         name: Build and Test
         runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request'
         steps:
             - name: Checkout
               uses: actions/checkout@v2
@@ -46,7 +47,7 @@ jobs:
               run: npm install
 
             - name: Set up npm auth token
-              run: echo "//registry.npmjs.org/:_authToken=\${NODE_TOKEN}" >> ~/.npmrc
+              run: echo "//registry.npmjs.org/:_authToken=$${NODE_TOKEN}" >> ~/.npmrc
               env:
                   NODE_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
In a [previous PR](https://github.com/guardian/mobile-apps-article-templates/pull/1661) a string interpolation error happened. I also noticed both jobs (build and test, publish) are executed concurrently which is not necessary on publish - only the publish step needs to happen. This PR

1) ensures that Build and Test only runs on PR's
2) Fixes a string interpolation error
3) Ensures that the script errors if the publish step produces any errors 

## Testing

I think it's most effective to test this after a merge to master, so I can be 100% sure that the scripts are executing correctly