### PR TITLE
Increase the margin on the author image

### DIFF
--- a/ArticleTemplates/assets/scss/modules/content/_meta.scss
+++ b/ArticleTemplates/assets/scss/modules/content/_meta.scss
@@ -50,7 +50,7 @@
     padding-top: base-px(.5);
 
     .avatar--author {
-        margin: base-px(0, 1, 1, 0);
+        margin: base-px(0, 1, 3, 0);
         float: left;
     }
 


### PR DESCRIPTION
This PR increases the margin on the bottom of the author pic, so that in the cases where the byline wraps around a line and there are both notifications and follow button visible. 

| Before | After |
| --- | --- |
|![no-comment-author-wrap-before](https://github.com/guardian/mobile-apps-article-templates/assets/1202622/3b87c91b-db59-4074-aa6c-e8cb1e104c04)|![no-comment-author-pic-wrap](https://github.com/guardian/mobile-apps-article-templates/assets/1202622/b5ab4b08-7f3b-435a-ab65-5daee9f24f77)|
