### PR TITLE
Support scrollies

### DIFF
--- a/.changeset/tasty-buses-bow.md
+++ b/.changeset/tasty-buses-bow.md
@@ -1,0 +1,5 @@
+---
+"@guardian/mobile-apps-article-templates": minor
+---
+
+Enable safe scrollies, which do not break out of their iframes

--- a/ArticleTemplates/assets/scss/modules/_atoms.scss
+++ b/ArticleTemplates/assets/scss/modules/_atoms.scss
@@ -4,3 +4,12 @@
     border: 0;
     margin: 1em 0;
 }
+
+
+iframe.scrolly {
+		position: sticky;
+		top: 0;
+		height: 100vh;
+		height: 100dvh;
+		overflow: hidden;
+}


### PR DESCRIPTION
Enable safe scrollies, which do not break out of their `iframe`s.

## Screenshots


https://github.com/guardian/mobile-apps-article-templates/assets/76776/3cbd2628-95f3-4298-b6a6-f9806c333994


## References

- https://github.com/guardian/dotcom-rendering/pull/10604
- https://github.com/guardian/interactive-generic-ai2html-scrolly/pull/6