### PR TITLE
Add instructions for publishing to npm repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ NPM will provide the following services:
 
 ## Publish to npm repository
 This repository has changed to `changesets` to publish the package to NPM package.
-* In your feature branch, run `npm run release` to generate the changeset file.  For article templates, it is usually just a patch version bump.
+* In your feature branch, run `npm run release` to generate the changeset file.  We usually just bump the patch version number.
 * Add the changeset file generated undder `.changeset` directory, commit and push to github
 * When your PR is merged, the github action for CI will create a release pull request ([example](https://github.com/guardian/mobile-apps-article-templates/pull/1693))
 * You can merge this release pull request if you want to publish the package to npm repository.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This repository has changed to `changesets` to publish the package to NPM packag
 * Add the changeset file generated undder `.changeset` directory, commit and push to github
 * When your PR is merged, the github action for CI will create a release pull request ([example](https://github.com/guardian/mobile-apps-article-templates/pull/1693))
 * You can merge this release pull request if you want to publish the package to npm repository.
-* Alternatively, you may leave the release pull request open.  If other PR are merged, their change sets will just be added to this release pull requests.
+* Alternatively, you may leave the release pull request open.  If other PR are merged, their change sets will just be added to this release pull request.
 
 ## Example templates
 These are examples of the main templates used across apps:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ NPM will provide the following services:
 * `npm run test` runs the JS unit tests from the `test/spec/unit/` directory
 * `npm run build` builds JS/CSS assets, used on CI environment for building assets
 * `npm run dev` builds JS and CSS (with source maps).
+* `npm run release` generates a changeset file, which makes `changesets` to create a release pull request when the PR is merged
+
+## Publish to npm repository
+This repository has changed to `changesets` to publish the package to NPM package.
+* In your feature branch, run `npm run release` to generate the changeset file.  For article templates, it is usually just a patch version bump.
+* Add the changeset file generated undder `.changeset` directory, commit and push to github
+* When your PR is merged, the github action for CI will create a release pull request ([example](https://github.com/guardian/mobile-apps-article-templates/pull/1693))
+* You can merge this release pull request if you want to publish the package to npm repository.
+* Alternatively, you may leave the release pull request open.  If other PR are merged, their change sets will just be added to this release pull requests.
 
 ## Example templates
 These are examples of the main templates used across apps:


### PR DESCRIPTION
Now that we've changed the github action for CI to use `changesets`, this PR adds the instructions on publishing the package to the `readme` doc.

