### PR TITLE
LIVE-6056 Add listen-to-article UI to features article template

### DIFF
--- a/.changeset/chatty-papayas-double.md
+++ b/.changeset/chatty-papayas-double.md
@@ -1,0 +1,5 @@
+---
+"@guardian/mobile-apps-article-templates": patch
+---
+
+Add listen-to-article UI to features template

--- a/ArticleTemplates/articleTemplateContainerFeatures.html
+++ b/ArticleTemplates/articleTemplateContainerFeatures.html
@@ -28,6 +28,26 @@
             <div class="standfirst__inner">__STANDFIRST__</div>
         </div>
 
+        <div class="listen-to-article__container keyline">
+            <div class="audio-player__wrapper">
+                <div class="audio-player">
+                    <div class="audio-player__button--loading ">
+                        <div class='pulse touchpoint__button'></div>
+                    </div>
+                    <a role="button" aria-role="button" class="audio-player__button touchpoint touchpoint--primary" id="audio-play-button-new" href="x-gu://playaudio/__AUDIO_URI__">
+                        <span class="touchpoint__button play" data-icon="&#xe04b;" aria-hidden="true"></span>
+                        <span class="touchpoint__button pause" data-icon="&#xe04D;" aria-hidden="true"></span>
+                        <span class="touchpoint__label screen-readable audio-player-readable">Play</span>
+                    </a>
+                    <div class="audio-player__info">
+                        <div class="audio-player__info__label">Listen to this podcast</div>
+                        <div class="audio-player__info__duration"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="audio-player__waveform"></div>
+        </div>
+
         <div class="meta keyline-4" id="meta">
             <div class="meta__misc">
                 <div class="meta__published__comments">__COMMENT_CTA__</div>


### PR DESCRIPTION
We are working on the new listen-to-article feature for the app.  This PR adds the new listen-to-article control UI on the legacy templates for features design.

| Light Mode | Dark Mode |
| --- | --- |
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/303543b0-0d01-401a-9e85-7ddfbf481624" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/265b76a4-a253-4358-9fa2-78d305f2f51b" width="300px" />|
