### PR TITLE
replace p tag by div for gallery view caption

### DIFF
--- a/.changeset/ninety-hairs-float.md
+++ b/.changeset/ninety-hairs-float.md
@@ -1,0 +1,5 @@
+---
+"@guardian/mobile-apps-article-templates": patch
+---
+
+Fix bug by updating the surrounding html tag for gallery caption

--- a/ArticleTemplates/galleryImageViewCaption.html
+++ b/ArticleTemplates/galleryImageViewCaption.html
@@ -9,7 +9,7 @@
         <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/style-async.css" />
     </head>
     <body class="garnett--type-media dark-mode-__DARK_MODE__" id="gallery-caption-container">
-        <p class="gallery-caption">__CAPTION__</p>
+        <span class="gallery-caption">__CAPTION__</span>
         <p class="gallery-credit">__CREDIT__</p>
     </body>
 </html>

--- a/ArticleTemplates/galleryImageViewCaption.html
+++ b/ArticleTemplates/galleryImageViewCaption.html
@@ -9,7 +9,7 @@
         <link rel="stylesheet" type="text/css" media="all" href="__TEMPLATES_DIRECTORY__assets/css/style-async.css" />
     </head>
     <body class="garnett--type-media dark-mode-__DARK_MODE__" id="gallery-caption-container">
-        <span class="gallery-caption">__CAPTION__</span>
+        <div class="gallery-caption">__CAPTION__</div>
         <p class="gallery-credit">__CREDIT__</p>
     </body>
 </html>


### PR DESCRIPTION
Fixes a bug where the caption has `h2` element. Putting the `<h2>` within the `<p>` was breaking the CSS selectors and the styles were not correctly applied. 
| Before | After |
| --- | --- |
|<img src="https://github.com/user-attachments/assets/0a21c9c2-e722-476c-a61e-b0fea4ad73af" width="300px" />|<img src="https://github.com/user-attachments/assets/e15ecd87-f629-4f64-a243-5ab787e4cee4" width="300px" />|



Fixes part of [#12637](https://github.com/guardian/dotcom-rendering/issues/12637)



