### PR TITLE
Hide and resize height of podcast player

### DIFF
--- a/ArticleTemplates/assets/js/bootstraps/audio.js
+++ b/ArticleTemplates/assets/js/bootstraps/audio.js
@@ -192,6 +192,28 @@ function styleCutoutContainer(duration, cutoutContainer) {
     cutoutContainer.dataset.background = 'true';
 }
 
+/**
+ * Hide the existing podcast controls and adjust the height they take up
+ * so they can be replaced by native controls.
+ * @param {number} desiredHeight - Height of native player that will replace this player
+ * @returns {object} elementOffset - { top, left, height, width }
+ */
+function hidePodcastPlayer(desiredHeight) {
+    const playerContainer = document.getElementsByClassName('audio-player__container')[0];
+    if (playerContainer) {
+        if (desiredHeight > 0) {
+            playerContainer.style.opacity = 0;
+            playerContainer.style.height = desiredHeight + 'px';
+        } else {
+            playerContainer.style.display = 'none';
+        }
+        const offset = getElementOffset(playerContainer);
+        signalDevice(JSON.stringify(offset));
+        return offset;
+    }
+    return null;
+}
+
 function setupGlobals() {
     // Global function to handle audio, called by native code
     window.superAudioSlider = superAudioSlider;
@@ -201,6 +223,7 @@ function setupGlobals() {
     window.audioLoad = audioLoad;
     window.audioFinishLoad = audioFinishLoad;
     window.audioBackground = audioBackground;
+    window.hidePodcastPlayer = hidePodcastPlayer;
 
     window.applyNativeFunctionCall('audioBackground');
     window.applyNativeFunctionCall('superAudioSlider');

--- a/ArticleTemplates/assets/js/bootstraps/audio.js
+++ b/ArticleTemplates/assets/js/bootstraps/audio.js
@@ -195,8 +195,10 @@ function styleCutoutContainer(duration, cutoutContainer) {
 /**
  * Hide the existing podcast controls and adjust the height they take up
  * so they can be replaced by native controls.
+ * When called returns (and sends via signalDevice) the relative position and size of the player container area
+ * By relative this means relative to the top left corner of the page, it does not change as page is scrolled.
  * @param {number} desiredHeight - Height of native player that will replace this player
- * @returns {object} elementOffset - { top, left, height, width }
+ * @returns {object} elementOffset - { top, left, height, width } (object can be null if container not found)
  */
 function hidePodcastPlayer(desiredHeight) {
     const playerContainer = document.getElementsByClassName('audio-player__container')[0];


### PR DESCRIPTION
Ticket: https://theguardian.atlassian.net/browse/LIVE-5764

Hide existing podcast controls when native player is showing on article.

These provides 2 UX options.
- Place native audio controls in same position as HTML ones were.
- Place native audio controls somewhere else (floating at the bottom of article for example).

We may want to place the native audio player in the same position as the HTML based one, so this function returns it's position relative to the page top left corner. This position does not change as the content is scrolled, keeping it in sync with scrolling is the responsibility of the native app. As the height of a audio player might vary by platform / font size, the height in px can be passed to hidePodcastPlayer as number. e.g hidePodcastPlayer(100).

If the native app just wants to hide the HTML audio controls, it can call hidePodcastPlayer(0)


| Before | After |
| --- | --- |
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/3285072/f18cae6f-9698-48c6-8215-7b1cf3f2ac95" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/3285072/ade9c6b0-877d-4de7-a5de-0a117c15f11e" width="300px" />|

