### PR TITLE
LIVE-6055 Add listen to article UI to immersive article template

### DIFF
--- a/.changeset/honest-pandas-battle.md
+++ b/.changeset/honest-pandas-battle.md
@@ -1,0 +1,5 @@
+---
+"@guardian/mobile-apps-article-templates": patch
+---
+
+Add listen-to-article UI to immersive design article template

--- a/ArticleTemplates/articleTemplateContainerImmersive.html
+++ b/ArticleTemplates/articleTemplateContainerImmersive.html
@@ -26,6 +26,26 @@
             </div>
         </div>
 
+        <div class="listen-to-article__container keyline">
+            <div class="audio-player__wrapper">
+                <div class="audio-player">
+                    <div class="audio-player__button--loading ">
+                        <div class='pulse touchpoint__button'></div>
+                    </div>
+                    <a role="button" aria-role="button" class="audio-player__button touchpoint touchpoint--primary" id="audio-play-button-new" href="x-gu://playaudio/__AUDIO_URI__">
+                        <span class="touchpoint__button play" data-icon="&#xe04b;" aria-hidden="true"></span>
+                        <span class="touchpoint__button pause" data-icon="&#xe04D;" aria-hidden="true"></span>
+                        <span class="touchpoint__label screen-readable audio-player-readable">Play</span>
+                    </a>
+                    <div class="audio-player__info">
+                        <div class="audio-player__info__label">Listen to this article</div>
+                        <div class="audio-player__info__duration"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="audio-player__waveform"></div>
+        </div>
+
         <div class="article__meta keyline-4">
             <div class="immersive__meta">
                 <div class="meta__published__comments">__COMMENT_CTA__</div>


### PR DESCRIPTION
This PR adds the listen-to-article control UI to immersive design article template.

| Light | Dark |
| --- | --- |
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/af8f7f10-940d-4b63-9425-69757417f2d2" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/a6c32677-a1c7-492f-905a-aa015a627cad" width="300px" />|

