### PR TITLE
LIVE-6057 Add listen to article UI to default article template

### DIFF
--- a/.changeset/red-zoos-breathe.md
+++ b/.changeset/red-zoos-breathe.md
@@ -1,0 +1,5 @@
+---
+"@guardian/mobile-apps-article-templates": patch
+---
+
+Add listen-to-article UI to default template. Fix the label in listen-to-article UI.

--- a/ArticleTemplates/articleTemplateContainer.html
+++ b/ArticleTemplates/articleTemplateContainer.html
@@ -30,6 +30,26 @@
             <div class="standfirst__inner">__STANDFIRST__</div>
         </div>
 
+        <div class="listen-to-article__container keyline">
+            <div class="audio-player__wrapper">
+                <div class="audio-player">
+                    <div class="audio-player__button--loading ">
+                        <div class='pulse touchpoint__button'></div>
+                    </div>
+                    <a role="button" aria-role="button" class="audio-player__button touchpoint touchpoint--primary" id="audio-play-button-new" href="x-gu://playaudio/__AUDIO_URI__">
+                        <span class="touchpoint__button play" data-icon="&#xe04b;" aria-hidden="true"></span>
+                        <span class="touchpoint__button pause" data-icon="&#xe04D;" aria-hidden="true"></span>
+                        <span class="touchpoint__label screen-readable audio-player-readable">Play</span>
+                    </a>
+                    <div class="audio-player__info">
+                        <div class="audio-player__info__label">Listen to this article</div>
+                        <div class="audio-player__info__duration"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="audio-player__waveform"></div>
+        </div>
+
         <div class="meta keyline-4" id="meta">
             <div class="meta__misc">
                 <div class="meta__published__comments">__COMMENT_CTA__</div>

--- a/ArticleTemplates/articleTemplateContainerComment.html
+++ b/ArticleTemplates/articleTemplateContainerComment.html
@@ -43,7 +43,7 @@
                         <span class="touchpoint__label screen-readable audio-player-readable">Play</span>
                     </a>
                     <div class="audio-player__info">
-                        <div class="audio-player__info__label">Listen to this podcast</div>
+                        <div class="audio-player__info__label">Listen to this article</div>
                         <div class="audio-player__info__duration"></div>
                     </div>
                 </div>

--- a/ArticleTemplates/articleTemplateContainerFeatures.html
+++ b/ArticleTemplates/articleTemplateContainerFeatures.html
@@ -40,7 +40,7 @@
                         <span class="touchpoint__label screen-readable audio-player-readable">Play</span>
                     </a>
                     <div class="audio-player__info">
-                        <div class="audio-player__info__label">Listen to this podcast</div>
+                        <div class="audio-player__info__label">Listen to this article</div>
                         <div class="audio-player__info__duration"></div>
                     </div>
                 </div>

--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeArticle.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeArticle.scss
@@ -31,6 +31,12 @@
             background-color: $backgroundBlack;
         }
 
+        .listen-to-article__container {
+            &.keyline:before {
+                background-color: $blackTwo;
+            }
+        }
+
         .article-kicker,
         .meta .byline__author a,
         .standfirst .byline__author a,


### PR DESCRIPTION
We are developing the listen-to-article feature.  This PR adds the listen to article control UI to the default article template (i.e. for articles which do not have comment, feature or immersive design).

| Light | Dark |
| --- | --- |
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/08cdc238-36c2-4dc1-8987-1a5499fbbcfb" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/8abbe2ef-4d15-475d-bf55-1175ea08fa70" width="300px" />|