### PR TITLE
Display buttons as inline-block

### DIFF
--- a/.changeset/stale-dodos-join.md
+++ b/.changeset/stale-dodos-join.md
@@ -1,0 +1,5 @@
+---
+"@guardian/mobile-apps-article-templates": patch
+---
+
+changes the display property of notifications button from block to inline-block

--- a/ArticleTemplates/articleTemplateAlerts.html
+++ b/ArticleTemplates/articleTemplateAlerts.html
@@ -8,6 +8,7 @@
         <span class="alerts__label">Following __AUTHOR_NAME__</span>
     </span>
 </a>
+</br>
 <a class="alerts __CONTRIBUTOR_FOLLOWING__" href="x-gu://follow/__CONTRIBUTOR_FOLLOWID__" data-follow-alert-id="__CONTRIBUTOR_FOLLOWID__">
     <span class="alerts__state--unfollow-notifications">
         <span data-icon="&#xe090;" aria-hidden="true" class="not-following"></span>

--- a/ArticleTemplates/assets/js/modules/myGuardianFollowInit.js
+++ b/ArticleTemplates/assets/js/modules/myGuardianFollowInit.js
@@ -2,7 +2,7 @@ function init() {
     if (GU.opts.myGuardianEnabled) {
         const followButtons = document.querySelectorAll('.my-guardian-follow-tag');
         followButtons.forEach((followButton) => {
-            followButton.style.display = 'block';
+            followButton.style.display = 'inline-block';
         });
     }
 }

--- a/ArticleTemplates/assets/scss/modules/_alerts.scss
+++ b/ArticleTemplates/assets/scss/modules/_alerts.scss
@@ -56,7 +56,7 @@
     font-family: $guardian-sans;
     white-space: nowrap;
     margin: base-px(0);
-    display: block;
+    display: inline-block;
     border-radius: 30px;
     max-width: 100%;
     color: color(brightness-7);


### PR DESCRIPTION
This changes the display property of notifications button from `block` to `inline-block` because the issue with setting this to `block` means that the area of the whole region is clickable. 
[This video](https://github.com/guardian/mobile-apps-article-templates/assets/1202622/deb655f0-c5bb-49ed-9db7-c9e7349e3fb4) shows the problem. 

The original intent of using the display property `block` was to put the addition of a second button on a new line. This is now achieved by adding a break tag in the mark up instead. 

![followbuttons](https://github.com/guardian/mobile-apps-article-templates/assets/1202622/4b260389-a26d-40c8-a51e-dd0d0c60e66c)
