### PR TITLE
Upgrade micromatch

### DIFF
--- a/.changeset/four-baboons-travel.md
+++ b/.changeset/four-baboons-travel.md
@@ -1,0 +1,5 @@
+---
+"@guardian/mobile-apps-article-templates": patch
+---
+
+Upgrade micromatch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardian/mobile-apps-article-templates",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardian/mobile-apps-article-templates",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@babel/polyfill": "^7.4.4",
         "@changesets/cli": "^2.27.6",
@@ -40,6 +40,7 @@
         "jest": "^29.6.1",
         "jest-canvas-mock": "^2.3.0",
         "jshint-summary": "^0.4.0",
+        "micromatch": "^4.0.8",
         "mini-css-extract-plugin": "^2.4.5",
         "regenerator-runtime": "^0.13.1",
         "sass": "^1.32.8",
@@ -11968,9 +11969,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "style-loader": "^3.3.1",
     "terser-webpack-plugin": "^5.3.0",
     "webpack": "^5.65.0",
-    "webpack-cli": "^4.1.0"
+    "webpack-cli": "^4.1.0",
+    "micromatch": "^4.0.8"
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.4",


### PR DESCRIPTION
This explicitly adds a version of micromatch with vulnerability fix as outlined in the snyk report

![micromatch](https://github.com/user-attachments/assets/6f7beb2f-2cf7-4c70-b702-2a8590f3a2cf)


| Before | After |
| --- | --- |
|<img src="" width="300px" />|<img src="" width="300px" />|
