### PR TITLE
fix match reports dark mode

### DIFF
--- a/.changeset/silent-frogs-relate.md
+++ b/.changeset/silent-frogs-relate.md
@@ -1,0 +1,5 @@
+---
+"@guardian/mobile-apps-article-templates": patch
+---
+
+Fix match reports dark mode

--- a/ArticleTemplates/assets/scss/themes/darkMode/_darkModeLiveblog.scss
+++ b/ArticleTemplates/assets/scss/themes/darkMode/_darkModeLiveblog.scss
@@ -4,7 +4,8 @@
     &.garnett--type-live,
     &.garnett--type-article.tone--deadBlog,
     &.garnett--type-specialreport.tone--deadBlog,
-    &.garnett--type-article.tone--football {
+    &.garnett--type-article.tone--football,
+    &.garnett--type-matchreport.tone--football {
         background-color: black;
 
         .article__body,


### PR DESCRIPTION
Co-authored-by: Ravi <7014230+arelra@users.noreply.github.com>

This PR fixes dark mode for the match report 

| Platform | Before | After |
| --- | --- | --- |
| iOS | <img src="https://github.com/user-attachments/assets/1ba85127-2f1e-4039-b2b3-5e66666ce9d6" width="300px" />|<img src="https://github.com/user-attachments/assets/bc009404-5165-469f-9c75-88f22269e7f8" width="300px" />|
| Android | <img src="https://github.com/user-attachments/assets/621636fa-7669-4fed-975b-5fa4c9de1cdf" width="300px" />|<img src="https://github.com/user-attachments/assets/2cdb02da-35d5-43c1-97b4-6cdf727df838" width="300px" />|



