### PR TITLE
Manual publish workflow

### DIFF
--- a/.github/workflows/manual_publish.yml
+++ b/.github/workflows/manual_publish.yml
@@ -1,0 +1,44 @@
+name: Build and Publish mobile-apps-article-templates
+
+on:
+    workflow_dispatch:
+      inputs:
+        gitref:
+          description: Branch or tag to deploy
+          required: true
+          type: string
+        tagversion:
+          description: Version tag for NPM release
+          required: true
+          type: string
+
+jobs:
+    publish:
+        name: Manual Publish
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                ref: ${{ inputs.gitref }}
+
+            - name: Setup Node
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 14
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Compile code
+              run: npm run build
+
+            - name: Set up npm auth token
+              run: echo "//registry.npmjs.org/:_authToken=${NODE_TOKEN}" >> ~/.npmrc
+              env:
+                  NODE_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            - name: Bump version and publish
+              run: |
+                  npm --no-git-tag-version version ${{inputs.tagversion}}
+                  npm publish --access public


### PR DESCRIPTION
Allow publishing from any branch (for deploying test versions before committing to main)

This can be helpful for testing template changes whilst switching between PR's.

For example, if a native developer is working on a change for which there is a draft PR open in templates, and wants someone else to test their native changes, currently the steps are:

Dev 1 and Dev 2 both have to
- Check out native branch that needs testing
- Point native package.json mobile-apps-article-templates to ../../mobile-apps-article-templates
- Check out templates branch that needs testing
- Run `npm run build` in mobile-apps-article-templates
- Rebuild native app

After this workflow the steps would be

Dev 1.
- Make templates changes
- Create testing release using this new workflow. Similar to [this one](https://www.npmjs.com/package/@guardian/braze-components/v/3.7.0-hack1)
- Point native package.json mobile-apps-article-templates to testing version e.g 1.0.805-testing1
- Share branch with dev 2 or create draft pull request

Dev 2 (on iOS and Android)
- Check out dev 1's native branch that needs testing
- Build and run

or Dev 2 (on Android only)
- Run `./scripts/run_pr_debug.sh 1234` for PR number 1234 that contains changes that need testing. 