### PR TITLE
LIVE-5793 Fix the colour of button in loading state in dark mode

### DIFF
--- a/ArticleTemplates/assets/scss/pillar/_arts.scss
+++ b/ArticleTemplates/assets/scss/pillar/_arts.scss
@@ -13,6 +13,7 @@
         color(arts-inverted),
         color(arts-dark-1),
         color(arts-dark-2),
-        color(arts-dark-3)
+        color(arts-dark-3),
+        color(arts-media-main),
     );
 }

--- a/ArticleTemplates/assets/scss/pillar/_lifestyle.scss
+++ b/ArticleTemplates/assets/scss/pillar/_lifestyle.scss
@@ -13,6 +13,7 @@
         color(lifestyle-inverted),
         color(lifestyle-dark-1),
         color(lifestyle-dark-2),
-        color(lifestyle-dark-3)
+        color(lifestyle-dark-3),
+        color(lifestyle-media-main),
     );
 }

--- a/ArticleTemplates/assets/scss/pillar/_news.scss
+++ b/ArticleTemplates/assets/scss/pillar/_news.scss
@@ -13,6 +13,7 @@
         color(news-inverted),
         color(news-dark-1),
         color(news-dark-2),
-        color(news-dark-3)
+        color(news-dark-3),
+        color(news-media-main),
     );
 }

--- a/ArticleTemplates/assets/scss/pillar/_opinion.scss
+++ b/ArticleTemplates/assets/scss/pillar/_opinion.scss
@@ -13,7 +13,8 @@
         color(opinion-inverted),
         color(opinion-dark-1),
         color(opinion-dark-2),
-        color(opinion-dark-3)
+        color(opinion-dark-3),
+        color(opinion-media-main),
     );
 
     // Light background in opinion articles
@@ -68,6 +69,7 @@
         color(opinion-inverted),
         color(opinion-dark-1),
         color(opinion-dark-2),
-        color(opinion-dark-3)
+        color(opinion-dark-3),
+        color(opinion-media-main),
     );
 }

--- a/ArticleTemplates/assets/scss/pillar/_sport.scss
+++ b/ArticleTemplates/assets/scss/pillar/_sport.scss
@@ -13,7 +13,8 @@
         color(sport-inverted),
         color(sport-dark-1),
         color(sport-dark-2),
-        color(sport-dark-3)
+        color(sport-dark-3),
+        color(sport-media-main),
     );
 
     // Common
@@ -183,6 +184,7 @@
         color(sport-inverted),
         color(sport-dark-1),
         color(sport-dark-2),
-        color(sport-dark-3)
+        color(sport-dark-3),
+        color(sport-media-main),
     );
 }

--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeMedia.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeMedia.scss
@@ -1,6 +1,6 @@
 @import "colours";
 
-@mixin darkModeMedia($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3) {
+@mixin darkModeMedia($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3, $media-main) {
     .audio-player__button.touchpoint--primary .touchpoint__button,
     .element-youtube .element-placeholder__button .touchpoint__button,
     .audio-player__slider__knob {
@@ -42,6 +42,15 @@
                 &:after,
                 & {
                     background-color: $ratingYellow;
+                }
+            }
+        }
+        .audio-player__container_new .audio-player__button--loading {
+            .pulse {
+                &:before,
+                &:after,
+                & {
+                    background-color: $media-main;
                 }
             }
         }

--- a/ArticleTemplates/assets/scss/themes/darkMode/_main.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_main.scss
@@ -14,7 +14,7 @@
 @import "darkModeComments";
 @import "darkModeLivePromo";
 
-@mixin pillar-colour-dark($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3) {
+@mixin pillar-colour-dark($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3, $media-main) {
     @media (prefers-color-scheme: dark) {
         @include darkModeShared($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeArticle($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
@@ -22,7 +22,7 @@
         @include darkModeCricket($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeFootball($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeOpinion($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
-        @include darkModeMedia($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
+        @include darkModeMedia($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3, $media-main);
         @include darkModeImmersive($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeNumberedList($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeQuiz($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
@@ -42,7 +42,7 @@
         @include darkModeCricket($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeFootball($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeOpinion($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
-        @include darkModeMedia($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
+        @include darkModeMedia($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3, $media-main);
         @include darkModeImmersive($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeNumberedList($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);
         @include darkModeQuiz($p-kicker, $p-inverted, $dark-1, $dark-2, $dark-3);


### PR DESCRIPTION
I saw that the new play button on podcast article template (created in #1679 ) in *loading* state still showed the old yellow colour under dark mode.  It is expected to have the same colour as the button in stopped / playing states.  

The reason is that in dark mode, the legacy template has another CSS rule to set the colour of the button in loading state, which overrides the rule which is used for the colour in light mode.

This PR fixed the colour by adding a rule for dark mode to override the previous CSS rule.

I took this fix as part of the previous ticket #1679 

| Before | After |
| --- | --- |
| Sport (dark) | Sport (dark) |
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/bf8ade98-3b74-4383-95dc-fc001830bf4a" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/bb6a91b2-7cf9-4778-88d7-37cd313981b9" width="300px" />|
| News (dark) | News (dark) |
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/a0a60805-bc93-4332-b563-2d5abd620230" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/a187692a-6c26-4ea5-aa3c-db33d4880c0a" width="300px" />|
| Lifestyle (dark) | Lifestyle (dark) |
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/5735805e-bc30-41ca-847a-057e8d1af193" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/8df52962-a0d1-4ad1-a295-df3ffc176a3d" width="300px" />|
| Culture (dark) | Culture (dark) |
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/13da1472-ec81-4a57-b120-2cf554e7205b" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/054f145f-6bf2-44bb-b225-76893a036147" width="300px" />|
| Opinion (dark) | Opinion (dark) |
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/56c32b2f-b635-4d59-892e-9bd5bdd3cc89" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/1fe8b790-74a0-482e-987e-83f132cd025c" width="300px" />|
