### PR TITLE
LIVE-6006 Fix the colour of play button when it is being pressed 

### DIFF
--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeMedia.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeMedia.scss
@@ -55,6 +55,13 @@
             }
         }
 
+        .audio-player__container_new .audio-player__button.touchpoint--primary .touchpoint__button {
+            background-color: $media-main;
+            &:active {
+                background-color: $media-main;
+            }
+        }
+
         .article__body .from-content-api.prose a,
         .standfirst a:not(.video-URL) {
             background-image: linear-gradient(rgba(220, 220, 220, 0.33) 0%, rgba(220, 220, 220, 0.5) 100%);


### PR DESCRIPTION
It was reported that the colour of the play button in the new podcast audio control was incorrectly changed to yellow when it was being pressed.  Further examination showed that it happened under dark mode only.

With the web inspector, it was found that when the button was pressed, the CSS rule with the pseudo class `:active` (an example was shown below) was applied instead of the intended rule:

<img width="380" alt="Screenshot 2023-11-23 at 17 09 06" src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/706ef43e-4f74-40f2-a425-3c537360e67e">


To fix the problem, new CSS rules have been defined for the colour of play button (in active or not) under dark mode:

<img width="400" alt="Screenshot 2023-11-23 at 17 41 03" src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/0b5deb78-05db-48fc-b1f5-a4bbe98abc64">
<img width="398" alt="Screenshot 2023-11-23 at 17 41 16" src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/7652b660-bd97-44a5-8093-a0324d85b5d5">

The SCSS applies to all pillars.  I captured the screenshots for news and sport pillar as examples

| Before | After |
| --- | --- |
| News | News |
| Pressed | Pressed |
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/78400b91-f2e9-4b6d-bd30-c4d61b624e9c" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/9673f69c-6264-489e-bb41-8d55ed8a23f3" width="300px" />|
| Sport | Sport |
| Pressed | Pressed |
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/fcb7bc7a-bed2-4618-9dd8-5661ada13b58" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/865fec47-aa5d-45a3-afbb-de69db7bfe20" width="300px" />|
