### PR TITLE
LIVE-6058 Add listen to article UI to football article template

### DIFF
--- a/.changeset/swift-tigers-listen.md
+++ b/.changeset/swift-tigers-listen.md
@@ -1,0 +1,5 @@
+---
+"@guardian/mobile-apps-article-templates": patch
+---
+
+Add listen-to-article UI to football template

--- a/ArticleTemplates/assets/js/bootstraps/article.js
+++ b/ArticleTemplates/assets/js/bootstraps/article.js
@@ -5,6 +5,7 @@ import { init as immersiveInit } from 'modules/immersive';
 import { init as numberedListInit } from 'modules/numberedList';
 import { init as creativeInjectorInit } from 'modules/creativeInjector';
 import { init as messengerInit } from 'modules/messenger';
+import { init as listenToArticleInit } from 'modules/listen-to-article';
 import resizeInit from 'modules/messenger/resize';
 
 function richLinkTracking() {
@@ -30,73 +31,6 @@ function richLinkTracking() {
     }
 }
 
-function showListenToArticlePlayer() {
-    const playerContainer = document.getElementsByClassName('listen-to-article__container')[0];
-    if (playerContainer) {
-        playerContainer.style.display = 'block';
-    }
-}
-
-function setAudioDuration(duration) {
-    const audioDuration = document.getElementsByClassName('audio-player__info__duration')[0];
-    if (audioDuration) {
-        audioDuration.textContent = duration;
-    }
-}
-
-function listenToArticlePlayerLoading() {
-    const audioPlayerContainer = document.getElementsByClassName('listen-to-article__container')[0];
-    if (audioPlayerContainer) {
-        const audioPlayer = audioPlayerContainer.getElementsByClassName('audio-player')[0];
-        if (audioPlayer) {
-            audioPlayer.classList.add('loading');
-        }
-    }
-}
-
-function listenToArticlePlayerPlaying() {
-    const audioPlayerContainer = document.getElementsByClassName('listen-to-article__container')[0];
-    if (audioPlayerContainer) {
-        const button = audioPlayerContainer.getElementsByClassName('audio-player__button')[0];
-        const audioPlayer = audioPlayerContainer.getElementsByClassName('audio-player')[0];
-        const screenReadable = audioPlayerContainer.getElementsByClassName('audio-player-readable')[0];
-
-        if (button && audioPlayer && screenReadable) {
-            const href = button.getAttribute('href');
-            button.setAttribute('href', href.replace(/x-gu:\/\/(playaudio|pauseaudio)\/(.*)/, 'x-gu://pauseaudio/$2'));
-            button.classList.add('pause');
-            audioPlayer.classList.remove('loading');
-            screenReadable.innerHTML = 'Pause';
-        }
-    }
-}
-
-function listenToArticlePlayerStopped() {
-    const audioPlayerContainer = document.getElementsByClassName('listen-to-article__container')[0];
-    if (audioPlayerContainer) {
-        const button = audioPlayerContainer.getElementsByClassName('audio-player__button')[0];
-        const audioPlayer = audioPlayerContainer.getElementsByClassName('audio-player')[0];
-        const screenReadable = audioPlayerContainer.getElementsByClassName('audio-player-readable')[0];
-
-        if (button && audioPlayer && screenReadable) {
-            const href = button.getAttribute('href');
-            button.setAttribute('href', href.replace(/x-gu:\/\/(playaudio|pauseaudio)\/(.*)/, 'x-gu://playaudio/$2'));
-            button.classList.remove('pause');
-            audioPlayer.classList.remove('loading');
-            screenReadable.innerHTML = "Play";
-        }
-    }
-}
-
-function setupGlobals() {
-    // Global function to handle listen-to-article UI, called by native code
-    window.showListenToArticlePlayer = showListenToArticlePlayer;
-    window.setAudioDuration = setAudioDuration;
-    window.listenToArticlePlayerLoading = listenToArticlePlayerLoading;
-    window.listenToArticlePlayerPlaying = listenToArticlePlayerPlaying;
-    window.listenToArticlePlayerStopped = listenToArticlePlayerStopped;
-}
-
 function init() {
     youtubeInit();
     twitterInit();
@@ -106,7 +40,7 @@ function init() {
     creativeInjectorInit();
     messengerInit([resizeInit]);
     richLinkTracking();
-    setupGlobals();
+    listenToArticleInit();
 }
 
 export { init };

--- a/ArticleTemplates/assets/js/bootstraps/football.js
+++ b/ArticleTemplates/assets/js/bootstraps/football.js
@@ -1,4 +1,5 @@
 import { init as initYoutube } from 'modules/youtube';
+import { init as initListenToArticle } from 'modules/listen-to-article';
 import { getElemsFromHTML } from 'modules/util';
 import { arc, pie, select } from 'd3';
 
@@ -209,6 +210,7 @@ function setupGlobals() {
 function init() {
     setupGlobals();
     initYoutube();
+    initListenToArticle();
 }
 
 export { init };

--- a/ArticleTemplates/assets/js/modules/listen-to-article.js
+++ b/ArticleTemplates/assets/js/modules/listen-to-article.js
@@ -1,0 +1,72 @@
+function showListenToArticlePlayer() {
+    const playerContainer = document.getElementsByClassName('listen-to-article__container')[0];
+    if (playerContainer) {
+        playerContainer.style.display = 'block';
+    }
+}
+
+function setAudioDuration(duration) {
+    const audioDuration = document.getElementsByClassName('audio-player__info__duration')[0];
+    if (audioDuration) {
+        audioDuration.textContent = duration;
+    }
+}
+
+function listenToArticlePlayerLoading() {
+    const audioPlayerContainer = document.getElementsByClassName('listen-to-article__container')[0];
+    if (audioPlayerContainer) {
+        const audioPlayer = audioPlayerContainer.getElementsByClassName('audio-player')[0];
+        if (audioPlayer) {
+            audioPlayer.classList.add('loading');
+        }
+    }
+}
+
+function listenToArticlePlayerPlaying() {
+    const audioPlayerContainer = document.getElementsByClassName('listen-to-article__container')[0];
+    if (audioPlayerContainer) {
+        const button = audioPlayerContainer.getElementsByClassName('audio-player__button')[0];
+        const audioPlayer = audioPlayerContainer.getElementsByClassName('audio-player')[0];
+        const screenReadable = audioPlayerContainer.getElementsByClassName('audio-player-readable')[0];
+
+        if (button && audioPlayer && screenReadable) {
+            const href = button.getAttribute('href');
+            button.setAttribute('href', href.replace(/x-gu:\/\/(playaudio|pauseaudio)\/(.*)/, 'x-gu://pauseaudio/$2'));
+            button.classList.add('pause');
+            audioPlayer.classList.remove('loading');
+            screenReadable.innerHTML = 'Pause';
+        }
+    }
+}
+
+function listenToArticlePlayerStopped() {
+    const audioPlayerContainer = document.getElementsByClassName('listen-to-article__container')[0];
+    if (audioPlayerContainer) {
+        const button = audioPlayerContainer.getElementsByClassName('audio-player__button')[0];
+        const audioPlayer = audioPlayerContainer.getElementsByClassName('audio-player')[0];
+        const screenReadable = audioPlayerContainer.getElementsByClassName('audio-player-readable')[0];
+
+        if (button && audioPlayer && screenReadable) {
+            const href = button.getAttribute('href');
+            button.setAttribute('href', href.replace(/x-gu:\/\/(playaudio|pauseaudio)\/(.*)/, 'x-gu://playaudio/$2'));
+            button.classList.remove('pause');
+            audioPlayer.classList.remove('loading');
+            screenReadable.innerHTML = "Play";
+        }
+    }
+}
+
+function setupGlobals() {
+    // Global function to handle listen-to-article UI, called by native code
+    window.showListenToArticlePlayer = showListenToArticlePlayer;
+    window.setAudioDuration = setAudioDuration;
+    window.listenToArticlePlayerLoading = listenToArticlePlayerLoading;
+    window.listenToArticlePlayerPlaying = listenToArticlePlayerPlaying;
+    window.listenToArticlePlayerStopped = listenToArticlePlayerStopped;
+}
+
+function init() {
+    setupGlobals();
+}
+
+export { init };


### PR DESCRIPTION
This PR aims to add the new listen-to-article UI to football template.

The football template actually uses the standard article template to render the main part of the article, which we've already added the HTML snippet for the UI.  However, the Javascript functions for controlling the UI were not available in this football template.

This PR extracts these functions into a separate module JS so that it can be shared between article JS and football JS modules. 

| Light | Mode |
| --- | --- |
|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/166c1a91-9d04-4f97-8e20-9ea07e4f1fc6" width="300px" />|<img src="https://github.com/guardian/mobile-apps-article-templates/assets/89925410/56001a99-46f3-4e00-a016-04d8a02f0dc4" width="300px" />|
