### PR TITLE
Build code before publishing to npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
             - name: Install dependencies
               run: npm install
 
+            - name: Test
+              run: npm run test
+            
+            - name: Build
+              run: npm run build
+
             - name: Set up npm auth token
               run: echo "//registry.npmjs.org/:_authToken=${NODE_TOKEN}" >> ~/.npmrc
               env:


### PR DESCRIPTION
Before the migration from TeamCity to Github actions mobile-apps-article-templates would run `npm run build` before publishing the build artifacts to npm and creating a new release. This adds back in that step so that css ends up in the npm release like it did before. 

Example of release without running `npm run build` https://www.npmjs.com/package/@guardian/mobile-apps-article-templates/v/1.0.888?activeTab=code
![Screenshot 2023-09-28 at 13 53 04](https://github.com/guardian/mobile-apps-article-templates/assets/3285072/1b9bb769-e1f5-437c-bad1-a49d0d3c0480)


Example of release where `npm run build` was run https://www.npmjs.com/package/@guardian/mobile-apps-article-templates/v/1.0.858?activeTab=code
![Screenshot 2023-09-28 at 13 53 14](https://github.com/guardian/mobile-apps-article-templates/assets/3285072/6705f6f6-f74c-4d5e-b5bc-cbcae396963f)
