### PR TITLE
Update Readme to help iOS simulator users

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ $ npm install
 }
 ```
 * You will then need to run `npm install` in the `ios-live` directory that contains the `package.json` in the repo.
+* If you find that the app is not using the expected version of the dependency (from your branch), try deleting `package-lock.json` and `node_modules` before running `npm install`.
 
 ### Running on Android simulator
 * Checkout the branch you are developing against


### PR DESCRIPTION
No matter how hard I tried, I could not get the app to use the correct version of the templates from a branch.
Finally I tried deleting both `package-lock.json` and `node_modules` - this seemed to do the trick to force npm to install the right versions (and regenerate those files). Maybe this will be helpful for any future users of this.