### PR TITLE
LIVE-6342 Fix audio atoms

### DIFF
--- a/.changeset/nine-lies-report.md
+++ b/.changeset/nine-lies-report.md
@@ -1,0 +1,5 @@
+---
+"@guardian/mobile-apps-article-templates": patch
+---
+
+Fix audio atoms

--- a/ArticleTemplates/assets/js/modules/atoms/services.js
+++ b/ArticleTemplates/assets/js/modules/atoms/services.js
@@ -78,5 +78,7 @@ export default {
         write(f) { f(); },
         read(f) { f(); }
     },
+    consent: { acast: false },
+    commercial: { isAdFree: true },
     viewport
 };


### PR DESCRIPTION
Editorials and users reported that audio atom does not work on this piece:
https://www.theguardian.com/us-news/2024/feb/26/ai-deepfake-quiz-spot-the-sham-audio-of-trump-and-biden

The audio atom should have been broken on legacy template for quite a while.

MAPI is using [atom-renderer](https://github.com/guardian/atom-renderer) to render atoms on legacy template, and this atom-renderer had a breaking change in this [PR](https://github.com/guardian/atom-renderer/pull/84).  Unfortunately, the legacy template was not updated for this change.

This PR updates the service object according to the requirement.

The audio atom worked properly when I tested this change locally: 

https://github.com/guardian/mobile-apps-article-templates/assets/89925410/d5dfd8d8-50c2-4ec9-890e-abffdb4f334b
