### PR TITLE
Remove ad slot support message

### DIFF
--- a/.changeset/fifty-birds-brush.md
+++ b/.changeset/fifty-birds-brush.md
@@ -1,0 +1,5 @@
+---
+"@guardian/mobile-apps-article-templates": minor
+---
+
+Remove ad upsell

--- a/ArticleTemplates/assets/js/modules/ads.js
+++ b/ArticleTemplates/assets/js/modules/ads.js
@@ -128,10 +128,6 @@ function createMpu(id) {
             <div class="advert-slot__wrapper advert-slot__wrapper--${id} test__banner" id="advert-slot__wrapper">
                 <div class="advert-slot__wrapper__content" id="${id}"></div>
             </div>
-            <div class="advert-slot__upgrade">
-                <h1>Support the Guardian and enjoy the app ad-free.</h1>
-                <a href="x-gu://subscribe" role="button">Support the Guardian</a>
-            </div>
         `;
         return mpu;
     }

--- a/ArticleTemplates/assets/scss/modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/modules/_advert-slot.scss
@@ -164,34 +164,6 @@
             margin-top: 0;
         }
     }
-
-    .advert-slot__upgrade {
-       background: color(tone-highlight);
-
-        h1 {
-            font-family: $egyptian-display;
-            padding: 8px;
-            color: color(brightness-7);
-            font-weight: 500;
-            font-size: 18px;
-            line-height: 22px;
-       }
-
-        a {
-            font-family: $guardian-sans;
-            padding: 12px 21px !important;
-            margin: 8px;
-            background: color(brightness-7);
-            color: color(brightness-100) !important;
-            text-decoration: none !important;
-            background-image: none !important;
-            border-radius: 24px;
-            font-weight: bold;
-            font-size: 17px;
-            line-height: 21px;
-            display: inline-block;
-       }
-    }
 }
 
 .ios {
@@ -261,8 +233,4 @@
             width: calc(70% - #{$gs-unit}*2);
         }
     }
-}
-
-.garnett--type-guardianlabs .advert-slot__upgrade {
-    display: none;
 }

--- a/ArticleTemplates/assets/scss/modules/_advert-slot.scss
+++ b/ArticleTemplates/assets/scss/modules/_advert-slot.scss
@@ -119,6 +119,7 @@
         padding: base-px(1, 0, 1, 1);
         width: 100%;
         position: relative;
+        text-align: center;
 
         .advert-slot__action {
             right: base-px(1);

--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeShared.scss
@@ -111,14 +111,6 @@
                 color: $whiteTwo !important;
             }
         }
-
-        .advert-slot__upgrade {
-            background: $ratingYellow;
-
-            a {
-                background-image: none !important;
-            }
-        }
     }
 
     @include mq($from: col4) {


### PR DESCRIPTION
Remove the 'Support the Guardian' upsell from templates

Also centered the ad label text to align with web ad labels

The height of inline1 ad slots has not been updated as we still need to reserve space for taller ad sizes such as Teads video ads. The extra space has been approved by the commercial team.

## iOS

| Before | After |
| --- | --- |
| inline1 | inline1 |
|<img src="https://github.com/user-attachments/assets/7891896d-dc29-4b36-9d20-fbcf170e0cc6" width="300px" />|<img src="https://github.com/user-attachments/assets/e07bd144-2146-48bb-ba3a-5a1460a5b267" width="300px" />|
| inline2+ | inline2+ |
|<img src="https://github.com/user-attachments/assets/618fe7f6-2d6b-4752-9d80-43070bedd5f5" width="300px" />|<img src="https://github.com/user-attachments/assets/bc0fbaaf-6f73-4039-8c83-566bde025b11" width="300px" />|

## Android

| Before | After |
| --- | --- |
| inline1 | inline1 |
| <img src="https://github.com/user-attachments/assets/d75a32d8-8463-430a-bbbe-27fdd823e672" width="300px" /> |<img src="https://github.com/user-attachments/assets/0baa5f91-6f5b-41cf-bc68-f9233ef92f69" width="300px" /> | 
| inline2+ | inline2+ |
| <img src="https://github.com/user-attachments/assets/c6683452-d350-4dc8-9f74-662ce34af78e" width="300px" /> |<img src="https://github.com/user-attachments/assets/bdf80697-6c2a-47ad-abe1-e1cc36c422be" width="300px" /> | 
